### PR TITLE
rework upsert flow to handle all errors from API

### DIFF
--- a/astrapy/api.py
+++ b/astrapy/api.py
@@ -73,7 +73,7 @@ class APIRequestHandler:
             # Cast the response to the expected type.
             response_body: API_RESPONSE = cast(API_RESPONSE, self.response.json())
 
-            # If the API produced an error, warn and return the API request error class
+            # If the API produced an error, warn and raise it as an Exception
             if "errors" in response_body and not self.skip_error_check:
                 logger.debug(response_body["errors"])
 

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -899,7 +899,7 @@ class AstraDBCollection:
         # Build the payload for the insert attempt
         result = self.insert_one(document, failures_allowed=True)
 
-        # If the call failed, then we replace the existing doc
+        # If the call failed because of preexisting doc, then we replace it
         if "errors" in result:
             if (
                 "errorCode" in result["errors"][0]
@@ -1768,7 +1768,7 @@ class AsyncAstraDBCollection:
         # Build the payload for the insert attempt
         result = await self.insert_one(document, failures_allowed=True)
 
-        # If the call failed, then we replace the existing doc
+        # If the call failed because of preexisting doc, then we replace it
         if "errors" in result:
             if (
                 "errorCode" in result["errors"][0]

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -650,6 +650,40 @@ async def test_upsert_document(
     assert response1["data"]["document"] == document1
 
 
+@pytest.mark.describe("upsert should catch general errors from API")
+async def test_upsert_api_errors(
+    async_writable_vector_collection: AsyncAstraDBCollection,
+) -> None:
+    _id0 = str(uuid.uuid4())
+    _id1 = str(uuid.uuid4())
+
+    document0a = {
+        "_id": _id0,
+        "nature": "good vector",
+        "$vector": [10, 11],
+    }
+    upsert_result0 = await async_writable_vector_collection.upsert(document0a)
+    assert upsert_result0 == _id0
+
+    # triggering an API error for the already-exists path of the upsert
+    document0b = {
+        "_id": _id0,
+        "nature": "faulty vector",
+        "$vector": [10, 11, 999, -153],
+    }
+    with pytest.raises(ValueError):
+        _ = await async_writable_vector_collection.upsert(document0b)
+
+    # triggering an API error for the already-exists path of the upsert
+    document1 = {
+        "_id": _id1,
+        "nature": "faulty vector from the start",
+        "$vector": [10, 11, 999, -153],
+    }
+    with pytest.raises(ValueError):
+        _ = await async_writable_vector_collection.upsert(document1)
+
+
 @pytest.mark.describe("update_one to create a subdocument, not through vector")
 async def test_update_one_create_subdocument_novector(
     async_disposable_vector_collection: AsyncAstraDBCollection,

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -698,6 +698,38 @@ def test_upsert_document(writable_vector_collection: AstraDBCollection) -> None:
     assert response1["data"]["document"] == document1
 
 
+@pytest.mark.describe("upsert should catch general errors from API")
+def test_upsert_api_errors(writable_vector_collection: AstraDBCollection) -> None:
+    _id0 = str(uuid.uuid4())
+    _id1 = str(uuid.uuid4())
+
+    document0a = {
+        "_id": _id0,
+        "nature": "good vector",
+        "$vector": [10, 11],
+    }
+    upsert_result0 = writable_vector_collection.upsert(document0a)
+    assert upsert_result0 == _id0
+
+    # triggering an API error for the already-exists path of the upsert
+    document0b = {
+        "_id": _id0,
+        "nature": "faulty vector",
+        "$vector": [10, 11, 999, -153],
+    }
+    with pytest.raises(ValueError):
+        _ = writable_vector_collection.upsert(document0b)
+
+    # triggering an API error for the already-exists path of the upsert
+    document1 = {
+        "_id": _id1,
+        "nature": "faulty vector from the start",
+        "$vector": [10, 11, 999, -153],
+    }
+    with pytest.raises(ValueError):
+        _ = writable_vector_collection.upsert(document1)
+
+
 @pytest.mark.describe("update_one to create a subdocument, not through vector")
 def test_update_one_create_subdocument_novector(
     disposable_vector_collection: AstraDBCollection,


### PR DESCRIPTION
Fixes #159  .

The errors in CI (apart from timeouts and such) are due to the "ordered=false" default - unrelated to this PR - #169 takes care of them.
