### PR TITLE
Fix bug in vector_ methods and rearrange tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -384,7 +384,9 @@ Ensure you provide all required environment variables (you can do so by editing 
 export ASTRA_DB_APPLICATION_TOKEN="..."
 export ASTRA_DB_API_ENDPOINT="..."
 export ASTRA_DB_KEYSPACE="..."              # Optional
+
 export ASTRA_DB_ID="..."                    # For the Ops testing only
+export ASTRA_DB_OPS_APPLICATION_TOKEN="..." # Ops-only, falls back to the other token
 ```
 
 then you can run:

--- a/README.MD
+++ b/README.MD
@@ -378,16 +378,25 @@ black --check tests && ruff tests && mypy tests
 
 ### Testing
 
-Ensure you provide all required environment variables:
+Ensure you provide all required environment variables (you can do so by editing `tests/.env` after `tests/.env.template`):
 
 ```bash
-export ASTRA_DB_ID="..."
 export ASTRA_DB_APPLICATION_TOKEN="..."
 export ASTRA_DB_API_ENDPOINT="..."
+export ASTRA_DB_KEYSPACE="..."              # Optional
+export ASTRA_DB_ID="..."                    # For the Ops testing only
 ```
 
 then you can run:
 
 ```bash
 pytest
+```
+
+To remove the noise from the logs (on by default), run `pytest -o log_cli=0`.
+
+To enable the `AstraDBOps` testing (off by default):
+
+```bash
+TEST_ASTRADBOPS=1 pytest
 ```

--- a/astrapy/__init__.py
+++ b/astrapy/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -152,12 +152,16 @@ class AstraDBCollection:
         self, itm: API_DOC, include_similarity: bool = True
     ) -> API_DOC:
         # Clean away the returned similarity score if so desired
-        if include_similarity:
-            if "$similarity" not in itm:
-                raise ValueError("Expected '$similarity' not found in document.")
+        if itm is None:
+            # TODO
             return itm
         else:
-            return {k: v for k, v in itm.items() if k != "$similarity"}
+            if include_similarity:
+                if "$similarity" not in itm:
+                    raise ValueError("Expected '$similarity' not found in document.")
+                return itm
+            else:
+                return {k: v for k, v in itm.items() if k != "$similarity"}
 
     def get(self, path: Optional[str] = None) -> Optional[API_RESPONSE]:
         """

--- a/tests/.env.template
+++ b/tests/.env.template
@@ -1,0 +1,14 @@
+########################
+# FOR THE REGULAR TESTS:
+########################
+ASTRA_DB_APPLICATION_TOKEN="AstraCS:..."
+ASTRA_DB_API_ENDPOINT="https://<DB_ID>-<DB_REGION>.apps.astra.datastax.com"
+#
+# OPTIONAL:
+# ASTRA_DB_KEYSPACE="..."
+
+
+###################
+# FOR THE OPS TEST:
+###################
+ASTRA_DB_ID="..."

--- a/tests/.env.template
+++ b/tests/.env.template
@@ -12,3 +12,5 @@ ASTRA_DB_API_ENDPOINT="https://<DB_ID>-<DB_REGION>.apps.astra.datastax.com"
 # FOR THE OPS TEST:
 ###################
 ASTRA_DB_ID="..."
+# OPTIONAL (falls back to the token above)
+ASTRA_DB_OPS_APPLICATION_TOKEN="..."

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Tests for the `db.py` parts related to DML & client creation
+"""
+
 import logging
 
 import pytest

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -1,0 +1,108 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+
+from astrapy.db import AstraDB, AstraDBCollection
+from astrapy.defaults import DEFAULT_KEYSPACE_NAME
+
+TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"
+TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME = "ephemeral_non_v_col"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.describe("should confirm path handling in constructor")
+def test_path_handling(astra_db_credentials_kwargs) -> None:
+    astra_db_1 = AstraDB(**astra_db_credentials_kwargs)
+
+    url_1 = astra_db_1.base_path
+
+    astra_db_2 = AstraDB(
+        **astra_db_credentials_kwargs,
+        api_version="v1",
+    )
+
+    url_2 = astra_db_2.base_path
+
+    astra_db_3 = AstraDB(
+        **astra_db_credentials_kwargs,
+        api_version="/v1",
+    )
+
+    url_3 = astra_db_3.base_path
+
+    astra_db_4 = AstraDB(
+        **astra_db_credentials_kwargs,
+        api_version="/v1/",
+    )
+
+    url_4 = astra_db_4.base_path
+
+    assert url_1 == url_2 == url_3 == url_4
+
+    # autofill of the default keyspace name
+    unspecified_ks_client = AstraDB(
+        **{
+            **astra_db_credentials_kwargs,
+            **{"namespace": DEFAULT_KEYSPACE_NAME},
+        }
+    )
+    explicit_ks_client = AstraDB(
+        **{
+            **astra_db_credentials_kwargs,
+            **{"namespace": None},
+        }
+    )
+    assert unspecified_ks_client.base_path == explicit_ks_client.base_path
+
+
+@pytest.mark.describe("should create, use and destroy a non-vector collection")
+def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
+    col = db.create_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
+    assert isinstance(col, AstraDBCollection)
+    col.insert_one({"_id": "first", "name": "a"})
+    col.insert_many(
+        [
+            {"_id": "second", "name": "b", "room": 7},
+            {"name": "c", "room": 7},
+            {"_id": "last", "type": "unnamed", "room": 7},
+        ]
+    )
+    docs = col.find(filter={"room": 7}, projection={"name": 1})
+    ids = [doc["_id"] for doc in docs["data"]["documents"]]
+    assert len(ids) == 3
+    assert "second" in ids
+    assert "first" not in ids
+    auto_id = [id for id in ids if id not in {"second", "last"}][0]
+    col.delete(auto_id)
+    assert col.find_one(filter={"name": "c"})["data"]["document"] is None
+    del_res = db.delete_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
+    assert del_res["status"]["ok"] == 1
+
+
+@pytest.mark.describe("should create and destroy a vector collection")
+def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
+    col = db.create_collection(collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2)
+    assert isinstance(col, AstraDBCollection)
+    del_res = db.delete_collection(collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME)
+    assert del_res["status"]["ok"] == 1
+
+
+@pytest.mark.describe("should get all collections")
+def test_get_collections(db: AstraDB) -> None:
+    res = db.get_collections()
+    assert res["status"]["collections"] is not None

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -17,6 +17,7 @@ Tests for the `db.py` parts related to DML & client creation
 """
 
 import logging
+from typing import Dict, Optional
 
 import pytest
 
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.describe("should confirm path handling in constructor")
-def test_path_handling(astra_db_credentials_kwargs) -> None:
+def test_path_handling(astra_db_credentials_kwargs: Dict[str, Optional[str]]) -> None:
     astra_db_1 = AstraDB(**astra_db_credentials_kwargs)
 
     url_1 = astra_db_1.base_path
@@ -100,9 +101,13 @@ def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
 
 @pytest.mark.describe("should create and destroy a vector collection")
 def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
-    col = db.create_collection(collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2)
+    col = db.create_collection(
+        collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
+    )
     assert isinstance(col, AstraDBCollection)
-    del_res = db.delete_collection(collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME)
+    del_res = db.delete_collection(
+        collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
+    )
     assert del_res["status"]["ok"] == 1
 
 

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -183,7 +183,7 @@ def test_find_limitless(readonly_vector_collection: AstraDBCollection) -> None:
 
 
 @pytest.mark.describe("insert_one, w/out _id, w/out vector")
-def test_create_document_0(writable_vector_collection: AstraDBCollection) -> None:
+def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     i_vector = [0.3, 0.5]
     id_v_i = str(uuid.uuid4())
     result_v_i = writable_vector_collection.insert_one(

--- a/tests/astrapy/test_db_dml_pagination.py
+++ b/tests/astrapy/test_db_dml_pagination.py
@@ -19,7 +19,7 @@ Tests for the `db.py` parts on pagination primitives
 import math
 import os
 import logging
-from typing import Iterable, List, Set, TypeVar
+from typing import Dict, Iterable, List, Optional, Set, TypeVar
 import pytest
 
 from astrapy.db import AstraDB, AstraDBCollection
@@ -53,7 +53,9 @@ def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable
 
 
 @pytest.fixture(scope="module")
-def pag_test_collection(astra_db_credentials_kwargs) -> Iterable[AstraDBCollection]:
+def pag_test_collection(
+    astra_db_credentials_kwargs: Dict[str, Optional[str]]
+) -> Iterable[AstraDBCollection]:
     astra_db = AstraDB(**astra_db_credentials_kwargs)
 
     astra_db_collection = astra_db.create_collection(
@@ -64,7 +66,9 @@ def pag_test_collection(astra_db_credentials_kwargs) -> Iterable[AstraDBCollecti
         inserted_ids: Set[str] = set()
         for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
             batch_ids = astra_db_collection.insert_many(
-                documents=[{"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch]
+                documents=[
+                    {"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch
+                ]
             )["status"]["insertedIds"]
             inserted_ids = inserted_ids | set(batch_ids)
         assert inserted_ids == {str(i) for i in range(N)}

--- a/tests/astrapy/test_db_dml_pagination.py
+++ b/tests/astrapy/test_db_dml_pagination.py
@@ -12,29 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Tests for the `db.py` parts on pagination primitives
+"""
+
 import math
 import os
 import logging
 from typing import Iterable, List, Set, TypeVar
-from dotenv import load_dotenv
 import pytest
 
 from astrapy.db import AstraDB, AstraDBCollection
-from astrapy.defaults import DEFAULT_KEYSPACE_NAME
 
 
 logger = logging.getLogger(__name__)
 
 
-load_dotenv()
-
-
-ASTRA_DB_APPLICATION_TOKEN = os.environ.get("ASTRA_DB_APPLICATION_TOKEN")
-ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
-ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
-
-
-PAG_TEST_COLLECTION_NAME = "pag_test_collection"
+TEST_PAGINATION_COLLECTION_NAME = "pagination_v_col"
 INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
 N = 200  # must be EVEN
 FIND_LIMIT = 183  # Keep this > 20 and <= N to actually put pagination to test
@@ -42,7 +36,7 @@ FIND_LIMIT = 183  # Keep this > 20 and <= N to actually put pagination to test
 T = TypeVar("T")
 
 
-def mk_vector(index: int, n_total_steps: int) -> List[float]:
+def _mk_vector(index: int, n_total_steps: int) -> List[float]:
     angle = 2 * math.pi * index / n_total_steps
     return [math.cos(angle), math.sin(angle)]
 
@@ -59,28 +53,24 @@ def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable
 
 
 @pytest.fixture(scope="module")
-def pag_test_collection() -> Iterable[AstraDBCollection]:
-    astra_db = AstraDB(
-        token=ASTRA_DB_APPLICATION_TOKEN,
-        api_endpoint=ASTRA_DB_API_ENDPOINT,
-        namespace=ASTRA_DB_KEYSPACE,
-    )
+def pag_test_collection(astra_db_credentials_kwargs) -> Iterable[AstraDBCollection]:
+    astra_db = AstraDB(**astra_db_credentials_kwargs)
 
     astra_db_collection = astra_db.create_collection(
-        collection_name=PAG_TEST_COLLECTION_NAME, dimension=2
+        collection_name=TEST_PAGINATION_COLLECTION_NAME, dimension=2
     )
 
     if int(os.getenv("TEST_PAGINATION_SKIP_INSERTION", "0")) == 0:
         inserted_ids: Set[str] = set()
         for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
             batch_ids = astra_db_collection.insert_many(
-                documents=[{"_id": str(i), "$vector": mk_vector(i, N)} for i in i_batch]
+                documents=[{"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch]
             )["status"]["insertedIds"]
             inserted_ids = inserted_ids | set(batch_ids)
         assert inserted_ids == {str(i) for i in range(N)}
     yield astra_db_collection
     if int(os.getenv("TEST_PAGINATION_SKIP_DELETE_COLLECTION", "0")) == 0:
-        _ = astra_db.delete_collection(collection_name=PAG_TEST_COLLECTION_NAME)
+        _ = astra_db.delete_collection(collection_name=TEST_PAGINATION_COLLECTION_NAME)
 
 
 @pytest.mark.describe(

--- a/tests/astrapy/test_db_dml_vector.py
+++ b/tests/astrapy/test_db_dml_vector.py
@@ -159,8 +159,7 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
     assert "$similarity" not in document_no_sim
 
     document_w_fields = readonly_vector_collection.vector_find_one(
-        [0.2, 0.6],
-        fields=["text"]
+        [0.2, 0.6], fields=["text"]
     )
 
     assert document_w_fields is not None
@@ -178,7 +177,9 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
 
 
 @pytest.mark.describe("vector_find_one_and_update")
-def test_vector_find_one_and_update(disposable_vector_collection: AstraDBCollection) -> None:
+def test_vector_find_one_and_update(
+    disposable_vector_collection: AstraDBCollection,
+) -> None:
     update = {"$set": {"status": "active"}}
 
     document0 = disposable_vector_collection.vector_find_one(
@@ -212,7 +213,9 @@ def test_vector_find_one_and_update(disposable_vector_collection: AstraDBCollect
 
 
 @pytest.mark.describe("vector_find_one_and_replace")
-def test_vector_find_one_and_replace(disposable_vector_collection: AstraDBCollection) -> None:
+def test_vector_find_one_and_replace(
+    disposable_vector_collection: AstraDBCollection,
+) -> None:
     replacement0 = {
         "_id": "1",
         "text": "Revised sample entry number <1>",

--- a/tests/astrapy/test_db_dml_vector.py
+++ b/tests/astrapy/test_db_dml_vector.py
@@ -1,0 +1,278 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the `db.py` parts on data manipulation `vector_*` methods
+"""
+
+import logging
+
+import pytest
+
+from astrapy.db import AstraDBCollection
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.describe("vector_find and include_similarity parameter")
+def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
+    documents_sim_1 = readonly_vector_collection.vector_find(
+        vector=[0.2, 0.6],
+        limit=3,
+    )
+
+    assert documents_sim_1 is not None
+    assert isinstance(documents_sim_1, list)
+    assert len(documents_sim_1) > 0
+    assert "_id" in documents_sim_1[0]
+    assert "$vector" in documents_sim_1[0]
+    assert "text" in documents_sim_1[0]
+    assert "$similarity" in documents_sim_1[0]
+
+    documents_sim_2 = readonly_vector_collection.vector_find(
+        vector=[0.2, 0.6],
+        limit=3,
+        include_similarity=True,
+    )
+
+    assert documents_sim_2 is not None
+    assert isinstance(documents_sim_2, list)
+    assert len(documents_sim_2) > 0
+    assert "_id" in documents_sim_2[0]
+    assert "$vector" in documents_sim_2[0]
+    assert "text" in documents_sim_2[0]
+    assert "$similarity" in documents_sim_2[0]
+
+    documents_no_sim = readonly_vector_collection.vector_find(
+        vector=[0.2, 0.6],
+        limit=3,
+        fields=["_id", "$vector"],
+        include_similarity=False,
+    )
+
+    assert documents_no_sim is not None
+    assert isinstance(documents_no_sim, list)
+    assert len(documents_no_sim) > 0
+    assert "_id" in documents_no_sim[0]
+    assert "$vector" in documents_no_sim[0]
+    assert "text" not in documents_no_sim[0]
+    assert "$similarity" not in documents_no_sim[0]
+
+
+@pytest.mark.describe("vector_find, obey projection")
+def test_vector_find_projection(readonly_vector_collection: AstraDBCollection) -> None:
+    query = [0.2, 0.6]
+
+    req_fieldsets = [
+        None,
+        set(),
+        {"text"},
+        {"$vector"},
+        {"text", "$vector"},
+    ]
+    exp_fieldsets = [
+        {"$vector", "_id", "otherfield", "anotherfield", "text"},
+        {"$vector", "_id", "otherfield", "anotherfield", "text"},
+        {"_id", "text"},
+        {"$vector", "_id"},
+        {"$vector", "_id", "text"},
+    ]
+    for include_similarity in [True, False]:
+        for req_fields, exp_fields0 in zip(req_fieldsets, exp_fieldsets):
+            vdocs = readonly_vector_collection.vector_find(
+                query,
+                limit=1,
+                fields=list(req_fields) if req_fields is not None else req_fields,
+                include_similarity=include_similarity,
+            )
+            if include_similarity:
+                exp_fields = exp_fields0 | {"$similarity"}
+            else:
+                exp_fields = exp_fields0
+            assert set(vdocs[0].keys()) == exp_fields
+
+
+@pytest.mark.describe("vector_find with filters")
+def test_vector_find_filters(readonly_vector_collection: AstraDBCollection) -> None:
+    documents = readonly_vector_collection.vector_find(
+        vector=[0.2, 0.6],
+        filter={"anotherfield": "alpha"},
+        limit=3,
+    )
+    assert isinstance(documents, list)
+    assert len(documents) == 2
+    assert {doc["otherfield"]["subfield"] for doc in documents} == {"x1y", "x2y"}
+
+    documents_no = readonly_vector_collection.vector_find(
+        vector=[0.2, 0.6],
+        filter={"anotherfield": "epsilon"},
+        limit=3,
+    )
+    assert isinstance(documents_no, list)
+    assert len(documents_no) == 0
+
+
+@pytest.mark.describe("vector_find_one and include_similarity parameter")
+def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
+    document0 = readonly_vector_collection.vector_find_one(
+        [0.2, 0.6],
+    )
+
+    assert document0 is not None
+    assert "_id" in document0
+    assert "$vector" in document0
+    assert "text" in document0
+    assert "$similarity" in document0
+
+    document_w_sim = readonly_vector_collection.vector_find_one(
+        [0.2, 0.6],
+        include_similarity=True,
+    )
+
+    assert document_w_sim is not None
+    assert "_id" in document_w_sim
+    assert "$vector" in document_w_sim
+    assert "text" in document_w_sim
+    assert "$similarity" in document_w_sim
+
+    document_no_sim = readonly_vector_collection.vector_find_one(
+        [0.2, 0.6],
+        include_similarity=False,
+    )
+
+    assert document_no_sim is not None
+    assert "_id" in document_no_sim
+    assert "$vector" in document_no_sim
+    assert "text" in document_no_sim
+    assert "$similarity" not in document_no_sim
+
+    document_w_fields = readonly_vector_collection.vector_find_one(
+        [0.2, 0.6],
+        fields=["text"]
+    )
+
+    assert document_w_fields is not None
+    assert "_id" in document_w_fields
+    assert "$vector" not in document_w_fields
+    assert "text" in document_w_fields
+    assert "$similarity" in document_w_fields
+
+    document_no = readonly_vector_collection.vector_find_one(
+        [0.2, 0.6],
+        filter={"nonexisting": "gotcha"},
+    )
+
+    assert document_no is None
+
+
+@pytest.mark.describe("vector_find_one_and_update")
+def test_vector_find_one_and_update(disposable_vector_collection: AstraDBCollection) -> None:
+    update = {"$set": {"status": "active"}}
+
+    document0 = disposable_vector_collection.vector_find_one(
+        vector=[0.1, 0.9],
+        filter={"status": "active"},
+    )
+    assert document0 is None
+
+    update_response = disposable_vector_collection.vector_find_one_and_update(
+        vector=[0.1, 0.9],
+        update=update,
+    )
+    assert update_response is not None
+    assert update_response["_id"] == "1"
+
+    document1 = disposable_vector_collection.vector_find_one(
+        vector=[0.1, 0.9],
+        filter={"status": "active"},
+    )
+
+    assert document1 is not None
+    assert document1["_id"] == update_response["_id"]
+    assert document1["status"] == "active"
+
+    update_response_no = disposable_vector_collection.vector_find_one_and_update(
+        vector=[0.1, 0.9],
+        filter={"nonexisting": "gotcha"},
+        update=update,
+    )
+    assert update_response_no is None
+
+
+@pytest.mark.describe("vector_find_one_and_replace")
+def test_vector_find_one_and_replace(disposable_vector_collection: AstraDBCollection) -> None:
+    replacement0 = {
+        "_id": "1",
+        "text": "Revised sample entry number <1>",
+        "added_field": True,
+        "$vector": [0.101, 0.899],
+    }
+
+    document0 = disposable_vector_collection.vector_find_one(
+        vector=[0.1, 0.9],
+        filter={"added_field": True},
+    )
+    assert document0 is None
+
+    replace_response0 = disposable_vector_collection.vector_find_one_and_replace(
+        vector=[0.1, 0.9],
+        replacement=replacement0,
+    )
+    assert replace_response0 is not None
+    assert replace_response0["_id"] == "1"
+
+    document1 = disposable_vector_collection.vector_find_one(
+        vector=[0.1, 0.9],
+        filter={"added_field": True},
+    )
+
+    assert document1 is not None
+    assert document1["_id"] == replace_response0["_id"]
+    assert "otherfield" not in document1
+    assert "anotherfield" not in document1
+    assert document1["text"] == replacement0["text"]
+    assert document1["added_field"] is True
+
+    # no supplying the _id
+    replacement1 = {
+        "text": "Further revised sample entry number <1>",
+        "different_added_field": False,
+        "$vector": [0.101, 0.899],
+    }
+
+    replace_response1 = disposable_vector_collection.vector_find_one_and_replace(
+        vector=[0.1, 0.9],
+        replacement=replacement1,
+    )
+    assert replace_response0 is not None
+    assert replace_response0["_id"] == "1"
+
+    document2 = disposable_vector_collection.vector_find_one(
+        vector=[0.1, 0.9],
+        filter={"different_added_field": False},
+    )
+
+    assert document2 is not None
+    assert document2["_id"] == replace_response1["_id"]
+    assert document2["text"] == replacement1["text"]
+    assert "added_field" not in document2
+    assert document2["different_added_field"] is False
+
+    replace_response_no = disposable_vector_collection.vector_find_one_and_replace(
+        vector=[0.1, 0.9],
+        filter={"nonexisting": "gotcha"},
+        replacement=replacement1,
+    )
+    assert replace_response_no is None

--- a/tests/astrapy/test_ops.py
+++ b/tests/astrapy/test_ops.py
@@ -12,33 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from astrapy.ops import AstraDBOps
-from astrapy.defaults import DEFAULT_KEYSPACE_NAME, DEFAULT_REGION
-
 import pytest
 import logging
 import os
 import uuid
 
 from dotenv import load_dotenv
-from faker import Faker
+
+from astrapy.ops import AstraDBOps
+from astrapy.defaults import DEFAULT_KEYSPACE_NAME, DEFAULT_REGION
+
 
 logger = logging.getLogger(__name__)
-fake = Faker()
 
 
 load_dotenv()
 
 
-# Parameter for the ops testing
+# Parameters for the AstraDBOps testing
 ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
 ASTRA_DB_ID = os.environ["ASTRA_DB_ID"]
 ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 ASTRA_DB_REGION = os.environ.get("ASTRA_DB_REGION", DEFAULT_REGION)
-
-
-# For now we skip these tests due to creation of DBs
-pytestmark = pytest.mark.skip("Currently skipping all ops tests")
 
 
 @pytest.fixture
@@ -46,47 +41,52 @@ def devops_client() -> AstraDBOps:
     return AstraDBOps(token=ASTRA_DB_APPLICATION_TOKEN)
 
 
-@pytest.mark.describe("should initialize an AstraDB Ops Client")
-def test_client_type(devops_client: AstraDBOps) -> None:
-    assert type(devops_client) is AstraDBOps
+# For now we skip these tests due to creation of DBs
+@pytest.mark.skipif(
+    int(os.environ.get("TEST_ASTRADBOPS", "0")) == 0,
+    reason="Ops tests not explicitly requested",
+)
+class TestAstraDBOps:
+    @pytest.mark.describe("should initialize an AstraDB Ops Client")
+    def test_client_type(self, devops_client: AstraDBOps) -> None:
+        assert type(devops_client) is AstraDBOps
 
+    @pytest.mark.describe("should get all databases")
+    def test_get_databases(self, devops_client: AstraDBOps) -> None:
+        response = devops_client.get_databases()
+        assert isinstance(response, list)
 
-@pytest.mark.describe("should get all databases")
-def test_get_databases(devops_client: AstraDBOps) -> None:
-    response = devops_client.get_databases()
-    assert isinstance(response, list)
+    @pytest.mark.describe("should create a database")
+    def test_create_database(self, devops_client: AstraDBOps) -> None:
+        database_definition = {
+            "name": "vector_test_create",
+            "tier": "serverless",
+            "cloudProvider": "GCP",
+            "keyspace": ASTRA_DB_KEYSPACE,
+            "region": ASTRA_DB_REGION,
+            "capacityUnits": 1,
+            "user": "token",
+            "password": ASTRA_DB_APPLICATION_TOKEN,
+            "dbType": "vector",
+        }
+        response = devops_client.create_database(
+            database_definition=database_definition
+        )
+        assert response is not None
+        assert "id" in response
+        assert response["id"] is not None
+        ASTRA_TEMP_DB = response["id"]
 
+        check_db = devops_client.get_database(database=ASTRA_TEMP_DB)
+        assert check_db is not None
 
-@pytest.mark.describe("should create a database")
-def test_create_database(devops_client: AstraDBOps) -> None:
-    database_definition = {
-        "name": "vector_test_create",
-        "tier": "serverless",
-        "cloudProvider": "GCP",
-        "keyspace": ASTRA_DB_KEYSPACE,
-        "region": ASTRA_DB_REGION,
-        "capacityUnits": 1,
-        "user": "token",
-        "password": ASTRA_DB_APPLICATION_TOKEN,
-        "dbType": "vector",
-    }
-    response = devops_client.create_database(database_definition=database_definition)
-    assert response is not None
-    assert "id" in response
-    assert response["id"] is not None
-    ASTRA_TEMP_DB = response["id"]
+        term_response = devops_client.terminate_database(database=ASTRA_TEMP_DB)
+        assert term_response is None
 
-    check_db = devops_client.get_database(database=ASTRA_TEMP_DB)
-    assert check_db is not None
+    @pytest.mark.describe("should create a keyspace")
+    def test_create_keyspace(self, devops_client: AstraDBOps) -> None:
+        response = devops_client.create_keyspace(
+            keyspace="test_namespace", database=str(uuid.uuid4())
+        )
 
-    term_response = devops_client.terminate_database(database=ASTRA_TEMP_DB)
-    assert term_response is None
-
-
-@pytest.mark.describe("should create a keyspace")
-def test_create_keyspace(devops_client: AstraDBOps) -> None:
-    response = devops_client.create_keyspace(
-        keyspace="test_namespace", database=str(uuid.uuid4())
-    )
-
-    assert response is not None
+        assert response is not None

--- a/tests/astrapy/test_ops.py
+++ b/tests/astrapy/test_ops.py
@@ -30,7 +30,10 @@ load_dotenv()
 
 
 # Parameters for the AstraDBOps testing
-ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
+ASTRA_DB_APPLICATION_TOKEN = os.environ.get(
+    "ASTRA_DB_OPS_APPLICATION_TOKEN",
+    os.environ.get("ASTRA_DB_APPLICATION_TOKEN", "no_token!"),
+)
 ASTRA_DB_ID = os.environ["ASTRA_DB_ID"]
 ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 ASTRA_DB_REGION = os.environ.get("ASTRA_DB_REGION", DEFAULT_REGION)

--- a/tests/astrapy/test_pagination.py
+++ b/tests/astrapy/test_pagination.py
@@ -34,7 +34,7 @@ ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
 ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 
 
-TEST_COLLECTION_NAME = "test_collection"
+PAG_TEST_COLLECTION_NAME = "pag_test_collection"
 INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
 N = 200  # must be EVEN
 FIND_LIMIT = 183  # Keep this > 20 and <= N to actually put pagination to test
@@ -59,7 +59,7 @@ def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable
 
 
 @pytest.fixture(scope="module")
-def test_collection() -> Iterable[AstraDBCollection]:
+def pag_test_collection() -> Iterable[AstraDBCollection]:
     astra_db = AstraDB(
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,
@@ -67,7 +67,7 @@ def test_collection() -> Iterable[AstraDBCollection]:
     )
 
     astra_db_collection = astra_db.create_collection(
-        collection_name=TEST_COLLECTION_NAME, dimension=2
+        collection_name=PAG_TEST_COLLECTION_NAME, dimension=2
     )
 
     if int(os.getenv("TEST_PAGINATION_SKIP_INSERTION", "0")) == 0:
@@ -80,17 +80,17 @@ def test_collection() -> Iterable[AstraDBCollection]:
         assert inserted_ids == {str(i) for i in range(N)}
     yield astra_db_collection
     if int(os.getenv("TEST_PAGINATION_SKIP_DELETE_COLLECTION", "0")) == 0:
-        _ = astra_db.delete_collection(collection_name=TEST_COLLECTION_NAME)
+        _ = astra_db.delete_collection(collection_name=PAG_TEST_COLLECTION_NAME)
 
 
 @pytest.mark.describe(
     "should retrieve the required amount of documents, all different, through pagination"
 )
-def test_find_paginated(test_collection: AstraDBCollection) -> None:
+def test_find_paginated(pag_test_collection: AstraDBCollection) -> None:
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}
 
-    paginated_documents = test_collection.paginated_find(
+    paginated_documents = pag_test_collection.paginated_find(
         projection=projection,
         options=options,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,108 @@
+"""
+Test fixtures
+"""
+import os
+import pytest
+import uuid
+from typing import Dict, Iterable, Optional
+
+from dotenv import load_dotenv
+
+from astrapy.defaults import DEFAULT_KEYSPACE_NAME
+from astrapy.types import API_DOC
+from astrapy.db import AstraDB, AstraDBCollection
+
+
+load_dotenv()
+
+ASTRA_DB_APPLICATION_TOKEN = os.environ.get("ASTRA_DB_APPLICATION_TOKEN")
+ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
+ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
+
+TEST_COLLECTION_NAME = "test_collection"
+TEST_FIXTURE_COLLECTION_NAME = "test_fixture_collection"
+TEST_FIXTURE_PROJECTION_COLLECTION_NAME = "test_projection_collection"
+TEST_NONVECTOR_COLLECTION_NAME = "test_nonvector_collection"
+
+@pytest.fixture(scope="session")
+def astra_db_credentials_kwargs() -> Dict[str, Optional[str]]:
+    return {
+        "token": ASTRA_DB_APPLICATION_TOKEN,
+        "api_endpoint": ASTRA_DB_API_ENDPOINT,
+        "namespace": ASTRA_DB_KEYSPACE,
+    }
+
+@pytest.fixture(scope="module")
+def cliff_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+def vv_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+def db(astra_db_credentials_kwargs) -> AstraDB:
+    return AstraDB(**astra_db_credentials_kwargs)
+
+
+@pytest.fixture(scope="module")
+def cliff_data(cliff_uuid: str) -> API_DOC:
+    json_query = {
+        "_id": cliff_uuid,
+        "first_name": "Cliff",
+        "last_name": "Wicklow",
+    }
+
+    return json_query
+
+
+@pytest.fixture(scope="module")
+def collection(db: AstraDB, cliff_data: API_DOC) -> Iterable[AstraDBCollection]:
+    db.delete_collection(collection_name=TEST_FIXTURE_COLLECTION_NAME)
+    collection = db.create_collection(
+        collection_name=TEST_FIXTURE_COLLECTION_NAME, dimension=5
+    )
+    collection.insert_one(document=cliff_data)
+
+    yield collection
+
+    db.delete_collection(collection_name=TEST_FIXTURE_COLLECTION_NAME)
+
+
+@pytest.fixture(scope="module")
+def projection_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+    collection = db.create_collection(
+        collection_name=TEST_FIXTURE_PROJECTION_COLLECTION_NAME, dimension=5
+    )
+
+    collection.insert_many(
+        [
+            {
+                "_id": "1",
+                "text": "Sample entry number <1>",
+                "otherfield": {"subfield": "x1y"},
+                "anotherfield": "delete_me",
+                "$vector": [0.1, 0.15, 0.3, 0.12, 0.05],
+            },
+            {
+                "_id": "2",
+                "text": "Sample entry number <2>",
+                "otherfield": {"subfield": "x2y"},
+                "anotherfield": "delete_me",
+                "$vector": [0.45, 0.09, 0.01, 0.2, 0.11],
+            },
+            {
+                "_id": "3",
+                "text": "Sample entry number <3>",
+                "otherfield": {"subfield": "x3y"},
+                "anotherfield": "dont_delete_me",
+                "$vector": [0.1, 0.05, 0.08, 0.3, 0.6],
+            },
+        ],
+    )
+
+    yield collection
+
+    db.delete_collection(collection_name=TEST_FIXTURE_PROJECTION_COLLECTION_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from typing import Dict, Iterable, Optional
 from dotenv import load_dotenv
 
 from astrapy.defaults import DEFAULT_KEYSPACE_NAME
-from astrapy.types import API_DOC
 from astrapy.db import AstraDB, AstraDBCollection
 
 
@@ -19,12 +18,8 @@ ASTRA_DB_APPLICATION_TOKEN = os.environ.get("ASTRA_DB_APPLICATION_TOKEN")
 ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
 ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 
-# tofix
-TEST_COLLECTION_NAME = "test_collection"
-TEST_FIXTURE_COLLECTION_NAME = "test_fixture_collection"
-TEST_NONVECTOR_COLLECTION_NAME = "test_nonvector_collection"
-
 # fixed
+TEST_WRITABLE_VECTOR_COLLECTION = "writable_v_col"
 TEST_READONLY_VECTOR_COLLECTION = "readonly_v_col"
 TEST_DISPOSABLE_VECTOR_COLLECTION = "disposable_v_col"
 
@@ -61,6 +56,7 @@ def astra_db_credentials_kwargs() -> Dict[str, Optional[str]]:
         "namespace": ASTRA_DB_KEYSPACE,
     }
 
+
 @pytest.fixture(scope="module")
 def cliff_uuid() -> str:
     return str(uuid.uuid4())
@@ -72,55 +68,51 @@ def vv_uuid() -> str:
 
 
 @pytest.fixture(scope="module")
-def db(astra_db_credentials_kwargs) -> AstraDB:
+def db(astra_db_credentials_kwargs: Dict[str, Optional[str]]) -> AstraDB:
     return AstraDB(**astra_db_credentials_kwargs)
 
 
 @pytest.fixture(scope="module")
-def cliff_data(cliff_uuid: str) -> API_DOC:
-    json_query = {
-        "_id": cliff_uuid,
-        "first_name": "Cliff",
-        "last_name": "Wicklow",
-    }
-
-    return json_query
-
-
-@pytest.fixture(scope="module")
-def collection(db: AstraDB, cliff_data: API_DOC) -> Iterable[AstraDBCollection]:
-    db.delete_collection(collection_name=TEST_FIXTURE_COLLECTION_NAME)
+def writable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+    """
+    This is lasting for the whole test. Functions can write to it,
+    no guarantee (i.e. each test should use a different ID...
+    """
     collection = db.create_collection(
-        collection_name=TEST_FIXTURE_COLLECTION_NAME, dimension=5
+        TEST_WRITABLE_VECTOR_COLLECTION,
+        dimension=2,
     )
-    collection.insert_one(document=cliff_data)
+
+    collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
 
-    db.delete_collection(collection_name=TEST_FIXTURE_COLLECTION_NAME)
+    db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="module")
 def readonly_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     collection = db.create_collection(
-        collection_name=TEST_READONLY_VECTOR_COLLECTION, dimension=2
+        TEST_READONLY_VECTOR_COLLECTION,
+        dimension=2,
     )
 
     collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
 
-    db.delete_collection(collection_name=TEST_READONLY_VECTOR_COLLECTION)
+    db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="function")
 def disposable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     collection = db.create_collection(
-        collection_name=TEST_DISPOSABLE_VECTOR_COLLECTION, dimension=2
+        TEST_DISPOSABLE_VECTOR_COLLECTION,
+        dimension=2,
     )
 
     collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
 
-    db.delete_collection(collection_name=TEST_DISPOSABLE_VECTOR_COLLECTION)
+    db.delete_collection(TEST_DISPOSABLE_VECTOR_COLLECTION)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,39 @@ ASTRA_DB_APPLICATION_TOKEN = os.environ.get("ASTRA_DB_APPLICATION_TOKEN")
 ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
 ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 
+# tofix
 TEST_COLLECTION_NAME = "test_collection"
 TEST_FIXTURE_COLLECTION_NAME = "test_fixture_collection"
-TEST_FIXTURE_PROJECTION_COLLECTION_NAME = "test_projection_collection"
 TEST_NONVECTOR_COLLECTION_NAME = "test_nonvector_collection"
+
+# fixed
+TEST_READONLY_VECTOR_COLLECTION = "readonly_v_col"
+TEST_DISPOSABLE_VECTOR_COLLECTION = "disposable_v_col"
+
+VECTOR_DOCUMENTS = [
+    {
+        "_id": "1",
+        "text": "Sample entry number <1>",
+        "otherfield": {"subfield": "x1y"},
+        "anotherfield": "alpha",
+        "$vector": [0.1, 0.9],
+    },
+    {
+        "_id": "2",
+        "text": "Sample entry number <2>",
+        "otherfield": {"subfield": "x2y"},
+        "anotherfield": "alpha",
+        "$vector": [0.5, 0.5],
+    },
+    {
+        "_id": "3",
+        "text": "Sample entry number <3>",
+        "otherfield": {"subfield": "x3y"},
+        "anotherfield": "omega",
+        "$vector": [0.9, 0.1],
+    },
+]
+
 
 @pytest.fixture(scope="session")
 def astra_db_credentials_kwargs() -> Dict[str, Optional[str]]:
@@ -72,37 +101,26 @@ def collection(db: AstraDB, cliff_data: API_DOC) -> Iterable[AstraDBCollection]:
 
 
 @pytest.fixture(scope="module")
-def projection_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+def readonly_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     collection = db.create_collection(
-        collection_name=TEST_FIXTURE_PROJECTION_COLLECTION_NAME, dimension=5
+        collection_name=TEST_READONLY_VECTOR_COLLECTION, dimension=2
     )
 
-    collection.insert_many(
-        [
-            {
-                "_id": "1",
-                "text": "Sample entry number <1>",
-                "otherfield": {"subfield": "x1y"},
-                "anotherfield": "delete_me",
-                "$vector": [0.1, 0.15, 0.3, 0.12, 0.05],
-            },
-            {
-                "_id": "2",
-                "text": "Sample entry number <2>",
-                "otherfield": {"subfield": "x2y"},
-                "anotherfield": "delete_me",
-                "$vector": [0.45, 0.09, 0.01, 0.2, 0.11],
-            },
-            {
-                "_id": "3",
-                "text": "Sample entry number <3>",
-                "otherfield": {"subfield": "x3y"},
-                "anotherfield": "dont_delete_me",
-                "$vector": [0.1, 0.05, 0.08, 0.3, 0.6],
-            },
-        ],
-    )
+    collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
 
-    db.delete_collection(collection_name=TEST_FIXTURE_PROJECTION_COLLECTION_NAME)
+    db.delete_collection(collection_name=TEST_READONLY_VECTOR_COLLECTION)
+
+
+@pytest.fixture(scope="function")
+def disposable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+    collection = db.create_collection(
+        collection_name=TEST_DISPOSABLE_VECTOR_COLLECTION, dimension=2
+    )
+
+    collection.insert_many(VECTOR_DOCUMENTS)
+
+    yield collection
+
+    db.delete_collection(collection_name=TEST_DISPOSABLE_VECTOR_COLLECTION)


### PR DESCRIPTION
### Original scope

This PR fixes the bug in #122 whereby in absence of any match, the `vector_*one*` methods would error with a "NoneType is not iterable".
With the introduction of usage of `includeSimilarity` in the API calls, the whole postprocessing step in all `vector_*` methods is not required and has been removed (simplification!).
Also the docstrings are adapted accondingly.

Closes #122 

### Testing

To better highlight the issue, I started adding to the tests ... then realized a major refactoring of the whole test suite was in order and I just went ahead with that. So, _this PR also contains a major improvement to the tests._

- Each test function can now be run as stand-alone (e.g. through `pytest ... -k <selector>`) in that it does not rely on any other test function to run, in any order. This warranted a `conftest.py` and a rethinking of all the collection fixtures
- To optimize DB usage, there are a few "read-only" session-wide collection fixtures, "writeable" session-wide ones (each function supposed to generate IDs to avoid collisions) and "disposable" function-wide fixtures to ensure isolation of tests.
- Also there were several missing tests, they were arranged in a non systematic fashion, named in unexpected ways, etc - to which I put a global, understandable order (see below for the new test names).
- Thanks to the fixtures above, I refactored the tests in more modules for easier management: schema stuff / pagination stuff / `vector_` methods / regular "db.py" stuff.
- And of course the ops stuff: to encourage occasional running, I added support for the `TEST_ASTRADBOPS` env var (as opposed to uncommenting a `skipif` in the code). Still not running by default.
- Also to cover the fact that the typical token by the user is not strong enough to do Ops stuff (yet is the token we want to test with), I introduce an optional "ops-specific token" overriding the "regular" token if desired.
- Cliff Wicklow is not dead, by the way, but now he's just making a cameo (blame the optimization of the collections :)
- The README now gives the basic options to manage testing (including the proper env vars, management of the optional OPS and how to suppress the extended logging).

As an aside, here are now the test function names (unchanged ops-test functions at the end):

```
test_path_handling
test_create_use_destroy_nonvector_collection
test_create_use_destroy_vector_collection
test_get_collections
test_find_paginated
test_truncate_collection_fail
test_truncate_nonvector_collection
test_truncate_vector_collection
test_find_one_filter_novector
test_find_filter_novector
test_find_find_one_projection
test_find
test_find_error
test_find_limitless
test_create_document
test_insert_many
test_insert_many_ordered_false
test_upsert_document
test_update_one_create_subdocument_novector
test_delete_subdocument_novector
test_find_one_and_update_vector
test_find_one_and_update_novector
test_find_one_and_replace_vector
test_find_one_and_replace_novector
test_delete_one_novector
test_delete_many_novector
test_pop_push_novector
test_vector_find
test_vector_find_projection
test_vector_find_filters
test_vector_find_one
test_vector_find_one_and_update
test_vector_find_one_and_replace

test_client_type
test_get_databases
test_create_database
test_create_keyspace
```