### PR TITLE
Adjust tests to the ordered=False API default

### DIFF
--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -355,7 +355,8 @@ def test_chunked_insert_many(
         if isinstance(response, dict)
         for ins_id in response["status"]["insertedIds"]
     ]
-    assert inserted_ids0 == _ids0
+    # unordered inserts: this only has to be a set equality
+    assert set(inserted_ids0) == set(_ids0)
 
     response0a = writable_vector_collection.find_one(filter={"_id": _ids0[0]})
     assert response0a is not None
@@ -378,7 +379,11 @@ def test_chunked_insert_many(
     ]
 
     with pytest.raises(ValueError):
-        _ = writable_vector_collection.chunked_insert_many(documents1, chunk_size=3)
+        _ = writable_vector_collection.chunked_insert_many(
+            documents1,
+            chunk_size=3,
+            options={"ordered": True},
+        )
 
     responses1_ok = writable_vector_collection.chunked_insert_many(
         documents1,
@@ -433,7 +438,8 @@ def test_concurrent_chunked_insert_many(
         if isinstance(response, dict)
         for ins_id in response["status"]["insertedIds"]
     ]
-    assert inserted_ids0 == _ids0
+    # unordered inserts: this only has to be a set equality
+    assert set(inserted_ids0) == set(_ids0)
 
     response0a = writable_vector_collection.find_one(filter={"_id": _ids0[0]})
     assert response0a is not None
@@ -456,8 +462,15 @@ def test_concurrent_chunked_insert_many(
     ]
 
     with pytest.raises(ValueError):
+        # the first doc must be pre-existing
+        # and the doc array size must be <= chunk size
+        # for this not to spoil the rest of the test
+        docs_for_error = documents0[0:1] + [{"_id": str(uuid.uuid4())}]
         _ = writable_vector_collection.chunked_insert_many(
-            documents1, chunk_size=3, concurrency=4
+            docs_for_error,
+            chunk_size=3,
+            concurrency=4,
+            options={"ordered": True},
         )
 
     responses1_ok = writable_vector_collection.chunked_insert_many(
@@ -487,8 +500,8 @@ def test_concurrent_chunked_insert_many(
     assert len(set(_ids0) & set(_ids1)) == len(errors1)
 
 
-@pytest.mark.describe("insert_many with 'ordered' set to False")
-def test_insert_many_ordered_false(
+@pytest.mark.describe("insert_many with 'ordered' set to True")
+def test_insert_many_ordered_true(
     writable_vector_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
@@ -506,7 +519,10 @@ def test_insert_many_ordered_false(
             "last_name": "Boss",
         },
     ]
-    response_a = writable_vector_collection.insert_many(documents_a)
+    response_a = writable_vector_collection.insert_many(
+        documents_a,
+        options={"ordered": True},
+    )
     assert response_a is not None
     assert response_a["status"]["insertedIds"] == [_id0, _id1]
 
@@ -523,8 +539,7 @@ def test_insert_many_ordered_false(
         },
     ]
     response_b = writable_vector_collection.insert_many(
-        documents_b,
-        partial_failures_allowed=True,
+        documents_b, partial_failures_allowed=True, options={"ordered": True}
     )
     assert response_b is not None
     assert response_b["status"]["insertedIds"] == []


### PR DESCRIPTION
The Data API beta7 has introduced the `ordered=False` default for insertMany.

The change in behaviour reverberate through several of the astrapy tests in not entirely trivial ways. This PR "fixes the tests" - which mostly amounts to

1. ensuring the correct `ordered` option is given explicitly when needed;
2. asserting on set equality and not list equality anymore in a few places, since for unordered inserts [the server is free to re-order the inserts and parallelize them for performance](https://github.com/stargate/jsonapi/commit/e25e8dab46015fb8d415b86ae21a57803d38ff27#diff-10a6655841047d3b5d397f09ba7216c68879c62a2efd3515e499d440796aee89).



