### PR TITLE
Add tests for collection "indexing" settings

### DIFF
--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -1323,3 +1323,53 @@ def test_insert_find_with_dates(
     assert response3 is not None
     document3 = response3["data"]["document"]
     assert document3 == expected_d_document
+
+
+@pytest.mark.describe("probe retrieval on a collection indexed with allowlist")
+def test_collection_indexing_allow(
+    allowindex_nonv_collection: AstraDBCollection,
+) -> None:
+    resp_ok1 = allowindex_nonv_collection.find_one({"A.a": "A.a"})
+    assert resp_ok1["data"]["document"] is not None
+    assert resp_ok1["data"]["document"]["_id"] == "0"
+
+    resp_ok2 = allowindex_nonv_collection.find_one({"C.a": "C.a"})
+    assert resp_ok2["data"]["document"] is not None
+    assert resp_ok2["data"]["document"]["_id"] == "0"
+
+    with pytest.raises(APIRequestError):
+        # path not indexed
+        allowindex_nonv_collection.find_one({"B.a": "B.a"})
+
+    with pytest.raises(APIRequestError):
+        # path not indexed
+        allowindex_nonv_collection.find_one({"C.b": "C.b"})
+
+    with pytest.raises(APIRequestError):
+        # id not indexed (raised only with some operators, such as $nin)
+        allowindex_nonv_collection.find_one({"_id": {"$nin": ["1", "2"]}})
+
+
+@pytest.mark.describe("probe retrieval on a collection indexed with denylist")
+def test_collection_indexing_deny(
+    denyindex_nonv_collection: AstraDBCollection,
+) -> None:
+    resp_ok1 = denyindex_nonv_collection.find_one({"A.a": "A.a"})
+    assert resp_ok1["data"]["document"] is not None
+    assert resp_ok1["data"]["document"]["_id"] == "0"
+
+    resp_ok2 = denyindex_nonv_collection.find_one({"C.a": "C.a"})
+    assert resp_ok2["data"]["document"] is not None
+    assert resp_ok2["data"]["document"]["_id"] == "0"
+
+    with pytest.raises(APIRequestError):
+        # path not indexed
+        denyindex_nonv_collection.find_one({"B.a": "B.a"})
+
+    with pytest.raises(APIRequestError):
+        # path not indexed
+        denyindex_nonv_collection.find_one({"C.b": "C.b"})
+
+    with pytest.raises(APIRequestError):
+        # id not indexed (raised only with some operators, such as $nin)
+        denyindex_nonv_collection.find_one({"_id": {"$nin": ["1", "2"]}})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,7 @@ def writable_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
         db.delete_collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def allowindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     """
     This is lasting for the whole test. Functions can write to it,
@@ -207,7 +207,7 @@ def allowindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
         db.delete_collection(TEST_WRITABLE_ALLOWINDEX_NONVECTOR_COLLECTION)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def denyindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     """
     This is lasting for the whole test. Functions can write to it,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,7 @@ def denyindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     This is lasting for the whole test. Functions can write to it,
     no guarantee (i.e. each test should use a different ID...
 
-    Note in light of the sample document this results in the same
+    Note in light of the sample document this almost results in the same
     filtering paths being available ... if one remembers to deny _id here.
     """
     collection = db.create_collection(


### PR DESCRIPTION
This PR adds two test on two new collections created with different non-default indexing settings: one is allow-list based, the other is deny-list based. Various filters are tested and it is verified they work (or don't) as expected.

I did not deem it necessary to double these tests in the async half of tests.

Tested in dev, 100% pass.
**Do not merge yet**, until the indexing makes it to prod.

Note: with these, the collections used in the test are now five. To avoid the "too many collections" error breaking the create-and-then-destroy-collection tests, these two are scoped to function (there are only 1 function using each of the two, anyway). In case deletions are suspended, no problem again since the tests at risk would be skipped.
