### PR TITLE
fix spelling of 'readme.md' -> 'readme.MD' in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     "Kirsten Hunter <kirsten.hunter@datastax.com>"
 ]
 license = "Apache-2.0"
-readme = "README.md"
+readme = "README.MD"
 packages = [
     { include = "astrapy" }
 ]


### PR DESCRIPTION
Otherwise a fresh `poetry install` would error by mismatch in `md != MD`:

```
$ poetry install
Installing dependencies from lock file

Package operations: 49 installs, 1 update, 0 removals

  • Installing click (8.1.7)
...
...
  • Installing types-toml (0.10.8.7)

[Errno 2] No such file or directory: '/home/stefano/personal/Datastax/code/other_clones/astrapy/README.md'
```