### PR TITLE
Feature/#166 slick truncate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
       ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
       ASTRA_DB_ID: ${{ secrets.ASTRA_DB_ID }}
+      TEST_SKIP_COLLECTION_DELETE: ${{ vars.TEST_SKIP_COLLECTION_DELETE }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
       ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
       ASTRA_DB_ID: ${{ secrets.ASTRA_DB_ID }}
-      TEST_SKIP_COLLECTION_DELETE: ${{ vars.TEST_SKIP_COLLECTION_DELETE }}
+      TEST_SKIP_COLLECTION_DELETE: ${{ secrets.TEST_SKIP_COLLECTION_DELETE }}
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -403,8 +403,14 @@ poetry run pytest
 
 To remove the noise from the logs (on by default), run `pytest -o log_cli=0`.
 
+To skip all collection deletions (done by default):
+
+```bash
+TEST_SKIP_COLLECTION_DELETE=1 poetry run pytest [...]
+```
+
 To enable the `AstraDBOps` testing (off by default):
 
 ```bash
-TEST_ASTRADBOPS=1 pytest
+TEST_ASTRADBOPS=1 poetry run pytest [...]
 ```

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -848,18 +848,28 @@ class AstraDBCollection:
 
         return response
 
+    def clear(self) -> API_RESPONSE:
+        """
+        Truncate the collection, deleting all documents
+        Returns:
+            dict: The response from the database.
+        """
+        clear_response = self.delete_many(filter={})
+
+        if clear_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError(
+                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+            )
+
+        return clear_response
+
     def truncate(self) -> API_RESPONSE:
         """
         Truncate the collection, deleting all documents
         Returns:
             dict: The response from the database.
         """
-        truncate_response = self.delete_many(filter={})
-
-        if truncate_response.get("status", {}).get("deletedCount") != -1:
-            raise ValueError("Could not issue a truncate API command.")
-
-        return truncate_response
+        return self.clear()
 
     def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
@@ -1703,18 +1713,28 @@ class AsyncAstraDBCollection:
 
         return response
 
+    async def clear(self) -> API_RESPONSE:
+        """
+        Truncate the collection, deleting all documents
+        Returns:
+            dict: The response from the database.
+        """
+        clear_response = await self.delete_many(filter={})
+
+        if clear_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError(
+                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+            )
+
+        return clear_response
+
     async def truncate(self) -> API_RESPONSE:
         """
         Truncate the collection, deleting all documents
         Returns:
             dict: The response from the database.
         """
-        truncate_response = await self.delete_many(filter={})
-
-        if truncate_response.get("status", {}).get("deletedCount") != -1:
-            raise ValueError("Could not issue a truncate API command.")
-
-        return truncate_response
+        return await self.clear()
 
     async def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
@@ -2001,9 +2021,9 @@ class AstraDB:
 
         return response
 
-    def truncate_collection(self, collection_name: str) -> AstraDBCollection:
+    def clear_collection(self, collection_name: str) -> AstraDBCollection:
         """
-        Truncate a collection in the database.
+        Truncate a collection in the database, deleting all stored documents.
         Args:
             collection_name (str): The name of the collection to truncate.
         Returns:
@@ -2014,13 +2034,25 @@ class AstraDB:
             collection_name=collection_name,
             astra_db=self,
         )
-        truncate_response = collection.delete_many(filter={})
+        clear_response = collection.delete_many(filter={})
 
-        if truncate_response.get("status", {}).get("deletedCount") != -1:
-            raise ValueError("Could not issue a truncate API command.")
+        if clear_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError(
+                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+            )
 
         # return the collection itself
         return collection
+
+    def truncate_collection(self, collection_name: str) -> AstraDBCollection:
+        """
+        Truncate a collection in the database, deleting all stored documents.
+        Args:
+            collection_name (str): The name of the collection to truncate.
+        Returns:
+            collection: an AstraDBCollection instance
+        """
+        return self.clear_collection(collection_name)
 
 
 class AsyncAstraDB:
@@ -2230,9 +2262,9 @@ class AsyncAstraDB:
 
         return response
 
-    async def truncate_collection(self, collection_name: str) -> AsyncAstraDBCollection:
+    async def clear_collection(self, collection_name: str) -> AsyncAstraDBCollection:
         """
-        Truncate a collection in the database.
+        Truncate a collection in the database, deleting all stored documents.
         Args:
             collection_name (str): The name of the collection to truncate.
         Returns:
@@ -2242,10 +2274,22 @@ class AsyncAstraDB:
             collection_name=collection_name,
             astra_db=self,
         )
-        truncate_response = await collection.delete_many(filter={})
+        clear_response = await collection.delete_many(filter={})
 
-        if truncate_response.get("status", {}).get("deletedCount") != -1:
-            raise ValueError("Could not issue a truncate API command.")
+        if clear_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError(
+                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+            )
 
         # return the collection itself
         return collection
+
+    async def truncate_collection(self, collection_name: str) -> AsyncAstraDBCollection:
+        """
+        Truncate a collection in the database, deleting all stored documents.
+        Args:
+            collection_name (str): The name of the collection to truncate.
+        Returns:
+            collection: an AsyncAstraDBCollection instance
+        """
+        return await self.clear_collection(collection_name)

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -2030,7 +2030,7 @@ class AstraDB:
             collection_name=collection_name,
             astra_db=self,
         )
-        clear_response = collection.delete_many(filter={})
+        clear_response = collection.clear()
 
         if clear_response.get("status", {}).get("deletedCount") != -1:
             raise ValueError(
@@ -2268,7 +2268,7 @@ class AsyncAstraDB:
             collection_name=collection_name,
             astra_db=self,
         )
