### PR TITLE
Support for $date, generalized pre- and post-processing, comprehensive management of vector coercion

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -158,9 +158,14 @@ class AstraDBCollection:
         )
         return response
 
-    def _pre_process_find(
+    def _recast_as_sort_projection(
         self, vector: List[float], fields: Optional[List[str]] = None
     ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+        """
+        Given a vector and optionally a list of fields,
+        reformulate them as a sort, projection pair for regular
+        'find'-like API calls (with basic validation as well).
+        """
         # Must pass a vector
         if not vector:
             raise ValueError("Must pass a vector")
@@ -248,7 +253,7 @@ class AstraDBCollection:
             raise ValueError("Must pass a limit")
 
         # Pre-process the included arguments
-        sort, projection = self._pre_process_find(
+        sort, projection = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -460,7 +465,7 @@ class AstraDBCollection:
             dict or None: either the matched document or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._pre_process_find(
+        sort, _ = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -527,7 +532,7 @@ class AstraDBCollection:
                 update operation, or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._pre_process_find(
+        sort, _ = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -620,7 +625,7 @@ class AstraDBCollection:
             dict or None: The found document or None if no matching document is found.
         """
         # Pre-process the included arguments
-        sort, projection = self._pre_process_find(
+        sort, projection = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -1027,9 +1032,14 @@ class AsyncAstraDBCollection:
         )
         return response
 
-    def _pre_process_find(
+    def _recast_as_sort_projection(
         self, vector: List[float], fields: Optional[List[str]] = None
     ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+        """
+        Given a vector and optionally a list of fields,
+        reformulate them as a sort, projection pair for regular
+        'find'-like API calls (with basic validation as well).
+        """
         # Must pass a vector
         if not vector:
             raise ValueError("Must pass a vector")
@@ -1117,7 +1127,7 @@ class AsyncAstraDBCollection:
             raise ValueError("Must pass a limit")
 
         # Pre-process the included arguments
-        sort, projection = self._pre_process_find(
+        sort, projection = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )
@@ -1325,7 +1335,7 @@ class AsyncAstraDBCollection:
             dict or None: either the matched document or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._pre_process_find(
+        sort, _ = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )
@@ -1392,7 +1402,7 @@ class AsyncAstraDBCollection:
                 update operation, or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._pre_process_find(
+        sort, _ = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )
@@ -1485,7 +1495,7 @@ class AsyncAstraDBCollection:
             dict or None: The found document or None if no matching document is found.
         """
         # Pre-process the included arguments
-        sort, projection = self._pre_process_find(
+        sort, projection = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -119,7 +119,7 @@ class AstraDBCollection:
             token=self.astra_db.token,
             method=method,
             path=path,
-            json_data=json_data,
+            json_data=normalize_for_api(json_data),
             url_params=url_params,
             skip_error_check=skip_error_check,
             **kwargs,
@@ -209,8 +209,6 @@ class AstraDBCollection:
         Returns:
             dict: The query response containing matched documents.
         """
-        sort = normalize_for_api(sort)
-
         json_query = make_payload(
             top_level="find",
             filter=filter,
@@ -429,8 +427,6 @@ class AstraDBCollection:
         Returns:
             dict: The result of the find and replace operation.
         """
-        replacement = normalize_for_api(replacement)
-
         json_query = make_payload(
             top_level="findOneAndReplace",
             filter=filter,
@@ -495,8 +491,6 @@ class AstraDBCollection:
         Returns:
             dict: The result of the find and update operation.
         """
-        update = normalize_for_api(update)
-
         json_query = make_payload(
             top_level="findOneAndUpdate",
             filter=filter,
@@ -532,8 +526,6 @@ class AstraDBCollection:
             dict or None: The result of the vector-based find and
                 update operation, or None if nothing found
         """
-        update = normalize_for_api(update)
-
         # Pre-process the included arguments
         sort, _ = self._pre_process_find(
             convert_vector_to_floats(vector),
@@ -654,8 +646,6 @@ class AstraDBCollection:
         Returns:
             dict: The response from the database after the insert operation.
         """
-        document = normalize_for_api(document)
-
         json_query = make_payload(top_level="insertOne", document=document)
 
         response = self._request(
@@ -683,9 +673,6 @@ class AstraDBCollection:
         Returns:
             dict: The response from the database after the insert operation.
         """
-        # Check if the vector is a list of floats
-        documents = [normalize_for_api(document) for document in documents]
-
         json_query = make_payload(
             top_level="insertMany", documents=documents, options=options
         )
@@ -882,7 +869,6 @@ class AstraDBCollection:
             str: The _id of the inserted or updated document.
         """
         # Build the payload for the insert attempt
-        document = normalize_for_api(document)
         result = self.insert_one(document, failures_allowed=True)
 
         # If the call failed, then we replace the existing doc
@@ -1003,7 +989,7 @@ class AsyncAstraDBCollection:
             token=self.astra_db.token,
             method=method,
             path=path,
-            json_data=json_data,
+            json_data=normalize_for_api(json_data),
             url_params=url_params,
             skip_error_check=skip_error_check,
         )
@@ -1092,8 +1078,6 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The query response containing matched documents.
         """
-        sort = normalize_for_api(sort)
-
         json_query = make_payload(
             top_level="find",
             filter=filter,
@@ -1308,8 +1292,6 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The result of the find and replace operation.
         """
-        replacement = normalize_for_api(replacement)
-
         json_query = make_payload(
             top_level="findOneAndReplace",
             filter=filter,
@@ -1374,8 +1356,6 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The result of the find and update operation.
         """
-        update = normalize_for_api(update)
-
         json_query = make_payload(
             top_level="findOneAndUpdate",
             filter=filter,
@@ -1411,8 +1391,6 @@ class AsyncAstraDBCollection:
             dict or None: The result of the vector-based find and
                 update operation, or None if nothing found
         """
-        update = normalize_for_api(update)
-
         # Pre-process the included arguments
         sort, _ = self._pre_process_find(
             vector,
@@ -1533,8 +1511,6 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The response from the database after the insert operation.
         """
-        document = normalize_for_api(document)
-
         json_query = make_payload(top_level="insertOne", document=document)
 
         response = await self._request(
@@ -1562,9 +1538,6 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The response from the database after the insert operation.
         """
-        # Check if the vector is a list of floats
-        documents = [normalize_for_api(document) for document in documents]
-
         json_query = make_payload(
             top_level="insertMany", documents=documents, options=options
         )
@@ -1737,7 +1710,6 @@ class AsyncAstraDBCollection:
             str: The _id of the inserted or updated document.
         """
         # Build the payload for the insert attempt
-        document = normalize_for_api(document)
         result = await self.insert_one(document, failures_allowed=True)
 
         # If the call failed, then we replace the existing doc

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -53,6 +53,7 @@ from astrapy.utils import (
     http_methods,
     amake_request,
     normalize_for_api,
+    restore_from_api,
 )
 from astrapy.types import (
     API_DOC,
@@ -125,7 +126,8 @@ class AstraDBCollection:
             **kwargs,
         )
 
-        response = request_handler.request()
+        direct_response = request_handler.request()
+        response = restore_from_api(direct_response)
 
         return response
 
@@ -999,7 +1001,8 @@ class AsyncAstraDBCollection:
             skip_error_check=skip_error_check,
         )
 
-        response = await arequest_handler.request()
+        direct_response = await arequest_handler.request()
+        response = restore_from_api(direct_response)
 
         return response
 

--- a/astrapy/utils.py
+++ b/astrapy/utils.py
@@ -196,11 +196,13 @@ def is_list_of_floats(vector: Iterable[Any]) -> bool:
         return False
 
 
-def _normalize_payload_value(key: str, value: Any) -> Any:
+def _normalize_payload_value(path: List[str], value: Any) -> Any:
     """
-    The key has only the role of regulating special treatments.
+    The path helps determining special treatments
     """
-    if key == "$vector":
+    _l2 = '.'.join(path[-2:])
+    _l1 = '.'.join(path[-1:])
+    if _l1 == "$vector" and _l2 != "projection.$vector":
         if not is_list_of_floats(value):
             return convert_vector_to_floats(value)
         else:
@@ -208,12 +210,12 @@ def _normalize_payload_value(key: str, value: Any) -> Any:
     else:
         if isinstance(value, dict):
             return {
-                k: _normalize_payload_value(k, v)
+                k: _normalize_payload_value(path + [k], v)
                 for k, v in value.items()
             }
         elif isinstance(value, list):
             return [
-                _normalize_payload_value(key, list_item)
+                _normalize_payload_value(path + [""], list_item)
                 for list_item in value
             ]
         else:
@@ -233,4 +235,4 @@ def normalize_for_api(payload: Dict[str, Any]) -> Dict[str, Any]:
         Dict[str, Any]: a "normalized" payload dict
     """
 
-    return _normalize_payload_value("", payload)
+    return _normalize_payload_value([], payload)

--- a/astrapy/utils.py
+++ b/astrapy/utils.py
@@ -182,21 +182,36 @@ def convert_vector_to_floats(vector: Iterable[Any]) -> List[float]:
     return [float(value) for value in vector]
 
 
-def preprocess_insert(document: Dict[str, Any]) -> Dict[str, Any]:
+def list_of_floats(vector: Iterable[Any]) -> bool:
     """
-    Perform preprocessing operations before an insertion
+    Safely determine if it's a list of floats.
+    Assumption: if list, and first item is float, then all items are.
+    """
+    if isinstance(vector, list):
+        if len(vector):
+            return isinstance(vector[0], float) or isinstance(vector[0], int)
+        else:
+            return True
+    else:
+        return False
+
+
+def normalize_for_api(document: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalize a document for API calls.
+    This includes e.g. ensuring vectors are plain lists of floats.
 
     Args:
-        vector (list): A vector of objects.
+        document (Dict[str, Any]): A dict expressing a document or equivalent
 
     Returns:
-        list: A vector of objects
+        Dict[str, Any]: a "normalized" dict
     """
 
-    # Process each field of the cocument
+    # Inspect each field of the document
     for key, value in document.items():
-        # Vector coercision
-        if key == "$vector" and not isinstance(document["$vector"][0], float):
+        # Vector coercion to plain list of floats
+        if key == "$vector" and not list_of_floats(document["$vector"]):
             document[key] = convert_vector_to_floats(value)
 
         # TODO: More pre-processing operations

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -188,7 +188,7 @@ async def test_find_error(
     async_readonly_vector_collection: AsyncAstraDBCollection,
 ) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
-    sort = {"$vector": "clearly not a list of floats!"}
+    sort = {"$vector": [0, "clearly not a list of floats!"]}
     options = {"limit": 100}
 
     with pytest.raises(APIRequestError):

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -74,6 +74,28 @@ async def test_vector_find(
     assert "$similarity" not in documents_no_sim[0]
 
 
+@pytest.mark.describe("should coerce vectors in vector_find")
+async def test_vector_find_float32(
+    async_readonly_vector_collection: AsyncAstraDBCollection,
+) -> None:
+    def ite():
+        for v in [0.1, 0.2]:
+            yield f"{v}"
+
+    documents_sim_1 = await async_readonly_vector_collection.vector_find(
+        vector=ite(),
+        limit=3,
+    )
+
+    assert documents_sim_1 is not None
+    assert isinstance(documents_sim_1, list)
+    assert len(documents_sim_1) > 0
+    assert "_id" in documents_sim_1[0]
+    assert "$vector" in documents_sim_1[0]
+    assert "text" in documents_sim_1[0]
+    assert "$similarity" in documents_sim_1[0]
+
+
 @pytest.mark.describe("vector_find, obey projection")
 async def test_vector_find_projection(
     async_readonly_vector_collection: AsyncAstraDBCollection,

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -17,7 +17,7 @@ Tests for the `db.py` parts on data manipulation `vector_*` methods
 """
 
 import logging
-from typing import cast
+from typing import cast, Iterable, List
 
 import pytest
 
@@ -78,12 +78,13 @@ async def test_vector_find(
 async def test_vector_find_float32(
     async_readonly_vector_collection: AsyncAstraDBCollection,
 ) -> None:
-    def ite():
+    def ite() -> Iterable[str]:
         for v in [0.1, 0.2]:
             yield f"{v}"
 
     documents_sim_1 = await async_readonly_vector_collection.vector_find(
-        vector=ite(),
+        # we surreptitously trick typing here
+        vector=cast(List[float], ite()),
         limit=3,
     )
 

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -182,7 +182,7 @@ def test_find(readonly_vector_collection: AstraDBCollection) -> None:
 @pytest.mark.describe("proper error raising in find")
 def test_find_error(readonly_vector_collection: AstraDBCollection) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
-    sort = {"$vector": "clearly not a list of floats!"}
+    sort = {"$vector": [0, "clearly not a list of floats!"]}
     options = {"limit": 100}
 
     with pytest.raises(APIRequestError):

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -157,6 +157,19 @@ def test_find_find_one_projection(
         assert fields == exp_fields
 
 
+@pytest.mark.describe("should coerce vectors in the find sort argument")
+def test_find_float32(
+    readonly_vector_collection: AstraDBCollection,
+) -> None:
+    def ite():
+        for v in [0.1, 0.2]:
+            yield f"{v}"
+    sort = {"$vector": ite()}
+    options = {"limit": 5}
+
+    response = readonly_vector_collection.find(sort=sort, options=options)
+    assert isinstance(response["data"]["documents"], list)
+
 @pytest.mark.describe("find through vector")
 def test_find(readonly_vector_collection: AstraDBCollection) -> None:
     sort = {"$vector": [0.2, 0.6]}
@@ -281,7 +294,7 @@ def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     )
 
 
-@pytest.mark.describe("should truncate a nonvector collection")
+@pytest.mark.describe("should coerce vectors to plain lists of floats")
 def test_insert_float32(
     writable_vector_collection: AstraDBCollection, N: int = 2
 ) -> None:

--- a/tests/astrapy/test_db_dml_vector.py
+++ b/tests/astrapy/test_db_dml_vector.py
@@ -72,6 +72,28 @@ def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
     assert "$similarity" not in documents_no_sim[0]
 
 
+@pytest.mark.describe("should coerce vectors in vector_find")
+def test_vector_find_float32(
+    readonly_vector_collection: AstraDBCollection,
+) -> None:
+    def ite():
+        for v in [0.1, 0.2]:
+            yield f"{v}"
+
+    documents_sim_1 = readonly_vector_collection.vector_find(
+        vector=ite(),
+        limit=3,
+    )
+
+    assert documents_sim_1 is not None
+    assert isinstance(documents_sim_1, list)
+    assert len(documents_sim_1) > 0
+    assert "_id" in documents_sim_1[0]
+    assert "$vector" in documents_sim_1[0]
+    assert "text" in documents_sim_1[0]
+    assert "$similarity" in documents_sim_1[0]
+
+
 @pytest.mark.describe("vector_find, obey projection")
 def test_vector_find_projection(readonly_vector_collection: AstraDBCollection) -> None:
     query = [0.2, 0.6]

--- a/tests/astrapy/test_db_dml_vector.py
+++ b/tests/astrapy/test_db_dml_vector.py
@@ -17,7 +17,7 @@ Tests for the `db.py` parts on data manipulation `vector_*` methods
 """
 
 import logging
-from typing import cast
+from typing import cast, Iterable, List
 
 import pytest
 
@@ -76,12 +76,12 @@ def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
 def test_vector_find_float32(
     readonly_vector_collection: AstraDBCollection,
 ) -> None:
-    def ite():
+    def ite() -> Iterable[str]:
         for v in [0.1, 0.2]:
             yield f"{v}"
 
     documents_sim_1 = readonly_vector_collection.vector_find(
-        vector=ite(),
+        vector=cast(List[float], ite()),  # we surreptitously trick typing here
         limit=3,
     )
 


### PR DESCRIPTION
Along the way to implementing $date consistently, this PR refactors the pre- and post-processing to and from the API calls in a way that visits the whole payloads/responses and ensures every method passes through it.
Tests updated accordingly.

Closes #163 .
