### PR TITLE
AstraDBCollection count_documents method

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -472,6 +472,31 @@ class AstraDBCollection:
 
         return cast(Union[API_DOC, None], raw_find_result["data"]["document"])
 
+    def count_documents(
+        self,
+        filter: Dict[str, Any] = {},
+    ) -> API_RESPONSE:
+        """
+        Count documents matching a given predicate (expressed as filter).
+        Args:
+            filter (dict, defaults to {}): Criteria to filter documents.
+        Returns:
+            dict: the response, either
+                {"status": {"count": <NUMBER> }}
+            or
+                {"errors": [...]}
+        """
+        json_query = make_payload(
+            top_level="countDocuments",
+            filter=filter,
+        )
+
+        response = self._post(
+            document=json_query,
+        )
+
+        return response
+
     def find_one(
         self,
         filter: Optional[Dict[str, Any]] = {},

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -182,6 +182,27 @@ def test_find_limitless(readonly_vector_collection: AstraDBCollection) -> None:
     assert isinstance(response["data"]["documents"], list)
 
 
+@pytest.mark.describe("correctly count documents according to predicate")
+def test_count_documents(
+    readonly_vector_collection: AstraDBCollection,
+) -> None:
+    c_all_response0 = readonly_vector_collection.count_documents()
+    assert c_all_response0["status"]["count"] == 3
+
+    c_all_response1 = readonly_vector_collection.count_documents(filter={})
+    assert c_all_response1["status"]["count"] == 3
+
+    c_pred_response = readonly_vector_collection.count_documents(
+        filter={"anotherfield": "alpha"}
+    )
+    assert c_pred_response["status"]["count"] == 2
+
+    c_no_response = readonly_vector_collection.count_documents(
+        filter={"false_field": 137}
+    )
+    assert c_no_response["status"]["count"] == 0
+
+
 @pytest.mark.describe("insert_one, w/out _id, w/out vector")
 def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     i_vector = [0.3, 0.5]


### PR DESCRIPTION
The method is based on a primitive method exposed by the API (see #129  for more)

Closes #129 
