### PR TITLE
adapt setup.py to readme file naming (md -> MD)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from os import path
 from astrapy import __version__
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+with open(path.join(this_directory, "README.MD"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Commit `85de9e431efe4aeb193bebdb51a361f1892bd0e3` (Tue Nov 7 20:50:13 2023 +0100) changed `README.md` to `README.MD` and since then `setup.py` is faulty. This fixes.