-        clear_response = await collection.delete_many(filter={})
+        clear_response = await collection.clear()
 
         if clear_response.get("status", {}).get("deletedCount") != -1:
             raise ValueError(

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -18,6 +18,7 @@ import httpx
 import logging
 import json
 import threading
+from warnings import warn
 
 
 from concurrent.futures import ThreadPoolExecutor
@@ -805,7 +806,11 @@ class AstraDBCollection:
         return self._put(path=path, document=document)
 
     def delete(self, id: str) -> API_RESPONSE:
-        # TODO: Deprecate this method
+        DEPRECATION_MESSAGE = (
+            "Method 'delete' of AstraDBCollection is deprecated. Please "
+            "switch to method 'delete_one'."
+        )
+        warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
         return self.delete_one(id)
 
     def delete_one(self, id: str) -> API_RESPONSE:
@@ -850,7 +855,7 @@ class AstraDBCollection:
 
     def clear(self) -> API_RESPONSE:
         """
-        Truncate the collection, deleting all documents
+        Clear the collection, deleting all documents
         Returns:
             dict: The response from the database.
         """
@@ -858,18 +863,10 @@ class AstraDBCollection:
 
         if clear_response.get("status", {}).get("deletedCount") != -1:
             raise ValueError(
-                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+                f"Could not issue a clear-collection API command (response: {json.dumps(clear_response)})."
             )
 
         return clear_response
-
-    def truncate(self) -> API_RESPONSE:
-        """
-        Truncate the collection, deleting all documents
-        Returns:
-            dict: The response from the database.
-        """
-        return self.clear()
 
     def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
@@ -1715,7 +1712,7 @@ class AsyncAstraDBCollection:
 
     async def clear(self) -> API_RESPONSE:
         """
-        Truncate the collection, deleting all documents
+        Clear the collection, deleting all documents
         Returns:
             dict: The response from the database.
         """
@@ -1723,18 +1720,10 @@ class AsyncAstraDBCollection:
 
         if clear_response.get("status", {}).get("deletedCount") != -1:
             raise ValueError(
-                f"Could not issue a truncation API command (response: {json.dumps(clear_response)})."
+                f"Could not issue a clear-collection API command (response: {json.dumps(clear_response)})."
             )
 
         return clear_response
-
-    async def truncate(self) -> API_RESPONSE:
-        """
-        Truncate the collection, deleting all documents
-        Returns:
-            dict: The response from the database.
-        """
-        return await self.clear()
 
     async def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
@@ -2021,15 +2010,22 @@ class AstraDB:
 
         return response
 
-    def clear_collection(self, collection_name: str) -> AstraDBCollection:
+    def truncate_collection(self, collection_name: str) -> AstraDBCollection:
         """
-        Truncate a collection in the database, deleting all stored documents.
+        Clear a collection in the database, deleting all stored documents.
         Args:
-            collection_name (str): The name of the collection to truncate.
+            collection_name (str): The name of the collection to clear.
         Returns:
             collection: an AstraDBCollection instance
         """
-        # truncate
+        DEPRECATION_MESSAGE = (
+            "Method 'truncate_collection' of AstraDB is deprecated. Please "
+            "switch to method 'clear' of the AstraDBCollection object, e.g. "
+            "'astra_db.collection(\"my_collection\").clear()'."
+            " Note the returned object is different."
+        )
+        warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+
         collection = AstraDBCollection(
             collection_name=collection_name,
             astra_db=self,
@@ -2043,16 +2039,6 @@ class AstraDB:
 
         # return the collection itself
         return collection
-
-    def truncate_collection(self, collection_name: str) -> AstraDBCollection:
-        """
-        Truncate a collection in the database, deleting all stored documents.
-        Args:
-            collection_name (str): The name of the collection to truncate.
-        Returns:
-            collection: an AstraDBCollection instance
-        """
-        return self.clear_collection(collection_name)
 
 
 class AsyncAstraDB:
@@ -2262,14 +2248,22 @@ class AsyncAstraDB:
 
         return response
 
-    async def clear_collection(self, collection_name: str) -> AsyncAstraDBCollection:
+    async def truncate_collection(self, collection_name: str) -> AsyncAstraDBCollection:
         """
-        Truncate a collection in the database, deleting all stored documents.
+        Clear a collection in the database, deleting all stored documents.
         Args:
-            collection_name (str): The name of the collection to truncate.
+            collection_name (str): The name of the collection to clear.
         Returns:
             collection: an AsyncAstraDBCollection instance
         """
+        DEPRECATION_MESSAGE = (
+            "Method 'truncate_collection' of AsyncAstraDB is deprecated. Please "
+            "switch to method 'clear' of the AsyncAstraDBCollection object, e.g. "
+            "'async_astra_db.collection(\"my_collection\").clear()'"
+            " Note the returned object is different."
+        )
+        warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+
         collection = AsyncAstraDBCollection(
             collection_name=collection_name,
             astra_db=self,
@@ -2283,13 +2277,3 @@ class AsyncAstraDB:
 
         # return the collection itself
         return collection
-
-    async def truncate_collection(self, collection_name: str) -> AsyncAstraDBCollection:
-        """
-        Truncate a collection in the database, deleting all stored documents.
-        Args:
-            collection_name (str): The name of the collection to truncate.
-        Returns:
-            collection: an AsyncAstraDBCollection instance
-        """
-        return await self.clear_collection(collection_name)

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -848,6 +848,19 @@ class AstraDBCollection:
 
         return response
 
+    def truncate(self) -> API_RESPONSE:
+        """
+        Truncate the collection, deleting all documents
+        Returns:
+            dict: The response from the database.
+        """
+        truncate_response = self.delete_many(filter={})
+
+        if truncate_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError("Could not issue a truncate API command.")
+
+        return truncate_response
+
     def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
         Delete a subdocument or field from a document in the collection.
@@ -1690,6 +1703,19 @@ class AsyncAstraDBCollection:
 
         return response
 
+    async def truncate(self) -> API_RESPONSE:
+        """
+        Truncate the collection, deleting all documents
+        Returns:
+            dict: The response from the database.
+        """
+        truncate_response = await self.delete_many(filter={})
+
+        if truncate_response.get("status", {}).get("deletedCount") != -1:
+            raise ValueError("Could not issue a truncate API command.")
+
+        return truncate_response
+
     async def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """
         Delete a subdocument or field from a document in the collection.
@@ -1981,7 +2007,7 @@ class AstraDB:
         Args:
             collection_name (str): The name of the collection to truncate.
         Returns:
-            dict: The response from the database.
+            collection: an AstraDBCollection instance
         """
         # truncate
         collection = AstraDBCollection(
@@ -2210,7 +2236,7 @@ class AsyncAstraDB:
         Args:
             collection_name (str): The name of the collection to truncate.
         Returns:
-            dict: The response from the database.
+            collection: an AsyncAstraDBCollection instance
         """
         collection = AsyncAstraDBCollection(
             collection_name=collection_name,

--- a/tests/.env.template
+++ b/tests/.env.template
@@ -2,19 +2,19 @@
 # FOR THE REGULAR TESTS:
 ########################
 #
-ASTRA_DB_APPLICATION_TOKEN="AstraCS:..."
+export ASTRA_DB_APPLICATION_TOKEN="AstraCS:..."
 #
-ASTRA_DB_API_ENDPOINT="https://<DB_ID>-<DB_REGION>.apps.astra.datastax.com"
+export ASTRA_DB_API_ENDPOINT="https://<DB_ID>-<DB_REGION>.apps.astra.datastax.com"
 #
 # OPTIONAL:
-# ASTRA_DB_KEYSPACE="..."
+# export ASTRA_DB_KEYSPACE="..."
 
 
 ###################
 # FOR THE OPS TEST:
 ###################
 #
-ASTRA_DB_ID="..."
+export ASTRA_DB_ID="..."
 #
 # OPTIONAL (falls back to the token above)
-# ASTRA_DB_OPS_APPLICATION_TOKEN="..."
+# export ASTRA_DB_OPS_APPLICATION_TOKEN="..."

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -123,7 +123,6 @@ async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> N
 async def test_get_collections(
     async_db: AsyncAstraDB,
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     res = await async_db.get_collections()
     assert res["status"]["collections"] is not None

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -16,6 +16,7 @@
 Tests for the `db.py` parts related to DML & client creation
 """
 
+import os
 import logging
 from typing import Dict, Optional
 
@@ -30,7 +31,7 @@ TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME = "ephemeral_non_v_col"
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.describe("should confirm path handling in constructor")
+@pytest.mark.describe("should confirm path handling in constructor (async)")
 async def test_path_handling(
     astra_db_credentials_kwargs: Dict[str, Optional[str]]
 ) -> None:
@@ -72,7 +73,11 @@ async def test_path_handling(
         assert unspecified_ks_client.base_path == explicit_ks_client.base_path
 
 
-@pytest.mark.describe("should create, use and destroy a non-vector collection")
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
+@pytest.mark.describe("should create, use and destroy a non-vector collection (async)")
 async def test_create_use_destroy_nonvector_collection(async_db: AsyncAstraDB) -> None:
     col = await async_db.create_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
     assert isinstance(col, AsyncAstraDBCollection)
@@ -98,7 +103,11 @@ async def test_create_use_destroy_nonvector_collection(async_db: AsyncAstraDB) -
     assert del_res["status"]["ok"] == 1
 
 
-@pytest.mark.describe("should create and destroy a vector collection")
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
+@pytest.mark.describe("should create and destroy a vector collection (async)")
 async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> None:
     col = await async_db.create_collection(
         collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
@@ -110,7 +119,7 @@ async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> N
     assert del_res["status"]["ok"] == 1
 
 
-@pytest.mark.describe("should get all collections")
+@pytest.mark.describe("should get all collections (async)")
 async def test_get_collections(async_db: AsyncAstraDB) -> None:
     res = await async_db.get_collections()
     assert res["status"]["collections"] is not None

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional
 
 import pytest
 
-from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
+from astrapy.db import AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
 from astrapy.defaults import DEFAULT_KEYSPACE_NAME
 
 TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"
@@ -121,7 +121,9 @@ async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> N
 
 @pytest.mark.describe("should get all collections (async)")
 async def test_get_collections(
-    async_db: AsyncAstraDB, async_readonly_v_collection: AsyncAstraDBCollection
+    async_db: AsyncAstraDB,
+    async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     res = await async_db.get_collections()
     assert res["status"]["collections"] is not None

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional
 
 import pytest
 
-from astrapy.db import AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
+from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
 from astrapy.defaults import DEFAULT_KEYSPACE_NAME
 
 TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -120,6 +120,9 @@ async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> N
 
 
 @pytest.mark.describe("should get all collections (async)")
-async def test_get_collections(async_db: AsyncAstraDB) -> None:
+async def test_get_collections(
+    async_db: AsyncAstraDB, async_readonly_v_collection: AsyncAstraDBCollection
+) -> None:
     res = await async_db.get_collections()
     assert res["status"]["collections"] is not None
+    assert async_readonly_v_collection.collection_name in res["status"]["collections"]

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -31,10 +31,10 @@ from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.describe("should fail truncating a non-existent collection (async)")
-async def test_truncate_collection_fail(async_db: AsyncAstraDB) -> None:
+@pytest.mark.describe("should fail clearing a non-existent collection (async)")
+async def test_clear_collection_fail(async_db: AsyncAstraDB) -> None:
     with pytest.raises(APIRequestError):
-        await async_db.truncate_collection("this$does%not exist!!!")
+        await (await async_db.collection("this$does%not exist!!!")).clear()
 
 
 @pytest.mark.describe("should truncate a nonvector collection through AstraDB (async)")
@@ -44,9 +44,10 @@ async def test_truncate_nonvector_collection_through_astradb(
 ) -> None:
     await async_empty_nonv_collection.insert_one({"a": 1})
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 1
-    tr_response_col = await async_db.truncate_collection(
-        async_empty_nonv_collection.collection_name
-    )
+    with pytest.warns(DeprecationWarning):
+        tr_response_col = await async_db.truncate_collection(
+            async_empty_nonv_collection.collection_name
+        )
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 0
     assert isinstance(tr_response_col, AsyncAstraDBCollection)
     assert (
@@ -61,32 +62,33 @@ async def test_truncate_vector_collection_through_astradb(
 ) -> None:
     await async_empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 1
-    tr_response_col = await async_db.truncate_collection(
-        async_empty_v_collection.collection_name
-    )
+    with pytest.warns(DeprecationWarning):
+        tr_response_col = await async_db.truncate_collection(
+            async_empty_v_collection.collection_name
+        )
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 0
     assert isinstance(tr_response_col, AsyncAstraDBCollection)
     assert tr_response_col.collection_name == async_empty_v_collection.collection_name
 
 
-@pytest.mark.describe("should truncate a nonvector collection (async)")
-async def test_truncate_nonvector_collection(
+@pytest.mark.describe("should clear a nonvector collection (async)")
+async def test_clear_nonvector_collection(
     async_empty_nonv_collection: AsyncAstraDBCollection,
 ) -> None:
     await async_empty_nonv_collection.insert_one({"a": 1})
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 1
-    tr_response = await async_empty_nonv_collection.truncate()
+    tr_response = await async_empty_nonv_collection.clear()
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 0
     assert tr_response["status"]["deletedCount"] == -1
 
 
-@pytest.mark.describe("should truncate a collection (async)")
-async def test_truncate_vector_collection(
+@pytest.mark.describe("should clear a collection (async)")
+async def test_clear_vector_collection(
     async_empty_v_collection: AsyncAstraDBCollection,
 ) -> None:
     await async_empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 1
-    tr_response = await async_empty_v_collection.truncate()
+    tr_response = await async_empty_v_collection.clear()
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 0
     assert tr_response["status"]["deletedCount"] == -1
 

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -17,6 +17,7 @@ Tests for the `db.py` parts on data manipulation "standard" methods
 (i.e. non `vector_*` methods)
 """
 
+import os
 import uuid
 import logging
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -27,49 +28,40 @@ from astrapy.api import APIRequestError
 from astrapy.types import API_DOC
 from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
 
-TEST_TRUNCATED_NONVECTOR_COLLECTION_NAME = "ephemeral_tr_non_v_col"
-TEST_TRUNCATED_VECTOR_COLLECTION_NAME = "ephemeral_tr_v_col"
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.describe("should fail truncating a non-existent collection")
+@pytest.mark.describe("should fail truncating a non-existent collection (async)")
 async def test_truncate_collection_fail(async_db: AsyncAstraDB) -> None:
     with pytest.raises(APIRequestError):
         await async_db.truncate_collection("this$does%not exist!!!")
 
 
-@pytest.mark.describe("should truncate a nonvector collection through AstraDB")
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
+@pytest.mark.describe("should truncate a nonvector collection through AstraDB (async)")
 async def test_truncate_nonvector_collection_through_astradb(
     async_db: AsyncAstraDB,
-    async_disposable_empty_nonvector_collection: AsyncAstraDBCollection,
+    async_empty_nonv_collection: AsyncAstraDBCollection,
 ) -> None:
-    await async_db.truncate_collection(
-        async_disposable_empty_nonvector_collection.collection_name
-    )
+    await async_empty_nonv_collection.insert_one({"a": 1})
     assert (
         len(
-            (await async_disposable_empty_nonvector_collection.find())["data"][
-                "documents"
-            ]
-        )
-        == 0
-    )
-    await async_disposable_empty_nonvector_collection.insert_one({"a": 1})
-    assert (
-        len(
-            (await async_disposable_empty_nonvector_collection.find())["data"][
+            (await async_empty_nonv_collection.find())["data"][
                 "documents"
             ]
         )
         == 1
     )
     await async_db.truncate_collection(
-        async_disposable_empty_nonvector_collection.collection_name
+        async_empty_nonv_collection.collection_name
     )
     assert (
         len(
-            (await async_disposable_empty_nonvector_collection.find())["data"][
+            (await async_empty_nonv_collection.find())["data"][
                 "documents"
             ]
         )
@@ -77,33 +69,29 @@ async def test_truncate_nonvector_collection_through_astradb(
     )
 
 
-@pytest.mark.describe("should truncate a collection through AstraDB")
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
+@pytest.mark.describe("should truncate a collection through AstraDB (async)")
 async def test_truncate_vector_collection_through_astradb(
-    async_db: AsyncAstraDB, async_disposable_vector_collection: AsyncAstraDBCollection
+    async_db: AsyncAstraDB, async_empty_v_collection: AsyncAstraDBCollection
 ) -> None:
-    await async_db.truncate_collection(
-        async_disposable_vector_collection.collection_name
-    )
+    await async_empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert (
-        len((await async_disposable_vector_collection.find())["data"]["documents"]) == 0
-    )
-    await async_disposable_vector_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
-    assert (
-        len((await async_disposable_vector_collection.find())["data"]["documents"]) == 1
+        len((await async_empty_v_collection.find())["data"]["documents"]) == 1
     )
     await async_db.truncate_collection(
-        async_disposable_vector_collection.collection_name
+        async_empty_v_collection.collection_name
     )
     assert (
-        len((await async_disposable_vector_collection.find())["data"]["documents"]) == 0
+        len((await async_empty_v_collection.find())["data"]["documents"]) == 0
     )
 
 
-@pytest.mark.describe("find_one, not through vector")
-async def test_find_one_filter_novector(
-    async_readonly_vector_collection: AsyncAstraDBCollection, cliff_uuid: str
-) -> None:
-    response = await async_readonly_vector_collection.find_one(
+@pytest.mark.describe("find_one, not through vector (async)")
+async def test_find_one_filter_novector(async_readonly_v_collection: AsyncAstraDBCollection) -> None:
+    response = await async_readonly_v_collection.find_one(
         filter={"_id": "1"},
     )
     document = response["data"]["document"]
@@ -113,7 +101,7 @@ async def test_find_one_filter_novector(
         == set()
     )
 
-    response_not_by_id = await async_readonly_vector_collection.find_one(
+    response_not_by_id = await async_readonly_v_collection.find_one(
         filter={"text": "Sample entry number <1>"},
     )
     document_not_by_id = response_not_by_id["data"]["document"]
@@ -124,31 +112,31 @@ async def test_find_one_filter_novector(
         == set()
     )
 
-    response_no = await async_readonly_vector_collection.find_one(
+    response_no = await async_readonly_v_collection.find_one(
         filter={"_id": "Z"},
     )
     document_no = response_no["data"]["document"]
     assert document_no is None
 
-    response_no_not_by_id = await async_readonly_vector_collection.find_one(
+    response_no_not_by_id = await async_readonly_v_collection.find_one(
         filter={"text": "No such text."},
     )
     document_no_not_by_id = response_no_not_by_id["data"]["document"]
     assert document_no_not_by_id is None
 
 
-@pytest.mark.describe("find, not through vector")
+@pytest.mark.describe("find, not through vector (async)")
 async def test_find_filter_novector(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    response_n2 = await async_readonly_vector_collection.find(
+    response_n2 = await async_readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
     )
     documents_n2 = response_n2["data"]["documents"]
     assert isinstance(documents_n2, list)
     assert {document["_id"] for document in documents_n2} == {"1", "2"}
 
-    response_n1 = await async_readonly_vector_collection.find(
+    response_n1 = await async_readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
         options={"limit": 1},
     )
@@ -158,9 +146,9 @@ async def test_find_filter_novector(
     assert documents_n1[0]["_id"] in {"1", "2"}
 
 
-@pytest.mark.describe("obey projection in find and find_one")
+@pytest.mark.describe("obey projection in find and find_one (async)")
 async def test_find_find_one_projection(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
     sort = {"$vector": query}
@@ -181,82 +169,82 @@ async def test_find_find_one_projection(
         {"$vector", "_id", "text"},
     ]
     for proj, exp_fields in zip(projs, exp_fieldsets):
-        response_n = await async_readonly_vector_collection.find(
+        response_n = await async_readonly_v_collection.find(
             sort=sort, options=options, projection=proj
         )
         fields = set(response_n["data"]["documents"][0].keys())
         assert fields == exp_fields
         #
-        response_1 = await async_readonly_vector_collection.find_one(
+        response_1 = await async_readonly_v_collection.find_one(
             sort=sort, projection=proj
         )
         fields = set(response_1["data"]["document"].keys())
         assert fields == exp_fields
 
 
-@pytest.mark.describe("find through vector")
-async def test_find(async_readonly_vector_collection: AsyncAstraDBCollection) -> None:
+@pytest.mark.describe("find through vector (async)")
+async def test_find(async_readonly_v_collection: AsyncAstraDBCollection) -> None:
     sort = {"$vector": [0.2, 0.6]}
     options = {"limit": 100}
 
-    response = await async_readonly_vector_collection.find(sort=sort, options=options)
+    response = await async_readonly_v_collection.find(sort=sort, options=options)
     assert isinstance(response["data"]["documents"], list)
 
 
-@pytest.mark.describe("proper error raising in find")
+@pytest.mark.describe("proper error raising in find (async)")
 async def test_find_error(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
     sort = {"$vector": "clearly not a list of floats!"}
     options = {"limit": 100}
 
     with pytest.raises(APIRequestError):
-        await async_readonly_vector_collection.find(sort=sort, options=options)
+        await async_readonly_v_collection.find(sort=sort, options=options)
 
 
-@pytest.mark.describe("find through vector, without explicit limit")
+@pytest.mark.describe("find through vector, without explicit limit (async)")
 async def test_find_limitless(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
     projection = {"$vector": 1}
 
-    response = await async_readonly_vector_collection.find(
+    response = await async_readonly_v_collection.find(
         sort=sort, projection=projection
     )
     assert response is not None
     assert isinstance(response["data"]["documents"], list)
 
 
-@pytest.mark.describe("correctly count documents according to predicate")
+@pytest.mark.describe("correctly count documents according to predicate (async)")
 async def test_count_documents(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    c_all_response0 = await async_readonly_vector_collection.count_documents()
+    c_all_response0 = await async_readonly_v_collection.count_documents()
     assert c_all_response0["status"]["count"] == 3
 
-    c_all_response1 = await async_readonly_vector_collection.count_documents(filter={})
+    c_all_response1 = await async_readonly_v_collection.count_documents(filter={})
     assert c_all_response1["status"]["count"] == 3
 
-    c_pred_response = await async_readonly_vector_collection.count_documents(
+    c_pred_response = await async_readonly_v_collection.count_documents(
         filter={"anotherfield": "alpha"}
     )
     assert c_pred_response["status"]["count"] == 2
 
-    c_no_response = await async_readonly_vector_collection.count_documents(
+    c_no_response = await async_readonly_v_collection.count_documents(
         filter={"false_field": 137}
     )
     assert c_no_response["status"]["count"] == 0
 
 
-@pytest.mark.describe("insert_one, w/out _id, w/out vector")
+@pytest.mark.describe("insert_one, w/out _id, w/out vector (async)")
 async def test_create_document(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     i_vector = [0.3, 0.5]
     id_v_i = str(uuid.uuid4())
-    result_v_i = await async_writable_vector_collection.insert_one(
+    result_v_i = await async_writable_v_collection.insert_one(
         {
             "_id": id_v_i,
             "a": 1,
@@ -265,13 +253,13 @@ async def test_create_document(
     )
     assert result_v_i["status"]["insertedIds"] == [id_v_i]
     assert (
-        await async_writable_vector_collection.find_one(
+        await async_writable_v_collection.find_one(
             {"_id": result_v_i["status"]["insertedIds"][0]}
         )
     )["data"]["document"]["a"] == 1
 
     id_n_i = str(uuid.uuid4())
-    result_n_i = await async_writable_vector_collection.insert_one(
+    result_n_i = await async_writable_v_collection.insert_one(
         {
             "_id": id_n_i,
             "a": 2,
@@ -279,20 +267,20 @@ async def test_create_document(
     )
     assert result_n_i["status"]["insertedIds"] == [id_n_i]
     assert (
-        await async_writable_vector_collection.find_one(
+        await async_writable_v_collection.find_one(
             {"_id": result_n_i["status"]["insertedIds"][0]}
         )
     )["data"]["document"]["a"] == 2
 
     with pytest.raises(ValueError):
-        await async_writable_vector_collection.insert_one(
+        await async_writable_v_collection.insert_one(
             {
                 "_id": id_n_i,
                 "a": 3,
             }
         )
 
-    result_v_n = await async_writable_vector_collection.insert_one(
+    result_v_n = await async_writable_v_collection.insert_one(
         {
             "a": 4,
             "$vector": i_vector,
@@ -302,12 +290,12 @@ async def test_create_document(
     assert isinstance(result_v_n["status"]["insertedIds"][0], str)
     assert len(result_v_n["status"]["insertedIds"]) == 1
     assert (
-        await async_writable_vector_collection.find_one(
+        await async_writable_v_collection.find_one(
             {"_id": result_v_n["status"]["insertedIds"][0]}
         )
     )["data"]["document"]["a"] == 4
 
-    result_n_n = await async_writable_vector_collection.insert_one(
+    result_n_n = await async_writable_v_collection.insert_one(
         {
             "a": 5,
         }
@@ -316,15 +304,15 @@ async def test_create_document(
     assert isinstance(result_n_n["status"]["insertedIds"][0], str)
     assert len(result_n_n["status"]["insertedIds"]) == 1
     assert (
-        await async_writable_vector_collection.find_one(
+        await async_writable_v_collection.find_one(
             {"_id": result_n_n["status"]["insertedIds"][0]}
         )
     )["data"]["document"]["a"] == 5
 
 
-@pytest.mark.describe("insert_many")
+@pytest.mark.describe("insert_many (async)")
 async def test_insert_many(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id2 = str(uuid.uuid4())
@@ -347,16 +335,16 @@ async def test_insert_many(
         },
     ]
 
-    response = await async_writable_vector_collection.insert_many(documents)
+    response = await async_writable_v_collection.insert_many(documents)
     assert response is not None
     inserted_ids = set(response["status"]["insertedIds"])
     assert len(inserted_ids - {_id0, _id2}) == 1
     assert isinstance(list(inserted_ids - {_id0, _id2})[0], str)
 
 
-@pytest.mark.describe("chunked_insert_many")
+@pytest.mark.describe("chunked_insert_many (async)")
 async def test_chunked_insert_many(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -373,7 +361,7 @@ async def test_chunked_insert_many(
 
     responses0: List[
         Union[Dict[str, Any], Exception]
-    ] = await async_writable_vector_collection.chunked_insert_many(
+    ] = await async_writable_v_collection.chunked_insert_many(
         documents0, chunk_size=3
     )
     assert responses0 is not None
@@ -386,7 +374,7 @@ async def test_chunked_insert_many(
     # unordered inserts: this only has to be a set equality
     assert set(inserted_ids0) == set(_ids0)
 
-    response0a = await async_writable_vector_collection.find_one(
+    response0a = await async_writable_v_collection.find_one(
         filter={"_id": _ids0[0]}
     )
     assert response0a is not None
@@ -409,13 +397,13 @@ async def test_chunked_insert_many(
     ]
 
     with pytest.raises(ValueError):
-        _ = await async_writable_vector_collection.chunked_insert_many(
+        _ = await async_writable_v_collection.chunked_insert_many(
             documents1,
             chunk_size=3,
             options={"ordered": True},
         )
 
-    responses1_ok = await async_writable_vector_collection.chunked_insert_many(
+    responses1_ok = await async_writable_v_collection.chunked_insert_many(
         documents1,
         chunk_size=3,
         options={"ordered": False},
@@ -441,9 +429,9 @@ async def test_chunked_insert_many(
     assert len(set(_ids0) & set(_ids1)) == len(errors1)
 
 
-@pytest.mark.describe("chunked_insert_many concurrently")
+@pytest.mark.describe("chunked_insert_many concurrently (async)")
 async def test_concurrent_chunked_insert_many(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -458,7 +446,7 @@ async def test_concurrent_chunked_insert_many(
         for doc_idx, _id in enumerate(_ids0)
     ]
 
-    responses0 = await async_writable_vector_collection.chunked_insert_many(
+    responses0 = await async_writable_v_collection.chunked_insert_many(
         documents0, chunk_size=3, concurrency=4
     )
     assert responses0 is not None
@@ -473,7 +461,7 @@ async def test_concurrent_chunked_insert_many(
     # unordered inserts: this only has to be a set equality
     assert set(inserted_ids0) == set(_ids0)
 
-    response0a = await async_writable_vector_collection.find_one(
+    response0a = await async_writable_v_collection.find_one(
         filter={"_id": _ids0[0]}
     )
     assert response0a is not None
@@ -500,14 +488,14 @@ async def test_concurrent_chunked_insert_many(
         # and the doc array size must be <= chunk size
         # for this not to spoil the rest of the test
         docs_for_error = documents0[0:1] + [{"_id": str(uuid.uuid4())}]
-        _ = await async_writable_vector_collection.chunked_insert_many(
+        _ = await async_writable_v_collection.chunked_insert_many(
             docs_for_error,
             chunk_size=3,
             concurrency=4,
             options={"ordered": True},
         )
 
-    responses1_ok = await async_writable_vector_collection.chunked_insert_many(
+    responses1_ok = await async_writable_v_collection.chunked_insert_many(
         documents1,
         chunk_size=3,
         options={"ordered": False},
@@ -534,9 +522,9 @@ async def test_concurrent_chunked_insert_many(
     assert len(set(_ids0) & set(_ids1)) == len(errors1)
 
 
-@pytest.mark.describe("insert_many with 'ordered' set to True")
+@pytest.mark.describe("insert_many with 'ordered' set to True (async)")
 async def test_insert_many_ordered_true(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id1 = str(uuid.uuid4())
@@ -553,7 +541,7 @@ async def test_insert_many_ordered_true(
             "last_name": "Boss",
         },
     ]
-    response_a = await async_writable_vector_collection.insert_many(
+    response_a = await async_writable_v_collection.insert_many(
         documents_a,
         options={"ordered": True},
     )
@@ -572,7 +560,7 @@ async def test_insert_many_ordered_true(
             "last_name": "Fuff",
         },
     ]
-    response_b = await async_writable_vector_collection.insert_many(
+    response_b = await async_writable_v_collection.insert_many(
         documents_b,
         partial_failures_allowed=True,
         options={"ordered": True},
@@ -580,7 +568,7 @@ async def test_insert_many_ordered_true(
     assert response_b is not None
     assert response_b["status"]["insertedIds"] == []
 
-    response_b2 = await async_writable_vector_collection.insert_many(
+    response_b2 = await async_writable_v_collection.insert_many(
         documents=documents_b,
         options={"ordered": False},
         partial_failures_allowed=True,
@@ -588,16 +576,16 @@ async def test_insert_many_ordered_true(
     assert response_b2 is not None
     assert response_b2["status"]["insertedIds"] == [_id2]
 
-    check_response = await async_writable_vector_collection.find_one(
+    check_response = await async_writable_v_collection.find_one(
         filter={"first_name": "Yep"}
     )
     assert check_response is not None
     assert check_response["data"]["document"]["_id"] == _id1
 
 
-@pytest.mark.describe("upsert_many")
+@pytest.mark.describe("upsert_many (async)")
 async def test_upsert_many(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(12)]
     documents0 = [
@@ -611,16 +599,16 @@ async def test_upsert_many(
         for doc_i, _id in enumerate(_ids0)
     ]
 
-    upsert_result0 = await async_writable_vector_collection.upsert_many(documents0)
+    upsert_result0 = await async_writable_v_collection.upsert_many(documents0)
     assert upsert_result0 == [doc["_id"] for doc in documents0]
 
-    response0a = await async_writable_vector_collection.find_one(
+    response0a = await async_writable_v_collection.find_one(
         filter={"_id": _ids0[0]}
     )
     assert response0a is not None
     assert response0a["data"]["document"] == documents0[0]
 
-    response0b = await async_writable_vector_collection.find_one(
+    response0b = await async_writable_v_collection.find_one(
         filter={"_id": _ids0[-1]}
     )
     assert response0b is not None
@@ -637,28 +625,28 @@ async def test_upsert_many(
         }
         for doc_i, _id in enumerate(_ids1)
     ]
-    upsert_result1 = await async_writable_vector_collection.upsert_many(
+    upsert_result1 = await async_writable_v_collection.upsert_many(
         documents1,
         concurrency=5,
     )
     assert upsert_result1 == [doc["_id"] for doc in documents1]
 
-    response1a = await async_writable_vector_collection.find_one(
+    response1a = await async_writable_v_collection.find_one(
         filter={"_id": _ids1[0]}
     )
     assert response1a is not None
     assert response1a["data"]["document"] == documents1[0]
 
-    response1b = await async_writable_vector_collection.find_one(
+    response1b = await async_writable_v_collection.find_one(
         filter={"_id": _ids1[-1]}
     )
     assert response1b is not None
     assert response1b["data"]["document"] == documents1[-1]
 
 
-@pytest.mark.describe("upsert")
+@pytest.mark.describe("upsert (async)")
 async def test_upsert_document(
-    async_writable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
 
@@ -671,10 +659,10 @@ async def test_upsert_document(
             },
         },
     }
-    upsert_result0 = await async_writable_vector_collection.upsert(document0)
+    upsert_result0 = await async_writable_v_collection.upsert(document0)
     assert upsert_result0 == _id
 
-    response0 = await async_writable_vector_collection.find_one(filter={"_id": _id})
+    response0 = await async_writable_v_collection.find_one(filter={"_id": _id})
     assert response0 is not None
     assert response0["data"]["document"] == document0
 
@@ -691,37 +679,49 @@ async def test_upsert_document(
             "accounting",
         ],
     }
-    upsert_result1 = await async_writable_vector_collection.upsert(document1)
+    upsert_result1 = await async_writable_v_collection.upsert(document1)
     assert upsert_result1 == _id
 
-    response1 = await async_writable_vector_collection.find_one(filter={"_id": _id})
+    response1 = await async_writable_v_collection.find_one(filter={"_id": _id})
     assert response1 is not None
     assert response1["data"]["document"] == document1
 
 
-@pytest.mark.describe("update_one to create a subdocument, not through vector")
+@pytest.mark.describe("update_one to create a subdocument, not through vector (async)")
 async def test_update_one_create_subdocument_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    update_one_response = await async_disposable_vector_collection.update_one(
-        filter={"_id": "1"},
+    _id = str(uuid.uuid4())
+    await async_writable_v_collection.insert_one({"_id": _id, "name": "Not Eric!"})
+    update_one_response = await async_writable_v_collection.update_one(
+        filter={"_id": _id},
         update={"$set": {"name": "Eric"}},
     )
 
     assert update_one_response["status"]["matchedCount"] >= 1
     assert update_one_response["status"]["modifiedCount"] == 1
 
-    response = await async_disposable_vector_collection.find_one(filter={"_id": "1"})
+    response = await async_writable_v_collection.find_one(filter={"_id": _id})
     assert response["data"]["document"]["name"] == "Eric"
 
 
-@pytest.mark.describe("delete_subdocument, not through vector")
+@pytest.mark.describe("delete_subdocument, not through vector (async)")
 async def test_delete_subdocument_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
+    _id = str(uuid.uuid4())
+    await async_writable_v_collection.insert_one(
+        {
+            "_id": _id,
+            "text": "Sample entry",
+            "otherfield": {"subfield": "abc"},
+            "anotherfield": "alpha",
+            "$vector": [0.1, 0.9],
+        },
+    )
     delete_subdocument_response = (
-        await async_disposable_vector_collection.delete_subdocument(
-            id="1",
+        await async_writable_v_collection.delete_subdocument(
+            id=_id,
             subdoc="otherfield.subfield",
         )
     )
@@ -729,16 +729,16 @@ async def test_delete_subdocument_novector(
     assert delete_subdocument_response["status"]["matchedCount"] >= 1
     assert delete_subdocument_response["status"]["modifiedCount"] == 1
 
-    response = await async_disposable_vector_collection.find_one(filter={"_id": "1"})
+    response = await async_writable_v_collection.find_one(filter={"_id": _id})
     assert response["data"]["document"]["otherfield"] == {}
 
 
-@pytest.mark.describe("find_one_and_update, through vector")
+@pytest.mark.describe("find_one_and_update, through vector (async)")
 async def test_find_one_and_update_vector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response0 = await async_writable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     sort = {"$vector": [0.2, 0.6]}
@@ -746,7 +746,7 @@ async def test_find_one_and_update_vector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = await async_disposable_vector_collection.find_one_and_update(
+    update_response0 = await async_writable_v_collection.find_one_and_update(
         sort=sort, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -754,14 +754,14 @@ async def test_find_one_and_update_vector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response1 = await async_writable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = await async_disposable_vector_collection.find_one_and_update(
+    update_response1 = await async_writable_v_collection.find_one_and_update(
         sort=sort, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -769,7 +769,7 @@ async def test_find_one_and_update_vector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response2 = await async_writable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -777,7 +777,7 @@ async def test_find_one_and_update_vector(
     update2 = update1
     options2 = options1
 
-    update_response2 = await async_disposable_vector_collection.find_one_and_update(
+    update_response2 = await async_writable_v_collection.find_one_and_update(
         sort=sort, update=update2, options=options2, filter=filter2
     )
     assert update_response2["data"]["document"] is None
@@ -785,12 +785,12 @@ async def test_find_one_and_update_vector(
     assert update_response2["status"]["modifiedCount"] == 0
 
 
-@pytest.mark.describe("find_one_and_update, not through vector")
+@pytest.mark.describe("find_one_and_update, not through vector (async)")
 async def test_find_one_and_update_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response0 = await async_writable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     update_filter = {"anotherfield": "omega"}
@@ -798,7 +798,7 @@ async def test_find_one_and_update_novector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = await async_disposable_vector_collection.find_one_and_update(
+    update_response0 = await async_writable_v_collection.find_one_and_update(
         filter=update_filter, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -806,14 +806,14 @@ async def test_find_one_and_update_novector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response1 = await async_writable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = await async_disposable_vector_collection.find_one_and_update(
+    update_response1 = await async_writable_v_collection.find_one_and_update(
         filter=update_filter, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -821,7 +821,7 @@ async def test_find_one_and_update_novector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = await async_disposable_vector_collection.find_one(filter=find_filter)
+    response2 = await async_writable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -829,7 +829,7 @@ async def test_find_one_and_update_novector(
     update2 = update1
     options2 = options1
 
-    update_response2 = await async_disposable_vector_collection.find_one_and_update(
+    update_response2 = await async_writable_v_collection.find_one_and_update(
         filter=filter2, update=update2, options=options2
     )
     assert update_response2["data"]["document"] is None
@@ -837,19 +837,19 @@ async def test_find_one_and_update_novector(
     assert update_response2["status"]["modifiedCount"] == 0
 
 
-@pytest.mark.describe("find_one_and_replace, through vector")
+@pytest.mark.describe("find_one_and_replace, through vector (async)")
 async def test_find_one_and_replace_vector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
 
-    response0 = await async_disposable_vector_collection.find_one(sort=sort)
+    response0 = await async_writable_v_collection.find_one(sort=sort)
     assert response0 is not None
     assert "anotherfield" in response0["data"]["document"]
 
     doc0vector = response0["data"]["document"]["$vector"]
 
-    replace_response0 = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response0 = await async_writable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phyla": ["Echinodermata", "Platelminta", "Chordata"],
@@ -859,7 +859,7 @@ async def test_find_one_and_replace_vector(
     assert replace_response0 is not None
     assert "anotherfield" in replace_response0["data"]["document"]
 
-    response1 = await async_disposable_vector_collection.find_one(sort=sort)
+    response1 = await async_writable_v_collection.find_one(sort=sort)
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -868,7 +868,7 @@ async def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response1 = await async_writable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phone": "0123-4567",
@@ -883,14 +883,14 @@ async def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = await async_disposable_vector_collection.find_one(sort=sort)
+    response2 = await async_writable_v_collection.find_one(sort=sort)
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
     filter_no = {"nonexisting_field": -123}
-    replace_response_no = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response_no = await async_writable_v_collection.find_one_and_replace(
         sort=sort,
         filter=filter_no,
         replacement={
@@ -902,15 +902,15 @@ async def test_find_one_and_replace_vector(
     assert replace_response_no["data"]["document"] is None
 
 
-@pytest.mark.describe("find_one_and_replace, not through vector")
+@pytest.mark.describe("find_one_and_replace, not through vector (async)")
 async def test_find_one_and_replace_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    response0 = await async_disposable_vector_collection.find_one(filter={"_id": "1"})
+    response0 = await async_writable_v_collection.find_one(filter={"_id": "1"})
     assert response0 is not None
     assert response0["data"]["document"]["anotherfield"] == "alpha"
 
-    replace_response0 = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response0 = await async_writable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "_id": "1",
@@ -920,7 +920,7 @@ async def test_find_one_and_replace_novector(
     assert replace_response0 is not None
     assert replace_response0["data"]["document"]["anotherfield"] == "alpha"
 
-    response1 = await async_disposable_vector_collection.find_one(filter={"_id": "1"})
+    response1 = await async_writable_v_collection.find_one(filter={"_id": "1"})
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -929,7 +929,7 @@ async def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response1 = await async_writable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "phone": "0123-4567",
@@ -943,13 +943,13 @@ async def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = await async_disposable_vector_collection.find_one(filter={"_id": "1"})
+    response2 = await async_writable_v_collection.find_one(filter={"_id": "1"})
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
-    replace_response_no = await async_disposable_vector_collection.find_one_and_replace(
+    replace_response_no = await async_writable_v_collection.find_one_and_replace(
         filter={"_id": "z"},
         replacement={
             "whatever": -123,
@@ -959,46 +959,46 @@ async def test_find_one_and_replace_novector(
     assert replace_response_no["data"]["document"] is None
 
 
-@pytest.mark.describe("delete_one, not through vector")
+@pytest.mark.describe("delete_one, not through vector (async)")
 async def test_delete_one_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    delete_response = await async_disposable_vector_collection.delete_one(id="3")
+    delete_response = await async_writable_v_collection.delete_one(id="3")
     assert delete_response["status"]["deletedCount"] == 1
 
-    response = await async_disposable_vector_collection.find_one(filter={"_id": "3"})
+    response = await async_writable_v_collection.find_one(filter={"_id": "3"})
     assert response["data"]["document"] is None
 
-    delete_response_no = await async_disposable_vector_collection.delete_one(id="3")
+    delete_response_no = await async_writable_v_collection.delete_one(id="3")
     assert delete_response_no["status"]["deletedCount"] == 0
 
 
-@pytest.mark.describe("delete_many, not through vector")
+@pytest.mark.describe("delete_many, not through vector (async)")
 async def test_delete_many_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_writable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    delete_response = await async_disposable_vector_collection.delete_many(
+    delete_response = await async_writable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response["status"]["deletedCount"] == 2
 
-    documents_no = await async_disposable_vector_collection.find(
+    documents_no = await async_writable_v_collection.find(
         filter={"anotherfield": "alpha"}
     )
     assert documents_no["data"]["documents"] == []
 
-    delete_response_no = await async_disposable_vector_collection.delete_many(
+    delete_response_no = await async_writable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response_no["status"]["deletedCount"] == 0
 
 
-@pytest.mark.describe("pop, push functions, not through vector")
+@pytest.mark.describe("pop, push functions, not through vector (async)")
 async def test_pop_push_novector(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_empty_v_collection: AsyncAstraDBCollection,
 ) -> None:
     user_id = str(uuid.uuid4())
-    await async_disposable_vector_collection.insert_one(
+    await async_empty_v_collection.insert_one(
         document={
             "_id": user_id,
             "first_name": "Cliff",
@@ -1010,7 +1010,7 @@ async def test_pop_push_novector(
     pop = {"roles": 1}
     options = {"returnDocument": "after"}
 
-    pop_response = await async_disposable_vector_collection.pop(
+    pop_response = await async_empty_v_collection.pop(
         filter={"_id": user_id}, pop=pop, options=options
     )
     assert pop_response is not None
@@ -1018,7 +1018,7 @@ async def test_pop_push_novector(
     assert pop_response["status"]["matchedCount"] >= 1
     assert pop_response["status"]["modifiedCount"] == 1
 
-    response1 = await async_disposable_vector_collection.find_one(
+    response1 = await async_empty_v_collection.find_one(
         filter={"_id": user_id}
     )
     assert response1 is not None
@@ -1026,7 +1026,7 @@ async def test_pop_push_novector(
 
     push = {"roles": "auditor"}
 
-    push_response = await async_disposable_vector_collection.push(
+    push_response = await async_empty_v_collection.push(
         filter={"_id": user_id}, push=push, options=options
     )
     assert push_response is not None
@@ -1034,7 +1034,7 @@ async def test_pop_push_novector(
     assert push_response["status"]["matchedCount"] >= 1
     assert push_response["status"]["modifiedCount"] == 1
 
-    response2 = await async_disposable_vector_collection.find_one(
+    response2 = await async_empty_v_collection.find_one(
         filter={"_id": user_id}
     )
     assert response2 is not None

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -25,7 +25,7 @@ import pytest
 
 from astrapy.api import APIRequestError
 from astrapy.types import API_DOC
-from astrapy.db import AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
+from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
 
 
 logger = logging.getLogger(__name__)

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -25,7 +25,7 @@ import pytest
 
 from astrapy.api import APIRequestError
 from astrapy.types import API_DOC
-from astrapy.db import AsyncAstraDB, AsyncAstraDBCollection
+from astrapy.db import AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,7 @@ async def test_truncate_collection_fail(async_db: AsyncAstraDB) -> None:
 async def test_truncate_nonvector_collection_through_astradb(
     async_db: AsyncAstraDB,
     async_empty_nonv_collection: AsyncAstraDBCollection,
+    empty_nonv_collection: AstraDBCollection,
 ) -> None:
     await async_empty_nonv_collection.insert_one({"a": 1})
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 1
@@ -56,7 +57,9 @@ async def test_truncate_nonvector_collection_through_astradb(
 
 @pytest.mark.describe("should truncate a collection through AstraDB (async)")
 async def test_truncate_vector_collection_through_astradb(
-    async_db: AsyncAstraDB, async_empty_v_collection: AsyncAstraDBCollection
+    async_db: AsyncAstraDB,
+    async_empty_v_collection: AsyncAstraDBCollection,
+    empty_v_collection: AstraDBCollection,
 ) -> None:
     await async_empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 1
@@ -93,6 +96,7 @@ async def test_truncate_vector_collection(
 @pytest.mark.describe("find_one, not through vector (async)")
 async def test_find_one_filter_novector(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     response = await async_readonly_v_collection.find_one(
         filter={"_id": "1"},
@@ -131,6 +135,7 @@ async def test_find_one_filter_novector(
 @pytest.mark.describe("find, not through vector (async)")
 async def test_find_filter_novector(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     response_n2 = await async_readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
@@ -152,6 +157,7 @@ async def test_find_filter_novector(
 @pytest.mark.describe("obey projection in find and find_one (async)")
 async def test_find_find_one_projection(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
     sort = {"$vector": query}
@@ -186,7 +192,10 @@ async def test_find_find_one_projection(
 
 
 @pytest.mark.describe("find through vector (async)")
-async def test_find(async_readonly_v_collection: AsyncAstraDBCollection) -> None:
+async def test_find(
+    async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
+) -> None:
     sort = {"$vector": [0.2, 0.6]}
     options = {"limit": 100}
 
@@ -197,6 +206,7 @@ async def test_find(async_readonly_v_collection: AsyncAstraDBCollection) -> None
 @pytest.mark.describe("proper error raising in find (async)")
 async def test_find_error(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
     sort = {"$vector": "clearly not a list of floats!"}
@@ -209,6 +219,7 @@ async def test_find_error(
 @pytest.mark.describe("find through vector, without explicit limit (async)")
 async def test_find_limitless(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
     projection = {"$vector": 1}
@@ -221,6 +232,7 @@ async def test_find_limitless(
 @pytest.mark.describe("correctly count documents according to predicate (async)")
 async def test_count_documents(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     c_all_response0 = await async_readonly_v_collection.count_documents()
     assert c_all_response0["status"]["count"] == 3
@@ -242,6 +254,7 @@ async def test_count_documents(
 @pytest.mark.describe("insert_one, w/out _id, w/out vector (async)")
 async def test_create_document(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     i_vector = [0.3, 0.5]
     id_v_i = str(uuid.uuid4())
@@ -314,6 +327,7 @@ async def test_create_document(
 @pytest.mark.describe("insert_many (async)")
 async def test_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id2 = str(uuid.uuid4())
@@ -346,6 +360,7 @@ async def test_insert_many(
 @pytest.mark.describe("chunked_insert_many (async)")
 async def test_chunked_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -429,6 +444,7 @@ async def test_chunked_insert_many(
 @pytest.mark.describe("chunked_insert_many concurrently (async)")
 async def test_concurrent_chunked_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -520,6 +536,7 @@ async def test_concurrent_chunked_insert_many(
 @pytest.mark.describe("insert_many with 'ordered' set to True (async)")
 async def test_insert_many_ordered_true(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id1 = str(uuid.uuid4())
@@ -581,6 +598,7 @@ async def test_insert_many_ordered_true(
 @pytest.mark.describe("upsert_many (async)")
 async def test_upsert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(12)]
     documents0 = [
@@ -634,6 +652,7 @@ async def test_upsert_many(
 @pytest.mark.describe("upsert (async)")
 async def test_upsert_document(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
 
@@ -677,6 +696,7 @@ async def test_upsert_document(
 @pytest.mark.describe("update_one to create a subdocument, not through vector (async)")
 async def test_update_one_create_subdocument_novector(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
     await async_writable_v_collection.insert_one({"_id": _id, "name": "Not Eric!"})
@@ -695,6 +715,7 @@ async def test_update_one_create_subdocument_novector(
 @pytest.mark.describe("delete_subdocument, not through vector (async)")
 async def test_delete_subdocument_novector(
     async_writable_v_collection: AsyncAstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
     await async_writable_v_collection.insert_one(
@@ -773,6 +794,7 @@ async def test_find_one_and_update_vector(
 @pytest.mark.describe("find_one_and_update, not through vector (async)")
 async def test_find_one_and_update_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
     response0 = await async_disposable_v_collection.find_one(filter=find_filter)
@@ -825,6 +847,7 @@ async def test_find_one_and_update_novector(
 @pytest.mark.describe("find_one_and_replace, through vector (async)")
 async def test_find_one_and_replace_vector(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
 
@@ -890,6 +913,7 @@ async def test_find_one_and_replace_vector(
 @pytest.mark.describe("find_one_and_replace, not through vector (async)")
 async def test_find_one_and_replace_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     response0 = await async_disposable_v_collection.find_one(filter={"_id": "1"})
     assert response0 is not None
@@ -947,6 +971,7 @@ async def test_find_one_and_replace_novector(
 @pytest.mark.describe("delete_one, not through vector (async)")
 async def test_delete_one_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     delete_response = await async_disposable_v_collection.delete_one(id="3")
     assert delete_response["status"]["deletedCount"] == 1
@@ -961,6 +986,7 @@ async def test_delete_one_novector(
 @pytest.mark.describe("delete_many, not through vector (async)")
 async def test_delete_many_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     delete_response = await async_disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
@@ -981,6 +1007,7 @@ async def test_delete_many_novector(
 @pytest.mark.describe("pop, push functions, not through vector (async)")
 async def test_pop_push_novector(
     async_empty_v_collection: AsyncAstraDBCollection,
+    empty_v_collection: AstraDBCollection,
 ) -> None:
     user_id = str(uuid.uuid4())
     await async_empty_v_collection.insert_one(

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -720,10 +720,10 @@ async def test_delete_subdocument_novector(
 
 @pytest.mark.describe("find_one_and_update, through vector (async)")
 async def test_find_one_and_update_vector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = await async_writable_v_collection.find_one(filter=find_filter)
+    response0 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     sort = {"$vector": [0.2, 0.6]}
@@ -731,7 +731,7 @@ async def test_find_one_and_update_vector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = await async_writable_v_collection.find_one_and_update(
+    update_response0 = await async_disposable_v_collection.find_one_and_update(
         sort=sort, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -739,14 +739,14 @@ async def test_find_one_and_update_vector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = await async_writable_v_collection.find_one(filter=find_filter)
+    response1 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = await async_writable_v_collection.find_one_and_update(
+    update_response1 = await async_disposable_v_collection.find_one_and_update(
         sort=sort, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -754,7 +754,7 @@ async def test_find_one_and_update_vector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = await async_writable_v_collection.find_one(filter=find_filter)
+    response2 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -762,7 +762,7 @@ async def test_find_one_and_update_vector(
     update2 = update1
     options2 = options1
 
-    update_response2 = await async_writable_v_collection.find_one_and_update(
+    update_response2 = await async_disposable_v_collection.find_one_and_update(
         sort=sort, update=update2, options=options2, filter=filter2
     )
     assert update_response2["data"]["document"] is None
@@ -772,10 +772,10 @@ async def test_find_one_and_update_vector(
 
 @pytest.mark.describe("find_one_and_update, not through vector (async)")
 async def test_find_one_and_update_novector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = await async_writable_v_collection.find_one(filter=find_filter)
+    response0 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     update_filter = {"anotherfield": "omega"}
@@ -783,7 +783,7 @@ async def test_find_one_and_update_novector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = await async_writable_v_collection.find_one_and_update(
+    update_response0 = await async_disposable_v_collection.find_one_and_update(
         filter=update_filter, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -791,14 +791,14 @@ async def test_find_one_and_update_novector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = await async_writable_v_collection.find_one(filter=find_filter)
+    response1 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = await async_writable_v_collection.find_one_and_update(
+    update_response1 = await async_disposable_v_collection.find_one_and_update(
         filter=update_filter, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -806,7 +806,7 @@ async def test_find_one_and_update_novector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = await async_writable_v_collection.find_one(filter=find_filter)
+    response2 = await async_disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -814,7 +814,7 @@ async def test_find_one_and_update_novector(
     update2 = update1
     options2 = options1
 
-    update_response2 = await async_writable_v_collection.find_one_and_update(
+    update_response2 = await async_disposable_v_collection.find_one_and_update(
         filter=filter2, update=update2, options=options2
     )
     assert update_response2["data"]["document"] is None
@@ -824,17 +824,17 @@ async def test_find_one_and_update_novector(
 
 @pytest.mark.describe("find_one_and_replace, through vector (async)")
 async def test_find_one_and_replace_vector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
 
-    response0 = await async_writable_v_collection.find_one(sort=sort)
+    response0 = await async_disposable_v_collection.find_one(sort=sort)
     assert response0 is not None
     assert "anotherfield" in response0["data"]["document"]
 
     doc0vector = response0["data"]["document"]["$vector"]
 
-    replace_response0 = await async_writable_v_collection.find_one_and_replace(
+    replace_response0 = await async_disposable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phyla": ["Echinodermata", "Platelminta", "Chordata"],
@@ -844,7 +844,7 @@ async def test_find_one_and_replace_vector(
     assert replace_response0 is not None
     assert "anotherfield" in replace_response0["data"]["document"]
 
-    response1 = await async_writable_v_collection.find_one(sort=sort)
+    response1 = await async_disposable_v_collection.find_one(sort=sort)
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -853,7 +853,7 @@ async def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = await async_writable_v_collection.find_one_and_replace(
+    replace_response1 = await async_disposable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phone": "0123-4567",
@@ -868,14 +868,14 @@ async def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = await async_writable_v_collection.find_one(sort=sort)
+    response2 = await async_disposable_v_collection.find_one(sort=sort)
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
     filter_no = {"nonexisting_field": -123}
-    replace_response_no = await async_writable_v_collection.find_one_and_replace(
+    replace_response_no = await async_disposable_v_collection.find_one_and_replace(
         sort=sort,
         filter=filter_no,
         replacement={
@@ -889,13 +889,13 @@ async def test_find_one_and_replace_vector(
 
 @pytest.mark.describe("find_one_and_replace, not through vector (async)")
 async def test_find_one_and_replace_novector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    response0 = await async_writable_v_collection.find_one(filter={"_id": "1"})
+    response0 = await async_disposable_v_collection.find_one(filter={"_id": "1"})
     assert response0 is not None
     assert response0["data"]["document"]["anotherfield"] == "alpha"
 
-    replace_response0 = await async_writable_v_collection.find_one_and_replace(
+    replace_response0 = await async_disposable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "_id": "1",
@@ -905,7 +905,7 @@ async def test_find_one_and_replace_novector(
     assert replace_response0 is not None
     assert replace_response0["data"]["document"]["anotherfield"] == "alpha"
 
-    response1 = await async_writable_v_collection.find_one(filter={"_id": "1"})
+    response1 = await async_disposable_v_collection.find_one(filter={"_id": "1"})
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -914,7 +914,7 @@ async def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = await async_writable_v_collection.find_one_and_replace(
+    replace_response1 = await async_disposable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "phone": "0123-4567",
@@ -928,13 +928,13 @@ async def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = await async_writable_v_collection.find_one(filter={"_id": "1"})
+    response2 = await async_disposable_v_collection.find_one(filter={"_id": "1"})
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
-    replace_response_no = await async_writable_v_collection.find_one_and_replace(
+    replace_response_no = await async_disposable_v_collection.find_one_and_replace(
         filter={"_id": "z"},
         replacement={
             "whatever": -123,
@@ -946,33 +946,33 @@ async def test_find_one_and_replace_novector(
 
 @pytest.mark.describe("delete_one, not through vector (async)")
 async def test_delete_one_novector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    delete_response = await async_writable_v_collection.delete_one(id="3")
+    delete_response = await async_disposable_v_collection.delete_one(id="3")
     assert delete_response["status"]["deletedCount"] == 1
 
-    response = await async_writable_v_collection.find_one(filter={"_id": "3"})
+    response = await async_disposable_v_collection.find_one(filter={"_id": "3"})
     assert response["data"]["document"] is None
 
-    delete_response_no = await async_writable_v_collection.delete_one(id="3")
+    delete_response_no = await async_disposable_v_collection.delete_one(id="3")
     assert delete_response_no["status"]["deletedCount"] == 0
 
 
 @pytest.mark.describe("delete_many, not through vector (async)")
 async def test_delete_many_novector(
-    async_writable_v_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    delete_response = await async_writable_v_collection.delete_many(
+    delete_response = await async_disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response["status"]["deletedCount"] == 2
 
-    documents_no = await async_writable_v_collection.find(
+    documents_no = await async_disposable_v_collection.find(
         filter={"anotherfield": "alpha"}
     )
     assert documents_no["data"]["documents"] == []
 
-    delete_response_no = await async_writable_v_collection.delete_many(
+    delete_response_no = await async_disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response_no["status"]["deletedCount"] == 0

--- a/tests/astrapy/test_async_db_dml.py
+++ b/tests/astrapy/test_async_db_dml.py
@@ -41,7 +41,6 @@ async def test_truncate_collection_fail(async_db: AsyncAstraDB) -> None:
 async def test_truncate_nonvector_collection_through_astradb(
     async_db: AsyncAstraDB,
     async_empty_nonv_collection: AsyncAstraDBCollection,
-    empty_nonv_collection: AstraDBCollection,
 ) -> None:
     await async_empty_nonv_collection.insert_one({"a": 1})
     assert len((await async_empty_nonv_collection.find())["data"]["documents"]) == 1
@@ -59,7 +58,6 @@ async def test_truncate_nonvector_collection_through_astradb(
 async def test_truncate_vector_collection_through_astradb(
     async_db: AsyncAstraDB,
     async_empty_v_collection: AsyncAstraDBCollection,
-    empty_v_collection: AstraDBCollection,
 ) -> None:
     await async_empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len((await async_empty_v_collection.find())["data"]["documents"]) == 1
@@ -96,7 +94,6 @@ async def test_truncate_vector_collection(
 @pytest.mark.describe("find_one, not through vector (async)")
 async def test_find_one_filter_novector(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     response = await async_readonly_v_collection.find_one(
         filter={"_id": "1"},
@@ -135,7 +132,6 @@ async def test_find_one_filter_novector(
 @pytest.mark.describe("find, not through vector (async)")
 async def test_find_filter_novector(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     response_n2 = await async_readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
@@ -157,7 +153,6 @@ async def test_find_filter_novector(
 @pytest.mark.describe("obey projection in find and find_one (async)")
 async def test_find_find_one_projection(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
     sort = {"$vector": query}
@@ -194,7 +189,6 @@ async def test_find_find_one_projection(
 @pytest.mark.describe("find through vector (async)")
 async def test_find(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
     options = {"limit": 100}
@@ -206,7 +200,6 @@ async def test_find(
 @pytest.mark.describe("proper error raising in find (async)")
 async def test_find_error(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
     sort = {"$vector": "clearly not a list of floats!"}
@@ -219,7 +212,6 @@ async def test_find_error(
 @pytest.mark.describe("find through vector, without explicit limit (async)")
 async def test_find_limitless(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
     projection = {"$vector": 1}
@@ -232,7 +224,6 @@ async def test_find_limitless(
 @pytest.mark.describe("correctly count documents according to predicate (async)")
 async def test_count_documents(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     c_all_response0 = await async_readonly_v_collection.count_documents()
     assert c_all_response0["status"]["count"] == 3
@@ -254,7 +245,6 @@ async def test_count_documents(
 @pytest.mark.describe("insert_one, w/out _id, w/out vector (async)")
 async def test_create_document(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     i_vector = [0.3, 0.5]
     id_v_i = str(uuid.uuid4())
@@ -327,7 +317,6 @@ async def test_create_document(
 @pytest.mark.describe("insert_many (async)")
 async def test_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id2 = str(uuid.uuid4())
@@ -360,7 +349,6 @@ async def test_insert_many(
 @pytest.mark.describe("chunked_insert_many (async)")
 async def test_chunked_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -444,7 +432,6 @@ async def test_chunked_insert_many(
 @pytest.mark.describe("chunked_insert_many concurrently (async)")
 async def test_concurrent_chunked_insert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -536,7 +523,6 @@ async def test_concurrent_chunked_insert_many(
 @pytest.mark.describe("insert_many with 'ordered' set to True (async)")
 async def test_insert_many_ordered_true(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id1 = str(uuid.uuid4())
@@ -598,7 +584,6 @@ async def test_insert_many_ordered_true(
 @pytest.mark.describe("upsert_many (async)")
 async def test_upsert_many(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(12)]
     documents0 = [
@@ -652,7 +637,6 @@ async def test_upsert_many(
 @pytest.mark.describe("upsert (async)")
 async def test_upsert_document(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
 
@@ -696,7 +680,6 @@ async def test_upsert_document(
 @pytest.mark.describe("update_one to create a subdocument, not through vector (async)")
 async def test_update_one_create_subdocument_novector(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
     await async_writable_v_collection.insert_one({"_id": _id, "name": "Not Eric!"})
@@ -715,7 +698,6 @@ async def test_update_one_create_subdocument_novector(
 @pytest.mark.describe("delete_subdocument, not through vector (async)")
 async def test_delete_subdocument_novector(
     async_writable_v_collection: AsyncAstraDBCollection,
-    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id = str(uuid.uuid4())
     await async_writable_v_collection.insert_one(
@@ -794,7 +776,6 @@ async def test_find_one_and_update_vector(
 @pytest.mark.describe("find_one_and_update, not through vector (async)")
 async def test_find_one_and_update_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
     response0 = await async_disposable_v_collection.find_one(filter=find_filter)
@@ -847,7 +828,6 @@ async def test_find_one_and_update_novector(
 @pytest.mark.describe("find_one_and_replace, through vector (async)")
 async def test_find_one_and_replace_vector(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
 
@@ -913,7 +893,6 @@ async def test_find_one_and_replace_vector(
 @pytest.mark.describe("find_one_and_replace, not through vector (async)")
 async def test_find_one_and_replace_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     response0 = await async_disposable_v_collection.find_one(filter={"_id": "1"})
     assert response0 is not None
@@ -971,7 +950,6 @@ async def test_find_one_and_replace_novector(
 @pytest.mark.describe("delete_one, not through vector (async)")
 async def test_delete_one_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     delete_response = await async_disposable_v_collection.delete_one(id="3")
     assert delete_response["status"]["deletedCount"] == 1
@@ -986,7 +964,6 @@ async def test_delete_one_novector(
 @pytest.mark.describe("delete_many, not through vector (async)")
 async def test_delete_many_novector(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     delete_response = await async_disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
@@ -1007,7 +984,6 @@ async def test_delete_many_novector(
 @pytest.mark.describe("pop, push functions, not through vector (async)")
 async def test_pop_push_novector(
     async_empty_v_collection: AsyncAstraDBCollection,
-    empty_v_collection: AstraDBCollection,
 ) -> None:
     user_id = str(uuid.uuid4())
     await async_empty_v_collection.insert_one(

--- a/tests/astrapy/test_async_db_dml_pagination.py
+++ b/tests/astrapy/test_async_db_dml_pagination.py
@@ -20,7 +20,7 @@ import logging
 from typing import Optional
 import pytest
 
-from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
+from astrapy.db import AsyncAstraDBCollection
 
 logger = logging.getLogger(__name__)
 

--- a/tests/astrapy/test_async_db_dml_pagination.py
+++ b/tests/astrapy/test_async_db_dml_pagination.py
@@ -42,7 +42,6 @@ PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetch
 async def test_find_paginated(
     prefetched: Optional[int],
     async_pagination_v_collection: AsyncAstraDBCollection,
-    pagination_v_collection: AstraDBCollection,
 ) -> None:
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}

--- a/tests/astrapy/test_async_db_dml_pagination.py
+++ b/tests/astrapy/test_async_db_dml_pagination.py
@@ -20,7 +20,7 @@ import logging
 from typing import Optional
 import pytest
 
-from astrapy.db import AsyncAstraDBCollection
+from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,9 @@ PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetch
     ],
 )
 async def test_find_paginated(
-    prefetched: Optional[int], async_pagination_v_collection: AsyncAstraDBCollection
+    prefetched: Optional[int],
+    async_pagination_v_collection: AsyncAstraDBCollection,
+    pagination_v_collection: AstraDBCollection,
 ) -> None:
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}

--- a/tests/astrapy/test_async_db_dml_pagination.py
+++ b/tests/astrapy/test_async_db_dml_pagination.py
@@ -16,12 +16,11 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
-import os
 import logging
-from typing import Dict, Iterable, List, Optional, Set, AsyncIterable
+from typing import Optional
 import pytest
 
-from astrapy.db import AsyncAstraDBCollection, AsyncAstraDB
+from astrapy.db import AsyncAstraDBCollection
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetch
 
 
 @pytest.mark.describe(
-    "should retrieve the required amount of documents, all different, through pagination"
+    "should retrieve the required amount of documents, all different, through pagination (async)"
 )
 @pytest.mark.parametrize(
     "prefetched",
@@ -51,6 +50,6 @@ async def test_find_paginated(
     )
     paginated_documents = [doc async for doc in paginated_documents_agen]
     paginated_ids = [doc["_id"] for doc in paginated_documents]
-    assert all(["$vector" not in doc for doc in  paginated_documents])
+    assert all(["$vector" not in doc for doc in paginated_documents])
     assert len(paginated_ids) == FIND_LIMIT
     assert len(paginated_ids) == len(set(paginated_ids))

--- a/tests/astrapy/test_async_db_dml_pagination.py
+++ b/tests/astrapy/test_async_db_dml_pagination.py
@@ -16,10 +16,9 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
-import math
 import os
 import logging
-from typing import Dict, Iterable, List, Optional, Set, TypeVar, AsyncIterable
+from typing import Dict, Iterable, List, Optional, Set, AsyncIterable
 import pytest
 
 from astrapy.db import AsyncAstraDBCollection, AsyncAstraDB
@@ -27,58 +26,8 @@ from astrapy.db import AsyncAstraDBCollection, AsyncAstraDB
 logger = logging.getLogger(__name__)
 
 
-TEST_PAGINATION_COLLECTION_NAME = "pagination_v_col"
-INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
-N = 200  # must be EVEN
 FIND_LIMIT = 183  # Keep this > 20 and <= N to actually put pagination to test
 PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetching
-
-T = TypeVar("T")
-
-
-def _mk_vector(index: int, n_total_steps: int) -> List[float]:
-    angle = 2 * math.pi * index / n_total_steps
-    return [math.cos(angle), math.sin(angle)]
-
-
-def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable[T]]:
-    this_batch = []
-    for entry in iterable:
-        this_batch.append(entry)
-        if len(this_batch) == batch_size:
-            yield this_batch
-            this_batch = []
-    if this_batch:
-        yield this_batch
-
-
-@pytest.fixture
-async def pag_test_collection(
-    astra_db_credentials_kwargs: Dict[str, Optional[str]]
-) -> AsyncIterable[AsyncAstraDBCollection]:
-    async with AsyncAstraDB(**astra_db_credentials_kwargs) as astra_db:
-        astra_db_collection = await astra_db.create_collection(
-            collection_name=TEST_PAGINATION_COLLECTION_NAME, dimension=2
-        )
-
-        if int(os.getenv("TEST_PAGINATION_SKIP_INSERTION", "0")) == 0:
-            inserted_ids: Set[str] = set()
-            for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
-                batch_ids = (
-                    await astra_db_collection.insert_many(
-                        documents=[
-                            {"_id": str(i), "$vector": _mk_vector(i, N)}
-                            for i in i_batch
-                        ]
-                    )
-                )["status"]["insertedIds"]
-                inserted_ids = inserted_ids | set(batch_ids)
-            assert inserted_ids == {str(i) for i in range(N)}
-        yield astra_db_collection
-        if int(os.getenv("TEST_PAGINATION_SKIP_DELETE_COLLECTION", "0")) == 0:
-            _ = await astra_db.delete_collection(
-                collection_name=TEST_PAGINATION_COLLECTION_NAME
-            )
 
 
 @pytest.mark.describe(
@@ -92,14 +41,16 @@ async def pag_test_collection(
     ],
 )
 async def test_find_paginated(
-    prefetched: Optional[int], pag_test_collection: AsyncAstraDBCollection
+    prefetched: Optional[int], async_pagination_v_collection: AsyncAstraDBCollection
 ) -> None:
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}
 
-    paginated_documents = pag_test_collection.paginated_find(
+    paginated_documents_agen = async_pagination_v_collection.paginated_find(
         projection=projection, options=options, prefetched=prefetched
     )
-    paginated_ids = [doc["_id"] async for doc in paginated_documents]
+    paginated_documents = [doc async for doc in paginated_documents_agen]
+    paginated_ids = [doc["_id"] for doc in paginated_documents]
+    assert all(["$vector" not in doc for doc in  paginated_documents])
     assert len(paginated_ids) == FIND_LIMIT
     assert len(paginated_ids) == len(set(paginated_ids))

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 @pytest.mark.describe("vector_find and include_similarity parameter (async)")
 async def test_vector_find(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     documents_sim_1 = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
@@ -78,7 +77,6 @@ async def test_vector_find(
 @pytest.mark.describe("vector_find, obey projection (async)")
 async def test_vector_find_projection(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
 
@@ -114,7 +112,6 @@ async def test_vector_find_projection(
 @pytest.mark.describe("vector_find with filters (async)")
 async def test_vector_find_filters(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     documents = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
@@ -137,7 +134,6 @@ async def test_vector_find_filters(
 @pytest.mark.describe("vector_find_one and include_similarity parameter (async)")
 async def test_vector_find_one(
     async_readonly_v_collection: AsyncAstraDBCollection,
-    readonly_v_collection: AstraDBCollection,
 ) -> None:
     document0 = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
@@ -192,7 +188,6 @@ async def test_vector_find_one(
 @pytest.mark.describe("vector_find_one_and_update (async)")
 async def test_vector_find_one_and_update(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     update = {"$set": {"status": "active"}}
 
@@ -229,7 +224,6 @@ async def test_vector_find_one_and_update(
 @pytest.mark.describe("vector_find_one_and_replace (async)")
 async def test_vector_find_one_and_replace(
     async_disposable_v_collection: AsyncAstraDBCollection,
-    disposable_v_collection: AstraDBCollection,
 ) -> None:
     replacement0 = {
         "_id": "1",

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -197,11 +197,9 @@ async def test_vector_find_one_and_update(
     )
     assert document0 is None
 
-    update_response = (
-        await async_disposable_v_collection.vector_find_one_and_update(
-            vector=[0.1, 0.9],
-            update=update,
-        )
+    update_response = await async_disposable_v_collection.vector_find_one_and_update(
+        vector=[0.1, 0.9],
+        update=update,
     )
     assert update_response is not None
     assert update_response["_id"] == "1"
@@ -215,12 +213,10 @@ async def test_vector_find_one_and_update(
     assert document1["_id"] == update_response["_id"]
     assert document1["status"] == "active"
 
-    update_response_no = (
-        await async_disposable_v_collection.vector_find_one_and_update(
-            vector=[0.1, 0.9],
-            filter={"nonexisting": "gotcha"},
-            update=update,
-        )
+    update_response_no = await async_disposable_v_collection.vector_find_one_and_update(
+        vector=[0.1, 0.9],
+        filter={"nonexisting": "gotcha"},
+        update=update,
     )
     assert update_response_no is None
 
@@ -242,11 +238,9 @@ async def test_vector_find_one_and_replace(
     )
     assert document0 is None
 
-    replace_response0 = (
-        await async_disposable_v_collection.vector_find_one_and_replace(
-            vector=[0.1, 0.9],
-            replacement=replacement0,
-        )
+    replace_response0 = await async_disposable_v_collection.vector_find_one_and_replace(
+        vector=[0.1, 0.9],
+        replacement=replacement0,
     )
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"
@@ -270,11 +264,9 @@ async def test_vector_find_one_and_replace(
         "$vector": [0.101, 0.899],
     }
 
-    replace_response1 = (
-        await async_disposable_v_collection.vector_find_one_and_replace(
-            vector=[0.1, 0.9],
-            replacement=replacement1,
-        )
+    replace_response1 = await async_disposable_v_collection.vector_find_one_and_replace(
+        vector=[0.1, 0.9],
+        replacement=replacement1,
     )
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -27,11 +27,11 @@ from astrapy.types import API_DOC
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.describe("vector_find and include_similarity parameter")
+@pytest.mark.describe("vector_find and include_similarity parameter (async)")
 async def test_vector_find(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    documents_sim_1 = await async_readonly_vector_collection.vector_find(
+    documents_sim_1 = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
     )
@@ -44,7 +44,7 @@ async def test_vector_find(
     assert "text" in documents_sim_1[0]
     assert "$similarity" in documents_sim_1[0]
 
-    documents_sim_2 = await async_readonly_vector_collection.vector_find(
+    documents_sim_2 = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
         include_similarity=True,
@@ -58,7 +58,7 @@ async def test_vector_find(
     assert "text" in documents_sim_2[0]
     assert "$similarity" in documents_sim_2[0]
 
-    documents_no_sim = await async_readonly_vector_collection.vector_find(
+    documents_no_sim = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
         fields=["_id", "$vector"],
@@ -74,9 +74,9 @@ async def test_vector_find(
     assert "$similarity" not in documents_no_sim[0]
 
 
-@pytest.mark.describe("vector_find, obey projection")
+@pytest.mark.describe("vector_find, obey projection (async)")
 async def test_vector_find_projection(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
 
@@ -96,7 +96,7 @@ async def test_vector_find_projection(
     ]
     for include_similarity in [True, False]:
         for req_fields, exp_fields0 in zip(req_fieldsets, exp_fieldsets):
-            vdocs = await async_readonly_vector_collection.vector_find(
+            vdocs = await async_readonly_v_collection.vector_find(
                 query,
                 limit=1,
                 fields=list(req_fields) if req_fields is not None else req_fields,
@@ -109,11 +109,11 @@ async def test_vector_find_projection(
             assert set(vdocs[0].keys()) == exp_fields
 
 
-@pytest.mark.describe("vector_find with filters")
+@pytest.mark.describe("vector_find with filters (async)")
 async def test_vector_find_filters(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    documents = await async_readonly_vector_collection.vector_find(
+    documents = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         filter={"anotherfield": "alpha"},
         limit=3,
@@ -122,7 +122,7 @@ async def test_vector_find_filters(
     assert len(documents) == 2
     assert {doc["otherfield"]["subfield"] for doc in documents} == {"x1y", "x2y"}
 
-    documents_no = await async_readonly_vector_collection.vector_find(
+    documents_no = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         filter={"anotherfield": "epsilon"},
         limit=3,
@@ -131,11 +131,11 @@ async def test_vector_find_filters(
     assert len(documents_no) == 0
 
 
-@pytest.mark.describe("vector_find_one and include_similarity parameter")
+@pytest.mark.describe("vector_find_one and include_similarity parameter (async)")
 async def test_vector_find_one(
-    async_readonly_vector_collection: AsyncAstraDBCollection,
+    async_readonly_v_collection: AsyncAstraDBCollection,
 ) -> None:
-    document0 = await async_readonly_vector_collection.vector_find_one(
+    document0 = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
     )
 
@@ -145,7 +145,7 @@ async def test_vector_find_one(
     assert "text" in document0
     assert "$similarity" in document0
 
-    document_w_sim = await async_readonly_vector_collection.vector_find_one(
+    document_w_sim = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         include_similarity=True,
     )
@@ -156,7 +156,7 @@ async def test_vector_find_one(
     assert "text" in document_w_sim
     assert "$similarity" in document_w_sim
 
-    document_no_sim = await async_readonly_vector_collection.vector_find_one(
+    document_no_sim = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         include_similarity=False,
     )
@@ -167,7 +167,7 @@ async def test_vector_find_one(
     assert "text" in document_no_sim
     assert "$similarity" not in document_no_sim
 
-    document_w_fields = await async_readonly_vector_collection.vector_find_one(
+    document_w_fields = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6], fields=["text"]
     )
 
@@ -177,7 +177,7 @@ async def test_vector_find_one(
     assert "text" in document_w_fields
     assert "$similarity" in document_w_fields
 
-    document_no = await async_readonly_vector_collection.vector_find_one(
+    document_no = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         filter={"nonexisting": "gotcha"},
     )
@@ -185,20 +185,20 @@ async def test_vector_find_one(
     assert document_no is None
 
 
-@pytest.mark.describe("vector_find_one_and_update")
+@pytest.mark.describe("vector_find_one_and_update (async)")
 async def test_vector_find_one_and_update(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     update = {"$set": {"status": "active"}}
 
-    document0 = await async_disposable_vector_collection.vector_find_one(
+    document0 = await async_disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"status": "active"},
     )
     assert document0 is None
 
     update_response = (
-        await async_disposable_vector_collection.vector_find_one_and_update(
+        await async_disposable_v_collection.vector_find_one_and_update(
             vector=[0.1, 0.9],
             update=update,
         )
@@ -206,7 +206,7 @@ async def test_vector_find_one_and_update(
     assert update_response is not None
     assert update_response["_id"] == "1"
 
-    document1 = await async_disposable_vector_collection.vector_find_one(
+    document1 = await async_disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"status": "active"},
     )
@@ -216,7 +216,7 @@ async def test_vector_find_one_and_update(
     assert document1["status"] == "active"
 
     update_response_no = (
-        await async_disposable_vector_collection.vector_find_one_and_update(
+        await async_disposable_v_collection.vector_find_one_and_update(
             vector=[0.1, 0.9],
             filter={"nonexisting": "gotcha"},
             update=update,
@@ -225,9 +225,9 @@ async def test_vector_find_one_and_update(
     assert update_response_no is None
 
 
-@pytest.mark.describe("vector_find_one_and_replace")
+@pytest.mark.describe("vector_find_one_and_replace (async)")
 async def test_vector_find_one_and_replace(
-    async_disposable_vector_collection: AsyncAstraDBCollection,
+    async_disposable_v_collection: AsyncAstraDBCollection,
 ) -> None:
     replacement0 = {
         "_id": "1",
@@ -236,14 +236,14 @@ async def test_vector_find_one_and_replace(
         "$vector": [0.101, 0.899],
     }
 
-    document0 = await async_disposable_vector_collection.vector_find_one(
+    document0 = await async_disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"added_field": True},
     )
     assert document0 is None
 
     replace_response0 = (
-        await async_disposable_vector_collection.vector_find_one_and_replace(
+        await async_disposable_v_collection.vector_find_one_and_replace(
             vector=[0.1, 0.9],
             replacement=replacement0,
         )
@@ -251,7 +251,7 @@ async def test_vector_find_one_and_replace(
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"
 
-    document1 = await async_disposable_vector_collection.vector_find_one(
+    document1 = await async_disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"added_field": True},
     )
@@ -271,7 +271,7 @@ async def test_vector_find_one_and_replace(
     }
 
     replace_response1 = (
-        await async_disposable_vector_collection.vector_find_one_and_replace(
+        await async_disposable_v_collection.vector_find_one_and_replace(
             vector=[0.1, 0.9],
             replacement=replacement1,
         )
@@ -279,7 +279,7 @@ async def test_vector_find_one_and_replace(
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"
 
-    document2 = await async_disposable_vector_collection.vector_find_one(
+    document2 = await async_disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"different_added_field": False},
     )
@@ -291,7 +291,7 @@ async def test_vector_find_one_and_replace(
     assert cast(API_DOC, document2)["different_added_field"] is False
 
     replace_response_no = (
-        await async_disposable_vector_collection.vector_find_one_and_replace(
+        await async_disposable_v_collection.vector_find_one_and_replace(
             vector=[0.1, 0.9],
             filter={"nonexisting": "gotcha"},
             replacement=replacement1,

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -21,7 +21,7 @@ from typing import cast
 
 import pytest
 
-from astrapy.db import AsyncAstraDBCollection
+from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
 from astrapy.types import API_DOC
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.describe("vector_find and include_similarity parameter (async)")
 async def test_vector_find(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     documents_sim_1 = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
@@ -77,6 +78,7 @@ async def test_vector_find(
 @pytest.mark.describe("vector_find, obey projection (async)")
 async def test_vector_find_projection(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
 
@@ -112,6 +114,7 @@ async def test_vector_find_projection(
 @pytest.mark.describe("vector_find with filters (async)")
 async def test_vector_find_filters(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     documents = await async_readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
@@ -134,6 +137,7 @@ async def test_vector_find_filters(
 @pytest.mark.describe("vector_find_one and include_similarity parameter (async)")
 async def test_vector_find_one(
     async_readonly_v_collection: AsyncAstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     document0 = await async_readonly_v_collection.vector_find_one(
         [0.2, 0.6],
@@ -188,6 +192,7 @@ async def test_vector_find_one(
 @pytest.mark.describe("vector_find_one_and_update (async)")
 async def test_vector_find_one_and_update(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     update = {"$set": {"status": "active"}}
 
@@ -224,6 +229,7 @@ async def test_vector_find_one_and_update(
 @pytest.mark.describe("vector_find_one_and_replace (async)")
 async def test_vector_find_one_and_replace(
     async_disposable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     replacement0 = {
         "_id": "1",

--- a/tests/astrapy/test_async_db_dml_vector.py
+++ b/tests/astrapy/test_async_db_dml_vector.py
@@ -21,7 +21,7 @@ from typing import cast
 
 import pytest
 
-from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
+from astrapy.db import AsyncAstraDBCollection
 from astrapy.types import API_DOC
 
 logger = logging.getLogger(__name__)

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -121,6 +121,7 @@ def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
 
 
 @pytest.mark.describe("should get all collections")
-def test_get_collections(db: AstraDB) -> None:
+def test_get_collections(db: AstraDB, readonly_v_collection: AstraDBCollection) -> None:
     res = db.get_collections()
     assert res["status"]["collections"] is not None
+    assert readonly_v_collection.collection_name in res["status"]["collections"]

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -16,6 +16,7 @@
 Tests for the `db.py` parts related to DML & client creation
 """
 
+import os
 import logging
 from typing import Dict, Optional
 
@@ -75,6 +76,10 @@ def test_path_handling(astra_db_credentials_kwargs: Dict[str, Optional[str]]) ->
     assert unspecified_ks_client.base_path == explicit_ks_client.base_path
 
 
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
 @pytest.mark.describe("should create, use and destroy a non-vector collection")
 def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
     col = db.create_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
@@ -99,6 +104,10 @@ def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
     assert del_res["status"]["ok"] == 1
 
 
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
 @pytest.mark.describe("should create and destroy a vector collection")
 def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
     col = db.create_collection(

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -33,10 +33,10 @@ from astrapy.db import AstraDB, AstraDBCollection
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.describe("should fail truncating a non-existent collection")
-def test_truncate_collection_fail(db: AstraDB) -> None:
+@pytest.mark.describe("should fail clearing a non-existent collection")
+def test_clear_collection_fail(db: AstraDB) -> None:
     with pytest.raises(APIRequestError):
-        db.truncate_collection("this$does%not exist!!!")
+        db.collection("this$does%not exist!!!").clear()
 
 
 @pytest.mark.describe("should truncate a nonvector collection through AstraDB")
@@ -45,7 +45,8 @@ def test_truncate_nonvector_collection_through_astradb(
 ) -> None:
     empty_nonv_collection.insert_one({"a": 1})
     assert len(empty_nonv_collection.find()["data"]["documents"]) == 1
-    tr_response_col = db.truncate_collection(empty_nonv_collection.collection_name)
+    with pytest.warns(DeprecationWarning):
+        tr_response_col = db.truncate_collection(empty_nonv_collection.collection_name)
     assert len(empty_nonv_collection.find()["data"]["documents"]) == 0
     assert isinstance(tr_response_col, AstraDBCollection)
     assert tr_response_col.collection_name == empty_nonv_collection.collection_name
@@ -57,28 +58,29 @@ def test_truncate_vector_collection_through_astradb(
 ) -> None:
     empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len(empty_v_collection.find()["data"]["documents"]) == 1
-    tr_response_col = db.truncate_collection(empty_v_collection.collection_name)
+    with pytest.warns(DeprecationWarning):
+        tr_response_col = db.truncate_collection(empty_v_collection.collection_name)
     assert len(empty_v_collection.find()["data"]["documents"]) == 0
     assert isinstance(tr_response_col, AstraDBCollection)
     assert tr_response_col.collection_name == empty_v_collection.collection_name
 
 
-@pytest.mark.describe("should truncate a nonvector collection")
-def test_truncate_nonvector_collection(
+@pytest.mark.describe("should clear a nonvector collection")
+def test_clear_nonvector_collection(
     empty_nonv_collection: AstraDBCollection,
 ) -> None:
     empty_nonv_collection.insert_one({"a": 1})
     assert len(empty_nonv_collection.find()["data"]["documents"]) == 1
-    tr_response = empty_nonv_collection.truncate()
+    tr_response = empty_nonv_collection.clear()
     assert len(empty_nonv_collection.find()["data"]["documents"]) == 0
     assert tr_response["status"]["deletedCount"] == -1
 
 
-@pytest.mark.describe("should truncate a collection")
-def test_truncate_vector_collection(empty_v_collection: AstraDBCollection) -> None:
+@pytest.mark.describe("should clear a collection")
+def test_clear_vector_collection(empty_v_collection: AstraDBCollection) -> None:
     empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
     assert len(empty_v_collection.find()["data"]["documents"]) == 1
-    tr_response = empty_v_collection.truncate()
+    tr_response = empty_v_collection.clear()
     assert len(empty_v_collection.find()["data"]["documents"]) == 0
     assert tr_response["status"]["deletedCount"] == -1
 

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -17,6 +17,7 @@ Tests for the `db.py` parts on data manipulation "standard" methods
 (i.e. non `vector_*` methods)
 """
 
+import os
 import uuid
 import logging
 import time
@@ -40,36 +41,37 @@ def test_truncate_collection_fail(db: AstraDB) -> None:
         db.truncate_collection("this$does%not exist!!!")
 
 
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
 @pytest.mark.describe("should truncate a nonvector collection through AstraDB")
 def test_truncate_nonvector_collection_through_astradb(
-    db: AstraDB, disposable_empty_nonvector_collection: AstraDBCollection
+    db: AstraDB, empty_nonv_collection: AstraDBCollection
 ) -> None:
-    db.truncate_collection(disposable_empty_nonvector_collection.collection_name)
-    assert len(disposable_empty_nonvector_collection.find()["data"]["documents"]) == 0
-    disposable_empty_nonvector_collection.insert_one({"a": 1})
-    assert len(disposable_empty_nonvector_collection.find()["data"]["documents"]) == 1
-    time.sleep(1)
-    db.truncate_collection(disposable_empty_nonvector_collection.collection_name)
-    assert len(disposable_empty_nonvector_collection.find()["data"]["documents"]) == 0
+    empty_nonv_collection.insert_one({"a": 1})
+    assert len(empty_nonv_collection.find()["data"]["documents"]) == 1
+    db.truncate_collection(empty_nonv_collection.collection_name)
+    assert len(empty_nonv_collection.find()["data"]["documents"]) == 0
 
 
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
 @pytest.mark.describe("should truncate a collection through AstraDB")
 def test_truncate_vector_collection_through_astradb(
-    db: AstraDB, writable_vector_collection: AstraDBCollection
+    db: AstraDB, empty_v_collection: AstraDBCollection
 ) -> None:
-    db.truncate_collection(writable_vector_collection.collection_name)
-    assert len(writable_vector_collection.find()["data"]["documents"]) == 0
-    writable_vector_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
-    assert len(writable_vector_collection.find()["data"]["documents"]) == 1
-    db.truncate_collection(writable_vector_collection.collection_name)
-    assert len(writable_vector_collection.find()["data"]["documents"]) == 0
+    empty_v_collection.insert_one({"a": 1, "$vector": [0.1, 0.2]})
+    assert len(empty_v_collection.find()["data"]["documents"]) == 1
+    db.truncate_collection(empty_v_collection.collection_name)
+    assert len(empty_v_collection.find()["data"]["documents"]) == 0
 
 
 @pytest.mark.describe("find_one, not through vector")
-def test_find_one_filter_novector(
-    readonly_vector_collection: AstraDBCollection, cliff_uuid: str
-) -> None:
-    response = readonly_vector_collection.find_one(
+def test_find_one_filter_novector(readonly_v_collection: AstraDBCollection) -> None:
+    response = readonly_v_collection.find_one(
         filter={"_id": "1"},
     )
     document = response["data"]["document"]
@@ -79,7 +81,7 @@ def test_find_one_filter_novector(
         == set()
     )
 
-    response_not_by_id = readonly_vector_collection.find_one(
+    response_not_by_id = readonly_v_collection.find_one(
         filter={"text": "Sample entry number <1>"},
     )
     document_not_by_id = response_not_by_id["data"]["document"]
@@ -90,13 +92,13 @@ def test_find_one_filter_novector(
         == set()
     )
 
-    response_no = readonly_vector_collection.find_one(
+    response_no = readonly_v_collection.find_one(
         filter={"_id": "Z"},
     )
     document_no = response_no["data"]["document"]
     assert document_no is None
 
-    response_no_not_by_id = readonly_vector_collection.find_one(
+    response_no_not_by_id = readonly_v_collection.find_one(
         filter={"text": "No such text."},
     )
     document_no_not_by_id = response_no_not_by_id["data"]["document"]
@@ -104,15 +106,15 @@ def test_find_one_filter_novector(
 
 
 @pytest.mark.describe("find, not through vector")
-def test_find_filter_novector(readonly_vector_collection: AstraDBCollection) -> None:
-    response_n2 = readonly_vector_collection.find(
+def test_find_filter_novector(readonly_v_collection: AstraDBCollection) -> None:
+    response_n2 = readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
     )
     documents_n2 = response_n2["data"]["documents"]
     assert isinstance(documents_n2, list)
     assert {document["_id"] for document in documents_n2} == {"1", "2"}
 
-    response_n1 = readonly_vector_collection.find(
+    response_n1 = readonly_v_collection.find(
         filter={"anotherfield": "alpha"},
         options={"limit": 1},
     )
@@ -124,7 +126,7 @@ def test_find_filter_novector(readonly_vector_collection: AstraDBCollection) -> 
 
 @pytest.mark.describe("obey projection in find and find_one")
 def test_find_find_one_projection(
-    readonly_vector_collection: AstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
     query = [0.2, 0.6]
     sort = {"$vector": query}
@@ -144,72 +146,72 @@ def test_find_find_one_projection(
         {"$vector", "_id", "text"},
     ]
     for proj, exp_fields in zip(projs, exp_fieldsets):
-        response_n = readonly_vector_collection.find(
+        response_n = readonly_v_collection.find(
             sort=sort, options=options, projection=proj
         )
         fields = set(response_n["data"]["documents"][0].keys())
         assert fields == exp_fields
         #
-        response_1 = readonly_vector_collection.find_one(sort=sort, projection=proj)
+        response_1 = readonly_v_collection.find_one(sort=sort, projection=proj)
         fields = set(response_1["data"]["document"].keys())
         assert fields == exp_fields
 
 
 @pytest.mark.describe("find through vector")
-def test_find(readonly_vector_collection: AstraDBCollection) -> None:
+def test_find(readonly_v_collection: AstraDBCollection) -> None:
     sort = {"$vector": [0.2, 0.6]}
     options = {"limit": 100}
 
-    response = readonly_vector_collection.find(sort=sort, options=options)
+    response = readonly_v_collection.find(sort=sort, options=options)
     assert isinstance(response["data"]["documents"], list)
 
 
 @pytest.mark.describe("proper error raising in find")
-def test_find_error(readonly_vector_collection: AstraDBCollection) -> None:
+def test_find_error(readonly_v_collection: AstraDBCollection) -> None:
     """Wrong type of arguments should raise an API error (ValueError)."""
     sort = {"$vector": "clearly not a list of floats!"}
     options = {"limit": 100}
 
     with pytest.raises(APIRequestError):
-        readonly_vector_collection.find(sort=sort, options=options)
+        readonly_v_collection.find(sort=sort, options=options)
 
 
 @pytest.mark.describe("find through vector, without explicit limit")
-def test_find_limitless(readonly_vector_collection: AstraDBCollection) -> None:
+def test_find_limitless(readonly_v_collection: AstraDBCollection) -> None:
     sort = {"$vector": [0.2, 0.6]}
     projection = {"$vector": 1}
 
-    response = readonly_vector_collection.find(sort=sort, projection=projection)
+    response = readonly_v_collection.find(sort=sort, projection=projection)
     assert response is not None
     assert isinstance(response["data"]["documents"], list)
 
 
 @pytest.mark.describe("correctly count documents according to predicate")
 def test_count_documents(
-    readonly_vector_collection: AstraDBCollection,
+    readonly_v_collection: AstraDBCollection,
 ) -> None:
-    c_all_response0 = readonly_vector_collection.count_documents()
+    c_all_response0 = readonly_v_collection.count_documents()
     assert c_all_response0["status"]["count"] == 3
 
-    c_all_response1 = readonly_vector_collection.count_documents(filter={})
+    c_all_response1 = readonly_v_collection.count_documents(filter={})
     assert c_all_response1["status"]["count"] == 3
 
-    c_pred_response = readonly_vector_collection.count_documents(
+    c_pred_response = readonly_v_collection.count_documents(
         filter={"anotherfield": "alpha"}
     )
     assert c_pred_response["status"]["count"] == 2
 
-    c_no_response = readonly_vector_collection.count_documents(
+    c_no_response = readonly_v_collection.count_documents(
         filter={"false_field": 137}
     )
     assert c_no_response["status"]["count"] == 0
 
 
 @pytest.mark.describe("insert_one, w/out _id, w/out vector")
-def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
+def test_create_document(writable_v_collection: AstraDBCollection) -> None:
     i_vector = [0.3, 0.5]
     id_v_i = str(uuid.uuid4())
-    result_v_i = writable_vector_collection.insert_one(
+    result_v_i = writable_v_collection.insert_one(
         {
             "_id": id_v_i,
             "a": 1,
@@ -218,14 +220,14 @@ def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     )
     assert result_v_i["status"]["insertedIds"] == [id_v_i]
     assert (
-        writable_vector_collection.find_one(
+        writable_v_collection.find_one(
             {"_id": result_v_i["status"]["insertedIds"][0]}
         )["data"]["document"]["a"]
         == 1
     )
 
     id_n_i = str(uuid.uuid4())
-    result_n_i = writable_vector_collection.insert_one(
+    result_n_i = writable_v_collection.insert_one(
         {
             "_id": id_n_i,
             "a": 2,
@@ -233,21 +235,21 @@ def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     )
     assert result_n_i["status"]["insertedIds"] == [id_n_i]
     assert (
-        writable_vector_collection.find_one(
+        writable_v_collection.find_one(
             {"_id": result_n_i["status"]["insertedIds"][0]}
         )["data"]["document"]["a"]
         == 2
     )
 
     with pytest.raises(ValueError):
-        result_n_i = writable_vector_collection.insert_one(
+        result_n_i = writable_v_collection.insert_one(
             {
                 "_id": id_n_i,
                 "a": 3,
             }
         )
 
-    result_v_n = writable_vector_collection.insert_one(
+    result_v_n = writable_v_collection.insert_one(
         {
             "a": 4,
             "$vector": i_vector,
@@ -257,13 +259,13 @@ def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     assert isinstance(result_v_n["status"]["insertedIds"][0], str)
     assert len(result_v_n["status"]["insertedIds"]) == 1
     assert (
-        writable_vector_collection.find_one(
+        writable_v_collection.find_one(
             {"_id": result_v_n["status"]["insertedIds"][0]}
         )["data"]["document"]["a"]
         == 4
     )
 
-    result_n_n = writable_vector_collection.insert_one(
+    result_n_n = writable_v_collection.insert_one(
         {
             "a": 5,
         }
@@ -272,16 +274,16 @@ def test_create_document(writable_vector_collection: AstraDBCollection) -> None:
     assert isinstance(result_n_n["status"]["insertedIds"][0], str)
     assert len(result_n_n["status"]["insertedIds"]) == 1
     assert (
-        writable_vector_collection.find_one(
+        writable_v_collection.find_one(
             {"_id": result_n_n["status"]["insertedIds"][0]}
         )["data"]["document"]["a"]
         == 5
     )
 
 
-@pytest.mark.describe("should truncate a nonvector collection")
+@pytest.mark.describe("should coerce 'vectors' to lists of floats")
 def test_insert_float32(
-    writable_vector_collection: AstraDBCollection, N: int = 2
+    writable_v_collection: AstraDBCollection, N: int = 2
 ) -> None:
     _id0 = str(uuid.uuid4())
     document = {
@@ -289,7 +291,7 @@ def test_insert_float32(
         "name": "Coerce",
         "$vector": [f"{(i+1)/N+2:.4f}" for i in range(N)],
     }
-    response = writable_vector_collection.insert_one(document)
+    response = writable_v_collection.insert_one(document)
     assert response is not None
     inserted_ids = response["status"]["insertedIds"]
     assert len(inserted_ids) == 1
@@ -297,7 +299,7 @@ def test_insert_float32(
 
 
 @pytest.mark.describe("insert_many")
-def test_insert_many(writable_vector_collection: AstraDBCollection) -> None:
+def test_insert_many(writable_v_collection: AstraDBCollection) -> None:
     _id0 = str(uuid.uuid4())
     _id2 = str(uuid.uuid4())
     documents: List[API_DOC] = [
@@ -319,7 +321,7 @@ def test_insert_many(writable_vector_collection: AstraDBCollection) -> None:
         },
     ]
 
-    response = writable_vector_collection.insert_many(documents)
+    response = writable_v_collection.insert_many(documents)
     assert response is not None
     inserted_ids = set(response["status"]["insertedIds"])
     assert len(inserted_ids - {_id0, _id2}) == 1
@@ -328,7 +330,7 @@ def test_insert_many(writable_vector_collection: AstraDBCollection) -> None:
 
 @pytest.mark.describe("chunked_insert_many")
 def test_chunked_insert_many(
-    writable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -343,7 +345,7 @@ def test_chunked_insert_many(
         for doc_idx, _id in enumerate(_ids0)
     ]
 
-    responses0 = writable_vector_collection.chunked_insert_many(
+    responses0 = writable_v_collection.chunked_insert_many(
         documents0, chunk_size=3
     )
     assert responses0 is not None
@@ -356,7 +358,7 @@ def test_chunked_insert_many(
     # unordered inserts: this only has to be a set equality
     assert set(inserted_ids0) == set(_ids0)
 
-    response0a = writable_vector_collection.find_one(filter={"_id": _ids0[0]})
+    response0a = writable_v_collection.find_one(filter={"_id": _ids0[0]})
     assert response0a is not None
     assert response0a["data"]["document"] == documents0[0]
 
@@ -377,13 +379,13 @@ def test_chunked_insert_many(
     ]
 
     with pytest.raises(ValueError):
-        _ = writable_vector_collection.chunked_insert_many(
+        _ = writable_v_collection.chunked_insert_many(
             documents1,
             chunk_size=3,
             options={"ordered": True},
         )
 
-    responses1_ok = writable_vector_collection.chunked_insert_many(
+    responses1_ok = writable_v_collection.chunked_insert_many(
         documents1,
         chunk_size=3,
         options={"ordered": False},
@@ -411,7 +413,7 @@ def test_chunked_insert_many(
 
 @pytest.mark.describe("chunked_insert_many concurrently")
 def test_concurrent_chunked_insert_many(
-    writable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(20)]
     documents0: List[API_DOC] = [
@@ -426,7 +428,7 @@ def test_concurrent_chunked_insert_many(
         for doc_idx, _id in enumerate(_ids0)
     ]
 
-    responses0 = writable_vector_collection.chunked_insert_many(
+    responses0 = writable_v_collection.chunked_insert_many(
         documents0, chunk_size=3, concurrency=4
     )
     assert responses0 is not None
@@ -439,7 +441,7 @@ def test_concurrent_chunked_insert_many(
     # unordered inserts: this only has to be a set equality
     assert set(inserted_ids0) == set(_ids0)
 
-    response0a = writable_vector_collection.find_one(filter={"_id": _ids0[0]})
+    response0a = writable_v_collection.find_one(filter={"_id": _ids0[0]})
     assert response0a is not None
     assert response0a["data"]["document"] == documents0[0]
 
@@ -464,14 +466,14 @@ def test_concurrent_chunked_insert_many(
         # and the doc array size must be <= chunk size
         # for this not to spoil the rest of the test
         docs_for_error = documents0[0:1] + [{"_id": str(uuid.uuid4())}]
-        _ = writable_vector_collection.chunked_insert_many(
+        _ = writable_v_collection.chunked_insert_many(
             docs_for_error,
             chunk_size=3,
             concurrency=4,
             options={"ordered": True},
         )
 
-    responses1_ok = writable_vector_collection.chunked_insert_many(
+    responses1_ok = writable_v_collection.chunked_insert_many(
         documents1,
         chunk_size=3,
         options={"ordered": False},
@@ -500,7 +502,7 @@ def test_concurrent_chunked_insert_many(
 
 @pytest.mark.describe("insert_many with 'ordered' set to True")
 def test_insert_many_ordered_true(
-    writable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id0 = str(uuid.uuid4())
     _id1 = str(uuid.uuid4())
@@ -517,7 +519,7 @@ def test_insert_many_ordered_true(
             "last_name": "Boss",
         },
     ]
-    response_a = writable_vector_collection.insert_many(
+    response_a = writable_v_collection.insert_many(
         documents_a,
         options={"ordered": True},
     )
@@ -536,13 +538,13 @@ def test_insert_many_ordered_true(
             "last_name": "Fuff",
         },
     ]
-    response_b = writable_vector_collection.insert_many(
+    response_b = writable_v_collection.insert_many(
         documents_b, partial_failures_allowed=True, options={"ordered": True}
     )
     assert response_b is not None
     assert response_b["status"]["insertedIds"] == []
 
-    response_b2 = writable_vector_collection.insert_many(
+    response_b2 = writable_v_collection.insert_many(
         documents=documents_b,
         options={"ordered": False},
         partial_failures_allowed=True,
@@ -550,18 +552,18 @@ def test_insert_many_ordered_true(
     assert response_b2 is not None
     assert response_b2["status"]["insertedIds"] == [_id2]
 
-    check_response = writable_vector_collection.find_one(filter={"first_name": "Yep"})
+    check_response = writable_v_collection.find_one(filter={"first_name": "Yep"})
     assert check_response is not None
     assert check_response["data"]["document"]["_id"] == _id1
 
 
 @pytest.mark.describe("test error handling - duplicate document")
 def test_error_handling_duplicate(
-    writable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _id1 = str(uuid.uuid4())
 
-    result1 = writable_vector_collection.insert_one(
+    result1 = writable_v_collection.insert_one(
         {
             "_id": _id1,
             "a": 1,
@@ -571,14 +573,14 @@ def test_error_handling_duplicate(
 
     assert result1["status"]["insertedIds"] == [_id1]
     assert (
-        writable_vector_collection.find_one(
+        writable_v_collection.find_one(
             {"_id": result1["status"]["insertedIds"][0]}
         )["data"]["document"]["a"]
         == 1
     )
 
     with pytest.raises(ValueError):
-        writable_vector_collection.insert_one(
+        writable_v_collection.insert_one(
             {
                 "_id": _id1,
                 "a": 1,
@@ -587,7 +589,7 @@ def test_error_handling_duplicate(
         )
 
     try:
-        writable_vector_collection.insert_one(
+        writable_v_collection.insert_one(
             {
                 "_id": _id1,
                 "a": 1,
@@ -603,12 +605,12 @@ def test_error_handling_duplicate(
 
 @pytest.mark.describe("test error handling - network error")
 def test_error_handling_network(
-    invalid_writable_vector_collection: AstraDBCollection,
+    invalid_writable_v_collection: AstraDBCollection,
 ) -> None:
     _id1 = str(uuid.uuid4())
 
     with pytest.raises(httpx.ConnectError):
-        invalid_writable_vector_collection.insert_one(
+        invalid_writable_v_collection.insert_one(
             {
                 "_id": _id1,
                 "a": 1,
@@ -619,7 +621,7 @@ def test_error_handling_network(
 
 @pytest.mark.describe("upsert_many")
 def test_upsert_many(
-    writable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
     _ids0 = [str(uuid.uuid4()) for _ in range(12)]
     documents0 = [
@@ -633,14 +635,14 @@ def test_upsert_many(
         for doc_i, _id in enumerate(_ids0)
     ]
 
-    upsert_result0 = writable_vector_collection.upsert_many(documents0)
+    upsert_result0 = writable_v_collection.upsert_many(documents0)
     assert upsert_result0 == [doc["_id"] for doc in documents0]
 
-    response0a = writable_vector_collection.find_one(filter={"_id": _ids0[0]})
+    response0a = writable_v_collection.find_one(filter={"_id": _ids0[0]})
     assert response0a is not None
     assert response0a["data"]["document"] == documents0[0]
 
-    response0b = writable_vector_collection.find_one(filter={"_id": _ids0[-1]})
+    response0b = writable_v_collection.find_one(filter={"_id": _ids0[-1]})
     assert response0b is not None
     assert response0b["data"]["document"] == documents0[-1]
 
@@ -655,23 +657,23 @@ def test_upsert_many(
         }
         for doc_i, _id in enumerate(_ids1)
     ]
-    upsert_result1 = writable_vector_collection.upsert_many(
+    upsert_result1 = writable_v_collection.upsert_many(
         documents1,
         concurrency=5,
     )
     assert upsert_result1 == [doc["_id"] for doc in documents1]
 
-    response1a = writable_vector_collection.find_one(filter={"_id": _ids1[0]})
+    response1a = writable_v_collection.find_one(filter={"_id": _ids1[0]})
     assert response1a is not None
     assert response1a["data"]["document"] == documents1[0]
 
-    response1b = writable_vector_collection.find_one(filter={"_id": _ids1[-1]})
+    response1b = writable_v_collection.find_one(filter={"_id": _ids1[-1]})
     assert response1b is not None
     assert response1b["data"]["document"] == documents1[-1]
 
 
 @pytest.mark.describe("upsert")
-def test_upsert_document(writable_vector_collection: AstraDBCollection) -> None:
+def test_upsert_document(writable_v_collection: AstraDBCollection) -> None:
     _id = str(uuid.uuid4())
 
     document0 = {
@@ -683,10 +685,10 @@ def test_upsert_document(writable_vector_collection: AstraDBCollection) -> None:
             },
         },
     }
-    upsert_result0 = writable_vector_collection.upsert(document0)
+    upsert_result0 = writable_v_collection.upsert(document0)
     assert upsert_result0 == _id
 
-    response0 = writable_vector_collection.find_one(filter={"_id": _id})
+    response0 = writable_v_collection.find_one(filter={"_id": _id})
     assert response0 is not None
     assert response0["data"]["document"] == document0
 
@@ -703,52 +705,64 @@ def test_upsert_document(writable_vector_collection: AstraDBCollection) -> None:
             "accounting",
         ],
     }
-    upsert_result1 = writable_vector_collection.upsert(document1)
+    upsert_result1 = writable_v_collection.upsert(document1)
     assert upsert_result1 == _id
 
-    response1 = writable_vector_collection.find_one(filter={"_id": _id})
+    response1 = writable_v_collection.find_one(filter={"_id": _id})
     assert response1 is not None
     assert response1["data"]["document"] == document1
 
 
 @pytest.mark.describe("update_one to create a subdocument, not through vector")
 def test_update_one_create_subdocument_novector(
-    disposable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
-    update_one_response = disposable_vector_collection.update_one(
-        filter={"_id": "1"},
+    _id = str(uuid.uuid4())
+    writable_v_collection.insert_one({"_id": _id, "name": "Not Eric!"})
+    update_one_response = writable_v_collection.update_one(
+        filter={"_id": _id},
         update={"$set": {"name": "Eric"}},
     )
 
     assert update_one_response["status"]["matchedCount"] >= 1
     assert update_one_response["status"]["modifiedCount"] == 1
 
-    response = disposable_vector_collection.find_one(filter={"_id": "1"})
+    response = writable_v_collection.find_one(filter={"_id": _id})
     assert response["data"]["document"]["name"] == "Eric"
 
 
 @pytest.mark.describe("delete_subdocument, not through vector")
 def test_delete_subdocument_novector(
-    disposable_vector_collection: AstraDBCollection,
+    writable_v_collection: AstraDBCollection,
 ) -> None:
-    delete_subdocument_response = disposable_vector_collection.delete_subdocument(
-        id="1",
+    _id = str(uuid.uuid4())
+    writable_v_collection.insert_one(
+        {
+            "_id": _id,
+            "text": "Sample entry",
+            "otherfield": {"subfield": "abc"},
+            "anotherfield": "alpha",
+            "$vector": [0.1, 0.9],
+        },
+    )
+    delete_subdocument_response = writable_v_collection.delete_subdocument(
+        id=_id,
         subdoc="otherfield.subfield",
     )
 
     assert delete_subdocument_response["status"]["matchedCount"] >= 1
     assert delete_subdocument_response["status"]["modifiedCount"] == 1
 
-    response = disposable_vector_collection.find_one(filter={"_id": "1"})
+    response = writable_v_collection.find_one(filter={"_id": _id})
     assert response["data"]["document"]["otherfield"] == {}
 
 
 @pytest.mark.describe("find_one_and_update, through vector")
 def test_find_one_and_update_vector(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = disposable_vector_collection.find_one(filter=find_filter)
+    response0 = disposable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     sort = {"$vector": [0.2, 0.6]}
@@ -756,7 +770,7 @@ def test_find_one_and_update_vector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = disposable_vector_collection.find_one_and_update(
+    update_response0 = disposable_v_collection.find_one_and_update(
         sort=sort, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -764,14 +778,14 @@ def test_find_one_and_update_vector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = disposable_vector_collection.find_one(filter=find_filter)
+    response1 = disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = disposable_vector_collection.find_one_and_update(
+    update_response1 = disposable_v_collection.find_one_and_update(
         sort=sort, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -779,7 +793,7 @@ def test_find_one_and_update_vector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = disposable_vector_collection.find_one(filter=find_filter)
+    response2 = disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -787,7 +801,7 @@ def test_find_one_and_update_vector(
     update2 = update1
     options2 = options1
 
-    update_response2 = disposable_vector_collection.find_one_and_update(
+    update_response2 = disposable_v_collection.find_one_and_update(
         sort=sort, update=update2, options=options2, filter=filter2
     )
     assert update_response2["data"]["document"] is None
@@ -797,10 +811,10 @@ def test_find_one_and_update_vector(
 
 @pytest.mark.describe("find_one_and_update, not through vector")
 def test_find_one_and_update_novector(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     find_filter = {"status": {"$exists": True}}
-    response0 = disposable_vector_collection.find_one(filter=find_filter)
+    response0 = disposable_v_collection.find_one(filter=find_filter)
     assert response0["data"]["document"] is None
 
     update_filter = {"anotherfield": "omega"}
@@ -808,7 +822,7 @@ def test_find_one_and_update_novector(
     update0 = {"$set": {"status": "active"}}
     options0 = {"returnDocument": "after"}
 
-    update_response0 = disposable_vector_collection.find_one_and_update(
+    update_response0 = disposable_v_collection.find_one_and_update(
         filter=update_filter, update=update0, options=options0
     )
     assert isinstance(update_response0["data"]["document"], dict)
@@ -816,14 +830,14 @@ def test_find_one_and_update_novector(
     assert update_response0["status"]["matchedCount"] >= 1
     assert update_response0["status"]["modifiedCount"] >= 1
 
-    response1 = disposable_vector_collection.find_one(filter=find_filter)
+    response1 = disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response1["data"]["document"], dict)
     assert response1["data"]["document"]["status"] == "active"
 
     update1 = {"$set": {"status": "inactive"}}
     options1 = {"returnDocument": "before"}
 
-    update_response1 = disposable_vector_collection.find_one_and_update(
+    update_response1 = disposable_v_collection.find_one_and_update(
         filter=update_filter, update=update1, options=options1
     )
     assert isinstance(update_response1["data"]["document"], dict)
@@ -831,7 +845,7 @@ def test_find_one_and_update_novector(
     assert update_response1["status"]["matchedCount"] >= 1
     assert update_response1["status"]["modifiedCount"] >= 1
 
-    response2 = disposable_vector_collection.find_one(filter=find_filter)
+    response2 = disposable_v_collection.find_one(filter=find_filter)
     assert isinstance(response2["data"]["document"], dict)
     assert response2["data"]["document"]["status"] == "inactive"
 
@@ -839,7 +853,7 @@ def test_find_one_and_update_novector(
     update2 = update1
     options2 = options1
 
-    update_response2 = disposable_vector_collection.find_one_and_update(
+    update_response2 = disposable_v_collection.find_one_and_update(
         filter=filter2, update=update2, options=options2
     )
     assert update_response2["data"]["document"] is None
@@ -849,17 +863,17 @@ def test_find_one_and_update_novector(
 
 @pytest.mark.describe("find_one_and_replace, through vector")
 def test_find_one_and_replace_vector(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     sort = {"$vector": [0.2, 0.6]}
 
-    response0 = disposable_vector_collection.find_one(sort=sort)
+    response0 = disposable_v_collection.find_one(sort=sort)
     assert response0 is not None
     assert "anotherfield" in response0["data"]["document"]
 
     doc0vector = response0["data"]["document"]["$vector"]
 
-    replace_response0 = disposable_vector_collection.find_one_and_replace(
+    replace_response0 = disposable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phyla": ["Echinodermata", "Platelminta", "Chordata"],
@@ -869,7 +883,7 @@ def test_find_one_and_replace_vector(
     assert replace_response0 is not None
     assert "anotherfield" in replace_response0["data"]["document"]
 
-    response1 = disposable_vector_collection.find_one(sort=sort)
+    response1 = disposable_v_collection.find_one(sort=sort)
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -878,7 +892,7 @@ def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = disposable_vector_collection.find_one_and_replace(
+    replace_response1 = disposable_v_collection.find_one_and_replace(
         sort=sort,
         replacement={
             "phone": "0123-4567",
@@ -893,14 +907,14 @@ def test_find_one_and_replace_vector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = disposable_vector_collection.find_one(sort=sort)
+    response2 = disposable_v_collection.find_one(sort=sort)
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
     filter_no = {"nonexisting_field": -123}
-    replace_response_no = disposable_vector_collection.find_one_and_replace(
+    replace_response_no = disposable_v_collection.find_one_and_replace(
         sort=sort,
         filter=filter_no,
         replacement={
@@ -914,13 +928,13 @@ def test_find_one_and_replace_vector(
 
 @pytest.mark.describe("find_one_and_replace, not through vector")
 def test_find_one_and_replace_novector(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
-    response0 = disposable_vector_collection.find_one(filter={"_id": "1"})
+    response0 = disposable_v_collection.find_one(filter={"_id": "1"})
     assert response0 is not None
     assert response0["data"]["document"]["anotherfield"] == "alpha"
 
-    replace_response0 = disposable_vector_collection.find_one_and_replace(
+    replace_response0 = disposable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "_id": "1",
@@ -930,7 +944,7 @@ def test_find_one_and_replace_novector(
     assert replace_response0 is not None
     assert replace_response0["data"]["document"]["anotherfield"] == "alpha"
 
-    response1 = disposable_vector_collection.find_one(filter={"_id": "1"})
+    response1 = disposable_v_collection.find_one(filter={"_id": "1"})
     assert response1 is not None
     assert response1["data"]["document"]["phyla"] == [
         "Echinodermata",
@@ -939,7 +953,7 @@ def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in response1["data"]["document"]
 
-    replace_response1 = disposable_vector_collection.find_one_and_replace(
+    replace_response1 = disposable_v_collection.find_one_and_replace(
         filter={"_id": "1"},
         replacement={
             "phone": "0123-4567",
@@ -953,13 +967,13 @@ def test_find_one_and_replace_novector(
     ]
     assert "anotherfield" not in replace_response1["data"]["document"]
 
-    response2 = disposable_vector_collection.find_one(filter={"_id": "1"})
+    response2 = disposable_v_collection.find_one(filter={"_id": "1"})
     assert response2 is not None
     assert response2["data"]["document"]["phone"] == "0123-4567"
     assert "phyla" not in response2["data"]["document"]
 
     # non-existing-doc case
-    replace_response_no = disposable_vector_collection.find_one_and_replace(
+    replace_response_no = disposable_v_collection.find_one_and_replace(
         filter={"_id": "z"},
         replacement={
             "whatever": -123,
@@ -970,37 +984,37 @@ def test_find_one_and_replace_novector(
 
 
 @pytest.mark.describe("delete_one, not through vector")
-def test_delete_one_novector(disposable_vector_collection: AstraDBCollection) -> None:
-    delete_response = disposable_vector_collection.delete_one(id="3")
+def test_delete_one_novector(disposable_v_collection: AstraDBCollection) -> None:
+    delete_response = disposable_v_collection.delete_one(id="3")
     assert delete_response["status"]["deletedCount"] == 1
 
-    response = disposable_vector_collection.find_one(filter={"_id": "3"})
+    response = disposable_v_collection.find_one(filter={"_id": "3"})
     assert response["data"]["document"] is None
 
-    delete_response_no = disposable_vector_collection.delete_one(id="3")
+    delete_response_no = disposable_v_collection.delete_one(id="3")
     assert delete_response_no["status"]["deletedCount"] == 0
 
 
 @pytest.mark.describe("delete_many, not through vector")
-def test_delete_many_novector(disposable_vector_collection: AstraDBCollection) -> None:
-    delete_response = disposable_vector_collection.delete_many(
+def test_delete_many_novector(disposable_v_collection: AstraDBCollection) -> None:
+    delete_response = disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response["status"]["deletedCount"] == 2
 
-    documents_no = disposable_vector_collection.find(filter={"anotherfield": "alpha"})
+    documents_no = disposable_v_collection.find(filter={"anotherfield": "alpha"})
     assert documents_no["data"]["documents"] == []
 
-    delete_response_no = disposable_vector_collection.delete_many(
+    delete_response_no = disposable_v_collection.delete_many(
         filter={"anotherfield": "alpha"}
     )
     assert delete_response_no["status"]["deletedCount"] == 0
 
 
 @pytest.mark.describe("pop, push functions, not through vector")
-def test_pop_push_novector(disposable_vector_collection: AstraDBCollection) -> None:
+def test_pop_push_novector(empty_v_collection: AstraDBCollection) -> None:
     user_id = str(uuid.uuid4())
-    disposable_vector_collection.insert_one(
+    empty_v_collection.insert_one(
         document={
             "_id": user_id,
             "first_name": "Cliff",
@@ -1012,7 +1026,7 @@ def test_pop_push_novector(disposable_vector_collection: AstraDBCollection) -> N
     pop = {"roles": 1}
     options = {"returnDocument": "after"}
 
-    pop_response = disposable_vector_collection.pop(
+    pop_response = empty_v_collection.pop(
         filter={"_id": user_id}, pop=pop, options=options
     )
     assert pop_response is not None
@@ -1020,13 +1034,13 @@ def test_pop_push_novector(disposable_vector_collection: AstraDBCollection) -> N
     assert pop_response["status"]["matchedCount"] >= 1
     assert pop_response["status"]["modifiedCount"] == 1
 
-    response1 = disposable_vector_collection.find_one(filter={"_id": user_id})
+    response1 = empty_v_collection.find_one(filter={"_id": user_id})
     assert response1 is not None
     assert response1["data"]["document"]["roles"] == ["user"]
 
     push = {"roles": "auditor"}
 
-    push_response = disposable_vector_collection.push(
+    push_response = empty_v_collection.push(
         filter={"_id": user_id}, push=push, options=options
     )
     assert push_response is not None
@@ -1034,14 +1048,14 @@ def test_pop_push_novector(disposable_vector_collection: AstraDBCollection) -> N
     assert push_response["status"]["matchedCount"] >= 1
     assert push_response["status"]["modifiedCount"] == 1
 
-    response2 = disposable_vector_collection.find_one(filter={"_id": user_id})
+    response2 = empty_v_collection.find_one(filter={"_id": user_id})
     assert response2 is not None
     assert response2["data"]["document"]["roles"] == ["user", "auditor"]
 
 
 @pytest.mark.describe("find/find_one with non-equality operators in filter")
 def test_find_find_one_non_equality_operators(
-    disposable_empty_nonvector_collection: AstraDBCollection,
+    empty_nonv_collection: AstraDBCollection,
 ) -> None:
     full_document = {
         "_id": "1",
@@ -1119,59 +1133,59 @@ def test_find_find_one_non_equality_operators(
             "b525cd48-abf7-4b40-b9ef-0c3248fbb8e8",
         ],
     }
-    disposable_empty_nonvector_collection.insert_one(full_document)
+    empty_nonv_collection.insert_one(full_document)
     projection = {"marker": 1}
 
     # find by id
-    resp0 = disposable_empty_nonvector_collection.find_one(
+    resp0 = empty_nonv_collection.find_one(
         filter={"_id": "1"}, projection=projection
     )
     assert resp0["data"]["document"]["marker"] == "abc"
 
     # find with $in
-    resp1 = disposable_empty_nonvector_collection.find(
+    resp1 = empty_nonv_collection.find(
         filter={"metadata_string": {"$in": ["hello", "world"]}}, projection=projection
     )
     assert resp1["data"]["documents"][0]["marker"] == "abc"
 
     # find with $nin
-    resp2 = disposable_empty_nonvector_collection.find(
+    resp2 = empty_nonv_collection.find(
         filter={"metadata_string": {"$nin": ["Hallo", "Welt"]}}, projection=projection
     )
     assert resp2["data"]["documents"][0]["marker"] == "abc"
 
     # find with $size
-    resp3 = disposable_empty_nonvector_collection.find(
+    resp3 = empty_nonv_collection.find(
         filter={"metadata_boolean_array": {"$size": 3}}, projection=projection
     )
     assert resp3["data"]["documents"][0]["marker"] == "abc"
 
     # find with $lt
-    resp4 = disposable_empty_nonvector_collection.find(
+    resp4 = empty_nonv_collection.find(
         filter={"metadata_int": {"$lt": 2}}, projection=projection
     )
     assert resp4["data"]["documents"][0]["marker"] == "abc"
 
     # find with $lte
-    resp5 = disposable_empty_nonvector_collection.find(
+    resp5 = empty_nonv_collection.find(
         filter={"metadata_int": {"$lte": 1}}, projection=projection
     )
     assert resp5["data"]["documents"][0]["marker"] == "abc"
 
     # find with $gt
-    resp6 = disposable_empty_nonvector_collection.find(
+    resp6 = empty_nonv_collection.find(
         filter={"metadata_int": {"$gt": 0}}, projection=projection
     )
     assert resp6["data"]["documents"][0]["marker"] == "abc"
 
     # find with $gte
-    resp7 = disposable_empty_nonvector_collection.find(
+    resp7 = empty_nonv_collection.find(
         filter={"metadata_int": {"$gte": 1}}, projection=projection
     )
     assert resp7["data"]["documents"][0]["marker"] == "abc"
 
     # find with $gte on a Date
-    resp8 = disposable_empty_nonvector_collection.find(
+    resp8 = empty_nonv_collection.find(
         filter={"metadata_instant": {"$lt": {"$date": 1704727050218}}},
         projection=projection,
     )

--- a/tests/astrapy/test_db_dml_pagination.py
+++ b/tests/astrapy/test_db_dml_pagination.py
@@ -16,12 +16,11 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
-import os
 import logging
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Optional
 import pytest
 
-from astrapy.db import AstraDB, AstraDBCollection
+from astrapy.db import AstraDBCollection
 
 
 logger = logging.getLogger(__name__)
@@ -44,7 +43,6 @@ PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetch
 def test_find_paginated(
     prefetched: Optional[int], pagination_v_collection: AstraDBCollection
 ) -> None:
-
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}
 
@@ -53,6 +51,6 @@ def test_find_paginated(
     )
     paginated_documents = list(paginated_documents_gen)
     paginated_ids = [doc["_id"] for doc in paginated_documents]
-    assert all(["$vector" not in doc for doc in  paginated_documents])
+    assert all(["$vector" not in doc for doc in paginated_documents])
     assert len(paginated_ids) == FIND_LIMIT
     assert len(paginated_ids) == len(set(paginated_ids))

--- a/tests/astrapy/test_db_dml_pagination.py
+++ b/tests/astrapy/test_db_dml_pagination.py
@@ -16,10 +16,9 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
-import math
 import os
 import logging
-from typing import Dict, Iterable, List, Optional, Set, TypeVar
+from typing import Dict, Iterable, List, Optional, Set
 import pytest
 
 from astrapy.db import AstraDB, AstraDBCollection
@@ -28,54 +27,8 @@ from astrapy.db import AstraDB, AstraDBCollection
 logger = logging.getLogger(__name__)
 
 
-TEST_PAGINATION_COLLECTION_NAME = "pagination_v_col"
-INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
-N = 200  # must be EVEN
 FIND_LIMIT = 183  # Keep this > 20 and <= N to actually put pagination to test
 PREFETCHED = 42  # Keep this > 20 and <= FIND_LIMIT to actually trigger prefetching
-
-T = TypeVar("T")
-
-
-def _mk_vector(index: int, n_total_steps: int) -> List[float]:
-    angle = 2 * math.pi * index / n_total_steps
-    return [math.cos(angle), math.sin(angle)]
-
-
-def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable[T]]:
-    this_batch = []
-    for entry in iterable:
-        this_batch.append(entry)
-        if len(this_batch) == batch_size:
-            yield this_batch
-            this_batch = []
-    if this_batch:
-        yield this_batch
-
-
-@pytest.fixture(scope="module")
-def pag_test_collection(
-    astra_db_credentials_kwargs: Dict[str, Optional[str]]
-) -> Iterable[AstraDBCollection]:
-    astra_db = AstraDB(**astra_db_credentials_kwargs)
-
-    astra_db_collection = astra_db.create_collection(
-        collection_name=TEST_PAGINATION_COLLECTION_NAME, dimension=2
-    )
-
-    if int(os.getenv("TEST_PAGINATION_SKIP_INSERTION", "0")) == 0:
-        inserted_ids: Set[str] = set()
-        for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
-            batch_ids = astra_db_collection.insert_many(
-                documents=[
-                    {"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch
-                ]
-            )["status"]["insertedIds"]
-            inserted_ids = inserted_ids | set(batch_ids)
-        assert inserted_ids == {str(i) for i in range(N)}
-    yield astra_db_collection
-    if int(os.getenv("TEST_PAGINATION_SKIP_DELETE_COLLECTION", "0")) == 0:
-        _ = astra_db.delete_collection(collection_name=TEST_PAGINATION_COLLECTION_NAME)
 
 
 @pytest.mark.describe(
@@ -89,14 +42,17 @@ def pag_test_collection(
     ],
 )
 def test_find_paginated(
-    prefetched: Optional[int], pag_test_collection: AstraDBCollection
+    prefetched: Optional[int], pagination_v_collection: AstraDBCollection
 ) -> None:
+
     options = {"limit": FIND_LIMIT}
     projection = {"$vector": 0}
 
-    paginated_documents = pag_test_collection.paginated_find(
+    paginated_documents_gen = pagination_v_collection.paginated_find(
         projection=projection, options=options, prefetched=prefetched
     )
+    paginated_documents = list(paginated_documents_gen)
     paginated_ids = [doc["_id"] for doc in paginated_documents]
+    assert all(["$vector" not in doc for doc in  paginated_documents])
     assert len(paginated_ids) == FIND_LIMIT
     assert len(paginated_ids) == len(set(paginated_ids))

--- a/tests/astrapy/test_db_dml_vector.py
+++ b/tests/astrapy/test_db_dml_vector.py
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.describe("vector_find and include_similarity parameter")
-def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
-    documents_sim_1 = readonly_vector_collection.vector_find(
+def test_vector_find(readonly_v_collection: AstraDBCollection) -> None:
+    documents_sim_1 = readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
     )
@@ -42,7 +42,7 @@ def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in documents_sim_1[0]
     assert "$similarity" in documents_sim_1[0]
 
-    documents_sim_2 = readonly_vector_collection.vector_find(
+    documents_sim_2 = readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
         include_similarity=True,
@@ -56,7 +56,7 @@ def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in documents_sim_2[0]
     assert "$similarity" in documents_sim_2[0]
 
-    documents_no_sim = readonly_vector_collection.vector_find(
+    documents_no_sim = readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         limit=3,
         fields=["_id", "$vector"],
@@ -73,7 +73,7 @@ def test_vector_find(readonly_vector_collection: AstraDBCollection) -> None:
 
 
 @pytest.mark.describe("vector_find, obey projection")
-def test_vector_find_projection(readonly_vector_collection: AstraDBCollection) -> None:
+def test_vector_find_projection(readonly_v_collection: AstraDBCollection) -> None:
     query = [0.2, 0.6]
 
     req_fieldsets = [
@@ -92,7 +92,7 @@ def test_vector_find_projection(readonly_vector_collection: AstraDBCollection) -
     ]
     for include_similarity in [True, False]:
         for req_fields, exp_fields0 in zip(req_fieldsets, exp_fieldsets):
-            vdocs = readonly_vector_collection.vector_find(
+            vdocs = readonly_v_collection.vector_find(
                 query,
                 limit=1,
                 fields=list(req_fields) if req_fields is not None else req_fields,
@@ -106,8 +106,8 @@ def test_vector_find_projection(readonly_vector_collection: AstraDBCollection) -
 
 
 @pytest.mark.describe("vector_find with filters")
-def test_vector_find_filters(readonly_vector_collection: AstraDBCollection) -> None:
-    documents = readonly_vector_collection.vector_find(
+def test_vector_find_filters(readonly_v_collection: AstraDBCollection) -> None:
+    documents = readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         filter={"anotherfield": "alpha"},
         limit=3,
@@ -116,7 +116,7 @@ def test_vector_find_filters(readonly_vector_collection: AstraDBCollection) -> N
     assert len(documents) == 2
     assert {doc["otherfield"]["subfield"] for doc in documents} == {"x1y", "x2y"}
 
-    documents_no = readonly_vector_collection.vector_find(
+    documents_no = readonly_v_collection.vector_find(
         vector=[0.2, 0.6],
         filter={"anotherfield": "epsilon"},
         limit=3,
@@ -126,8 +126,8 @@ def test_vector_find_filters(readonly_vector_collection: AstraDBCollection) -> N
 
 
 @pytest.mark.describe("vector_find_one and include_similarity parameter")
-def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
-    document0 = readonly_vector_collection.vector_find_one(
+def test_vector_find_one(readonly_v_collection: AstraDBCollection) -> None:
+    document0 = readonly_v_collection.vector_find_one(
         [0.2, 0.6],
     )
 
@@ -137,7 +137,7 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in document0
     assert "$similarity" in document0
 
-    document_w_sim = readonly_vector_collection.vector_find_one(
+    document_w_sim = readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         include_similarity=True,
     )
@@ -148,7 +148,7 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in document_w_sim
     assert "$similarity" in document_w_sim
 
-    document_no_sim = readonly_vector_collection.vector_find_one(
+    document_no_sim = readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         include_similarity=False,
     )
@@ -159,7 +159,7 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in document_no_sim
     assert "$similarity" not in document_no_sim
 
-    document_w_fields = readonly_vector_collection.vector_find_one(
+    document_w_fields = readonly_v_collection.vector_find_one(
         [0.2, 0.6], fields=["text"]
     )
 
@@ -169,7 +169,7 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
     assert "text" in document_w_fields
     assert "$similarity" in document_w_fields
 
-    document_no = readonly_vector_collection.vector_find_one(
+    document_no = readonly_v_collection.vector_find_one(
         [0.2, 0.6],
         filter={"nonexisting": "gotcha"},
     )
@@ -179,24 +179,24 @@ def test_vector_find_one(readonly_vector_collection: AstraDBCollection) -> None:
 
 @pytest.mark.describe("vector_find_one_and_update")
 def test_vector_find_one_and_update(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     update = {"$set": {"status": "active"}}
 
-    document0 = disposable_vector_collection.vector_find_one(
+    document0 = disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"status": "active"},
     )
     assert document0 is None
 
-    update_response = disposable_vector_collection.vector_find_one_and_update(
+    update_response = disposable_v_collection.vector_find_one_and_update(
         vector=[0.1, 0.9],
         update=update,
     )
     assert update_response is not None
     assert update_response["_id"] == "1"
 
-    document1 = disposable_vector_collection.vector_find_one(
+    document1 = disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"status": "active"},
     )
@@ -205,7 +205,7 @@ def test_vector_find_one_and_update(
     assert document1["_id"] == update_response["_id"]
     assert document1["status"] == "active"
 
-    update_response_no = disposable_vector_collection.vector_find_one_and_update(
+    update_response_no = disposable_v_collection.vector_find_one_and_update(
         vector=[0.1, 0.9],
         filter={"nonexisting": "gotcha"},
         update=update,
@@ -215,7 +215,7 @@ def test_vector_find_one_and_update(
 
 @pytest.mark.describe("vector_find_one_and_replace")
 def test_vector_find_one_and_replace(
-    disposable_vector_collection: AstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> None:
     replacement0 = {
         "_id": "1",
@@ -224,20 +224,20 @@ def test_vector_find_one_and_replace(
         "$vector": [0.101, 0.899],
     }
 
-    document0 = disposable_vector_collection.vector_find_one(
+    document0 = disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"added_field": True},
     )
     assert document0 is None
 
-    replace_response0 = disposable_vector_collection.vector_find_one_and_replace(
+    replace_response0 = disposable_v_collection.vector_find_one_and_replace(
         vector=[0.1, 0.9],
         replacement=replacement0,
     )
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"
 
-    document1 = disposable_vector_collection.vector_find_one(
+    document1 = disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"added_field": True},
     )
@@ -256,14 +256,14 @@ def test_vector_find_one_and_replace(
         "$vector": [0.101, 0.899],
     }
 
-    replace_response1 = disposable_vector_collection.vector_find_one_and_replace(
+    replace_response1 = disposable_v_collection.vector_find_one_and_replace(
         vector=[0.1, 0.9],
         replacement=replacement1,
     )
     assert replace_response0 is not None
     assert replace_response0["_id"] == "1"
 
-    document2 = disposable_vector_collection.vector_find_one(
+    document2 = disposable_v_collection.vector_find_one(
         vector=[0.1, 0.9],
         filter={"different_added_field": False},
     )
@@ -274,7 +274,7 @@ def test_vector_find_one_and_replace(
     assert "added_field" not in cast(API_DOC, document2)
     assert cast(API_DOC, document2)["different_added_field"] is False
 
-    replace_response_no = disposable_vector_collection.vector_find_one_and_replace(
+    replace_response_no = disposable_v_collection.vector_find_one_and_replace(
         vector=[0.1, 0.9],
         filter={"nonexisting": "gotcha"},
         replacement=replacement1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,19 @@ def disposable_empty_nonvector_collection(db: AstraDB) -> Iterable[AstraDBCollec
 
 
 @pytest.fixture(scope="function")
+async def async_disposable_empty_nonvector_collection(
+    db: AsyncAstraDB,
+) -> AsyncIterable[AsyncAstraDBCollection]:
+    collection = await db.create_collection(
+        TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION,
+    )
+
+    yield collection
+
+    await db.delete_collection(TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION)
+
+
+@pytest.fixture(scope="function")
 def disposable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     collection = db.create_collection(
         TEST_DISPOSABLE_VECTOR_COLLECTION,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,7 +285,7 @@ async def async_writable_nonv_collection(
         await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="function")
 async def async_empty_nonv_collection(
     async_writable_nonv_collection: AsyncAstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,21 @@
 Test fixtures
 """
 import os
+import math
 
 import pytest
 import uuid
-from typing import Dict, Iterable, Optional, AsyncIterable
+from typing import AsyncIterable, Dict, Iterable, List, Optional, TypeVar
 
 import pytest_asyncio
-from dotenv import load_dotenv
+# from dotenv import load_dotenv
 
 from astrapy.defaults import DEFAULT_KEYSPACE_NAME
 from astrapy.db import AstraDB, AstraDBCollection, AsyncAstraDB, AsyncAstraDBCollection
 
-load_dotenv()
+T = TypeVar("T")
+
+# load_dotenv()
 
 ASTRA_DB_APPLICATION_TOKEN = os.environ.get("ASTRA_DB_APPLICATION_TOKEN")
 ASTRA_DB_API_ENDPOINT = os.environ.get("ASTRA_DB_API_ENDPOINT")
@@ -22,8 +25,7 @@ ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_KEYSPACE_NAME)
 # fixed
 TEST_WRITABLE_VECTOR_COLLECTION = "writable_v_col"
 TEST_READONLY_VECTOR_COLLECTION = "readonly_v_col"
-TEST_DISPOSABLE_VECTOR_COLLECTION = "disposable_v_col"
-TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION = "disposable_empty_col"
+TEST_WRITABLE_NONVECTOR_COLLECTION = "writable_nonv_col"
 
 VECTOR_DOCUMENTS = [
     {
@@ -50,6 +52,17 @@ VECTOR_DOCUMENTS = [
 ]
 
 
+def _batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterable[Iterable[T]]:
+    this_batch = []
+    for entry in iterable:
+        this_batch.append(entry)
+        if len(this_batch) == batch_size:
+            yield this_batch
+            this_batch = []
+    if this_batch:
+        yield this_batch
+
+
 @pytest.fixture(scope="session")
 def astra_db_credentials_kwargs() -> Dict[str, Optional[str]]:
     return {
@@ -68,22 +81,12 @@ def astra_invalid_db_credentials_kwargs() -> Dict[str, Optional[str]]:
     }
 
 
-@pytest.fixture(scope="module")
-def cliff_uuid() -> str:
-    return str(uuid.uuid4())
-
-
-@pytest.fixture(scope="module")
-def vv_uuid() -> str:
-    return str(uuid.uuid4())
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def db(astra_db_credentials_kwargs: Dict[str, Optional[str]]) -> AstraDB:
     return AstraDB(**astra_db_credentials_kwargs)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 async def async_db(
     astra_db_credentials_kwargs: Dict[str, Optional[str]]
 ) -> AsyncIterable[AsyncAstraDB]:
@@ -98,8 +101,24 @@ def invalid_db(
     return AstraDB(**astra_invalid_db_credentials_kwargs)
 
 
-@pytest.fixture(scope="module")
-def writable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+@pytest.fixture(scope="session")
+def readonly_v_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
+    collection = db.create_collection(
+        TEST_READONLY_VECTOR_COLLECTION,
+        dimension=2,
+    )
+
+    collection.truncate()
+    collection.insert_many(VECTOR_DOCUMENTS)
+
+    yield collection
+
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
+
+
+@pytest.fixture(scope="session")
+def writable_v_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     """
     This is lasting for the whole test. Functions can write to it,
     no guarantee (i.e. each test should use a different ID...
@@ -109,41 +128,58 @@ def writable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
         dimension=2,
     )
 
-    collection.insert_many(VECTOR_DOCUMENTS)
-
     yield collection
 
-    db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
-@pytest_asyncio.fixture
-async def async_writable_vector_collection(
-    async_db: AsyncAstraDB,
-) -> AsyncIterable[AsyncAstraDBCollection]:
+@pytest.fixture(scope="function")
+def empty_v_collection(
+    writable_v_collection: AstraDBCollection,
+) -> Iterable[AstraDBCollection]:
+    """available empty to each test function."""
+    writable_v_collection.truncate()
+    yield writable_v_collection
+
+
+@pytest.fixture(scope="function")
+def disposable_v_collection(
+    writable_v_collection: AstraDBCollection,
+) -> Iterable[AstraDBCollection]:
+    """available prepopulated to each test function."""
+    writable_v_collection.truncate()
+    writable_v_collection.insert_many(VECTOR_DOCUMENTS)
+    yield writable_v_collection
+
+
+@pytest.fixture(scope="session")
+def writable_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     """
     This is lasting for the whole test. Functions can write to it,
     no guarantee (i.e. each test should use a different ID...
     """
-    collection = await async_db.create_collection(
-        TEST_WRITABLE_VECTOR_COLLECTION,
-        dimension=2,
-    )
-
-    await collection.insert_many(VECTOR_DOCUMENTS)
+    collection = db.create_collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
 
     yield collection
 
-    await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        db.delete_collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
+
+
+@pytest.fixture(scope="function")
+def empty_nonv_collection(
+    writable_nonv_collection: AstraDBCollection,
+) -> Iterable[AstraDBCollection]:
+    """available empty to each test function."""
+    writable_nonv_collection.truncate()
+    yield writable_nonv_collection
 
 
 @pytest.fixture(scope="module")
-def invalid_writable_vector_collection(
+def invalid_writable_v_collection(
     invalid_db: AstraDB,
 ) -> Iterable[AstraDBCollection]:
-    """
-    This is lasting for the whole test. Functions can write to it,
-    no guarantee (i.e. each test should use a different ID...
-    """
     collection = invalid_db.collection(
         TEST_WRITABLE_VECTOR_COLLECTION,
     )
@@ -151,85 +187,136 @@ def invalid_writable_vector_collection(
     yield collection
 
 
-@pytest.fixture(scope="module")
-def readonly_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
-    collection = db.create_collection(
-        TEST_READONLY_VECTOR_COLLECTION,
-        dimension=2,
-    )
+@pytest.fixture(scope="function")
+def pagination_v_collection(empty_v_collection: AstraDBCollection) -> Iterable[AstraDBCollection]:
 
-    collection.insert_many(VECTOR_DOCUMENTS)
+    INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
+    N = 200  # must be EVEN
 
-    yield collection
+    def _mk_vector(index: int, n_total_steps: int) -> List[float]:
+        angle = 2 * math.pi * index / n_total_steps
+        return [math.cos(angle), math.sin(angle)]
 
-    db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
+    inserted_ids: Set[str] = set()
+    for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
+        batch_ids = empty_v_collection.insert_many(
+            documents=[
+                {"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch
+            ]
+        )["status"]["insertedIds"]
+        inserted_ids = inserted_ids | set(batch_ids)
+    assert inserted_ids == {str(i) for i in range(N)}
+
+    yield empty_v_collection
 
 
-@pytest.fixture
-async def async_readonly_vector_collection(
+@pytest_asyncio.fixture(scope="function")
+async def async_readonly_v_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
+    """
+    This is lasting for the whole test. Functions can write to it,
+    no guarantee (i.e. each test should use a different ID...
+    """
     collection = await async_db.create_collection(
         TEST_READONLY_VECTOR_COLLECTION,
         dimension=2,
     )
 
+    await collection.truncate()
     await collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
 
-    await async_db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        await async_db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
 
 
-@pytest.fixture(scope="function")
-def disposable_empty_nonvector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
-    collection = db.create_collection(
-        TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION,
-    )
-
-    yield collection
-
-    db.delete_collection(TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION)
-
-
-@pytest.fixture(scope="function")
-async def async_disposable_empty_nonvector_collection(
-    db: AsyncAstraDB,
-) -> AsyncIterable[AsyncAstraDBCollection]:
-    collection = await db.create_collection(
-        TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION,
-    )
-
-    yield collection
-
-    await db.delete_collection(TEST_DISPOSABLE_EMPTY_NONVECTOR_COLLECTION)
-
-
-@pytest.fixture(scope="function")
-def disposable_vector_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
-    collection = db.create_collection(
-        TEST_DISPOSABLE_VECTOR_COLLECTION,
-        dimension=2,
-    )
-
-    collection.insert_many(VECTOR_DOCUMENTS)
-
-    yield collection
-
-    db.delete_collection(TEST_DISPOSABLE_VECTOR_COLLECTION)
-
-
-@pytest.fixture
-async def async_disposable_vector_collection(
+@pytest_asyncio.fixture(scope="session")
+async def async_writable_v_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
+    """
+    This is lasting for the whole test. Functions can write to it,
+    no guarantee (i.e. each test should use a different ID...
+    """
     collection = await async_db.create_collection(
-        TEST_DISPOSABLE_VECTOR_COLLECTION,
+        TEST_WRITABLE_VECTOR_COLLECTION,
         dimension=2,
     )
 
-    await collection.insert_many(VECTOR_DOCUMENTS)
+    yield collection
+
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def async_empty_v_collection(
+    async_writable_v_collection: AsyncAstraDBCollection,
+) -> AsyncIterable[AsyncAstraDBCollection]:
+    """available empty to each test function."""
+    await async_writable_v_collection.truncate()
+    yield async_writable_v_collection
+
+
+@pytest_asyncio.fixture(scope="function")
+async def async_disposable_v_collection(
+    async_writable_v_collection: AsyncAstraDBCollection,
+) -> AsyncIterable[AsyncAstraDBCollection]:
+    """available prepopulated to each test function."""
+    await async_writable_v_collection.truncate()
+    await async_writable_v_collection.insert_many(VECTOR_DOCUMENTS)
+    yield writable_v_collection
+
+
+@pytest_asyncio.fixture(scope="session")
+async def async_writable_nonv_collection(
+    async_db: AsyncAstraDB,
+) -> AsyncIterable[AsyncAstraDBCollection]:
+    """
+    This is lasting for the whole test. Functions can write to it,
+    no guarantee (i.e. each test should use a different ID...
+    """
+    collection = await async_db.create_collection(
+        TEST_WRITABLE_VECTOR_COLLECTION,
+        dimension=2,
+    )
 
     yield collection
 
-    await async_db.delete_collection(TEST_DISPOSABLE_VECTOR_COLLECTION)
+    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
+        await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
+
+
+@pytest_asyncio.fixture
+async def async_empty_nonv_collection(
+    async_writable_nonv_collection: AsyncAstraDBCollection,
+) -> AsyncIterable[AsyncAstraDBCollection]:
+    """available empty to each test function."""
+    await async_writable_nonv_collection.truncate()
+    yield async_writable_nonv_collection
+
+
+@pytest_asyncio.fixture(scope="function")
+async def async_pagination_v_collection(async_empty_v_collection: AsyncAstraDBCollection) -> AsyncIterable[AsyncAstraDBCollection]:
+
+    INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
+    N = 200  # must be EVEN
+
+    def _mk_vector(index: int, n_total_steps: int) -> List[float]:
+        angle = 2 * math.pi * index / n_total_steps
+        return [math.cos(angle), math.sin(angle)]
+
+    inserted_ids: Set[str] = set()
+    for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
+        insert_response = await async_empty_v_collection.insert_many(
+            documents=[
+                {"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch
+            ]
+        )
+        batch_ids = insert_response["status"]["insertedIds"]
+        inserted_ids = inserted_ids | set(batch_ids)
+    assert inserted_ids == {str(i) for i in range(N)}
+
+    yield async_empty_v_collection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,10 +209,11 @@ def pagination_v_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_readonly_v_collection(
     async_db: AsyncAstraDB,
+    readonly_v_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     collection = await async_db.collection(TEST_READONLY_VECTOR_COLLECTION)
 
@@ -222,10 +223,11 @@ async def async_readonly_v_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_writable_v_collection(
     async_db: AsyncAstraDB,
+    writable_v_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     collection = await async_db.collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
@@ -235,12 +237,13 @@ async def async_writable_v_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_empty_v_collection(
     async_writable_v_collection: AsyncAstraDBCollection,
+    empty_v_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
     available empty to each test function.
 
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     yield async_writable_v_collection
 
@@ -248,12 +251,13 @@ async def async_empty_v_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_disposable_v_collection(
     async_writable_v_collection: AsyncAstraDBCollection,
+    disposable_v_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
     available prepopulated to each test function.
 
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     yield async_writable_v_collection
 
@@ -261,10 +265,11 @@ async def async_disposable_v_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_writable_nonv_collection(
     async_db: AsyncAstraDB,
+    writable_nonv_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     collection = await async_db.collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
 
@@ -274,12 +279,13 @@ async def async_writable_nonv_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_empty_nonv_collection(
     async_writable_nonv_collection: AsyncAstraDBCollection,
+    empty_nonv_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
     available empty to each test function.
 
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     yield async_writable_nonv_collection
 
@@ -287,9 +293,10 @@ async def async_empty_nonv_collection(
 @pytest_asyncio.fixture(scope="function")
 async def async_pagination_v_collection(
     async_empty_v_collection: AsyncAstraDBCollection,
+    pagination_v_collection: AstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This fixture piggybacks on its sync counterspart:
-    it must not do anything to the collection (test functions depend on both)
+    This fixture piggybacks on its sync counterpart (and depends on it):
+    it must not actually do anything to the collection
     """
     yield async_empty_v_collection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def db(astra_db_credentials_kwargs: Dict[str, Optional[str]]) -> AstraDB:
     return AstraDB(**astra_db_credentials_kwargs)
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="function")
 async def async_db(
     astra_db_credentials_kwargs: Dict[str, Optional[str]]
 ) -> AsyncIterable[AsyncAstraDB]:
@@ -228,7 +228,7 @@ async def async_readonly_v_collection(
         await async_db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture(scope="function")
 async def async_writable_v_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
@@ -266,7 +266,7 @@ async def async_disposable_v_collection(
     yield async_writable_v_collection
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture(scope="function")
 async def async_writable_nonv_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,21 +211,12 @@ async def async_readonly_v_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This is lasting for the whole test. Functions can write to it,
-    no guarantee (i.e. each test should use a different ID...
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
     """
-    collection = await async_db.create_collection(
-        TEST_READONLY_VECTOR_COLLECTION,
-        dimension=2,
-    )
-
-    await collection.truncate()
-    await collection.insert_many(VECTOR_DOCUMENTS)
+    collection = await async_db.collection(TEST_READONLY_VECTOR_COLLECTION)
 
     yield collection
-
-    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        await async_db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -233,26 +224,24 @@ async def async_writable_v_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This is lasting for the whole test. Functions can write to it,
-    no guarantee (i.e. each test should use a different ID...
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
     """
-    collection = await async_db.create_collection(
-        TEST_WRITABLE_VECTOR_COLLECTION,
-        dimension=2,
-    )
+    collection = await async_db.collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
     yield collection
-
-    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
 @pytest_asyncio.fixture(scope="function")
 async def async_empty_v_collection(
     async_writable_v_collection: AsyncAstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
-    """available empty to each test function."""
-    await async_writable_v_collection.truncate()
+    """
+    available empty to each test function.
+
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
+    """
     yield async_writable_v_collection
 
 
@@ -260,9 +249,12 @@ async def async_empty_v_collection(
 async def async_disposable_v_collection(
     async_writable_v_collection: AsyncAstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
-    """available prepopulated to each test function."""
-    await async_writable_v_collection.truncate()
-    await async_writable_v_collection.insert_many(VECTOR_DOCUMENTS)
+    """
+    available prepopulated to each test function.
+
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
+    """
     yield async_writable_v_collection
 
 
@@ -271,26 +263,24 @@ async def async_writable_nonv_collection(
     async_db: AsyncAstraDB,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
     """
-    This is lasting for the whole test. Functions can write to it,
-    no guarantee (i.e. each test should use a different ID...
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
     """
-    collection = await async_db.create_collection(
-        TEST_WRITABLE_VECTOR_COLLECTION,
-        dimension=2,
-    )
+    collection = await async_db.collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
 
     yield collection
-
-    if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        await async_db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
 @pytest_asyncio.fixture(scope="function")
 async def async_empty_nonv_collection(
     async_writable_nonv_collection: AsyncAstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
-    """available empty to each test function."""
-    await async_writable_nonv_collection.truncate()
+    """
+    available empty to each test function.
+
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
+    """
     yield async_writable_nonv_collection
 
 
@@ -298,20 +288,8 @@ async def async_empty_nonv_collection(
 async def async_pagination_v_collection(
     async_empty_v_collection: AsyncAstraDBCollection,
 ) -> AsyncIterable[AsyncAstraDBCollection]:
-    INSERT_BATCH_SIZE = 20  # max 20, fixed by API constraints
-    N = 200  # must be EVEN
-
-    def _mk_vector(index: int, n_total_steps: int) -> List[float]:
-        angle = 2 * math.pi * index / n_total_steps
-        return [math.cos(angle), math.sin(angle)]
-
-    inserted_ids: Set[str] = set()
-    for i_batch in _batch_iterable(range(N), INSERT_BATCH_SIZE):
-        insert_response = await async_empty_v_collection.insert_many(
-            documents=[{"_id": str(i), "$vector": _mk_vector(i, N)} for i in i_batch]
-        )
-        batch_ids = insert_response["status"]["insertedIds"]
-        inserted_ids = inserted_ids | set(batch_ids)
-    assert inserted_ids == {str(i) for i in range(N)}
-
+    """
+    This fixture piggybacks on its sync counterspart:
+    it must not do anything to the collection (test functions depend on both)
+    """
     yield async_empty_v_collection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def readonly_v_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
         dimension=2,
     )
 
-    collection.truncate()
+    collection.clear()
     collection.insert_many(VECTOR_DOCUMENTS)
 
     yield collection
@@ -136,7 +136,7 @@ def empty_v_collection(
     writable_v_collection: AstraDBCollection,
 ) -> Iterable[AstraDBCollection]:
     """available empty to each test function."""
-    writable_v_collection.truncate()
+    writable_v_collection.clear()
     yield writable_v_collection
 
 
@@ -145,7 +145,7 @@ def disposable_v_collection(
     writable_v_collection: AstraDBCollection,
 ) -> Iterable[AstraDBCollection]:
     """available prepopulated to each test function."""
-    writable_v_collection.truncate()
+    writable_v_collection.clear()
     writable_v_collection.insert_many(VECTOR_DOCUMENTS)
     yield writable_v_collection
 
@@ -169,7 +169,7 @@ def empty_nonv_collection(
     writable_nonv_collection: AstraDBCollection,
 ) -> Iterable[AstraDBCollection]:
     """available empty to each test function."""
-    writable_nonv_collection.truncate()
+    writable_nonv_collection.clear()
     yield writable_nonv_collection
 
 


### PR DESCRIPTION
Closes #166 

This introduces usage of delete_many with empty payload for truncation instead of the drop-and-recreate previous flow. It also exposes a `truncate()` method at collection-level.

What is more, a massive overhaul of the tests is enabled by this, which optimizes DDL usage minimizing the amount of collection deletions through a stack of nested fixtures and truncations at the right layer in this stack.

Additionally, it is now possible to set `TEST_ASTRADBOPS=1` to skip the truncations entirely and have the tests complete in barely two minutes under current Astra DB conditions.