### PR TITLE
Fix #186 - token and api endpoint not optional

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -1867,8 +1867,8 @@ class AstraDB:
         """
         Initialize an Astra DB instance.
         Args:
-            token (str, optional): Authentication token for Astra DB.
-            api_endpoint (str, optional): API endpoint URL.
+            token (str): Authentication token for Astra DB.
+            api_endpoint (str): API endpoint URL.
             namespace (str, optional): Namespace for the database.
         """
         if token is None or api_endpoint is None:
@@ -2099,8 +2099,8 @@ class AsyncAstraDB:
         """
         Initialize an Astra DB instance.
         Args:
-            token (str, optional): Authentication token for Astra DB.
-            api_endpoint (str, optional): API endpoint URL.
+            token (str): Authentication token for Astra DB.
+            api_endpoint (str): API endpoint URL.
             namespace (str, optional): Namespace for the database.
         """
         self.client = httpx.AsyncClient()

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -1858,8 +1858,8 @@ class AstraDB:
 
     def __init__(
         self,
-        token: Optional[str] = None,
-        api_endpoint: Optional[str] = None,
+        token: str,
+        api_endpoint: str,
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
         namespace: Optional[str] = None,
@@ -2090,8 +2090,8 @@ class AstraDB:
 class AsyncAstraDB:
     def __init__(
         self,
-        token: Optional[str] = None,
-        api_endpoint: Optional[str] = None,
+        token: str,
+        api_endpoint: str,
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
         namespace: Optional[str] = None,

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -35,24 +35,30 @@ logger = logging.getLogger(__name__)
 async def test_path_handling(
     astra_db_credentials_kwargs: Dict[str, Optional[str]]
 ) -> None:
-    async with AsyncAstraDB(**astra_db_credentials_kwargs) as astra_db_1:
+    token = astra_db_credentials_kwargs["token"]
+    api_endpoint = astra_db_credentials_kwargs["api_endpoint"]
+    namespace = astra_db_credentials_kwargs.get("namespace")
+
+    if token is None or api_endpoint is None:
+        raise ValueError("Required ASTRA DB configuration is missing")
+
+    async with AsyncAstraDB(
+        token=token, api_endpoint=api_endpoint, namespace=namespace
+    ) as astra_db_1:
         url_1 = astra_db_1.base_path
 
     async with AsyncAstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="v1",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="v1"
     ) as astra_db_2:
         url_2 = astra_db_2.base_path
 
     async with AsyncAstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="/v1",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="/v1"
     ) as astra_db_3:
         url_3 = astra_db_3.base_path
 
     async with AsyncAstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="/v1/",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="/v1/"
     ) as astra_db_4:
         url_4 = astra_db_4.base_path
 
@@ -60,15 +66,9 @@ async def test_path_handling(
 
     # autofill of the default keyspace name
     async with AsyncAstraDB(
-        **{
-            **astra_db_credentials_kwargs,
-            **{"namespace": DEFAULT_KEYSPACE_NAME},
-        }
+        token=token, api_endpoint=api_endpoint, namespace=DEFAULT_KEYSPACE_NAME
     ) as unspecified_ks_client, AsyncAstraDB(
-        **{
-            **astra_db_credentials_kwargs,
-            **{"namespace": None},
-        }
+        token=token, api_endpoint=api_endpoint, namespace=None
     ) as explicit_ks_client:
         assert unspecified_ks_client.base_path == explicit_ks_client.base_path
 

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -33,46 +33,39 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.describe("should confirm path handling in constructor")
 def test_path_handling(astra_db_credentials_kwargs: Dict[str, Optional[str]]) -> None:
-    astra_db_1 = AstraDB(**astra_db_credentials_kwargs)
+    token = astra_db_credentials_kwargs["token"]
+    api_endpoint = astra_db_credentials_kwargs["api_endpoint"]
+    namespace = astra_db_credentials_kwargs.get("namespace")
 
+    if token is None or api_endpoint is None:
+        raise ValueError("Required ASTRA DB configuration is missing")
+
+    astra_db_1 = AstraDB(token=token, api_endpoint=api_endpoint, namespace=namespace)
     url_1 = astra_db_1.base_path
 
     astra_db_2 = AstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="v1",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="v1"
     )
-
     url_2 = astra_db_2.base_path
 
     astra_db_3 = AstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="/v1",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="/v1"
     )
-
     url_3 = astra_db_3.base_path
 
     astra_db_4 = AstraDB(
-        **astra_db_credentials_kwargs,
-        api_version="/v1/",
+        token=token, api_endpoint=api_endpoint, namespace=namespace, api_version="/v1/"
     )
-
     url_4 = astra_db_4.base_path
 
     assert url_1 == url_2 == url_3 == url_4
 
     # autofill of the default keyspace name
     unspecified_ks_client = AstraDB(
-        **{
-            **astra_db_credentials_kwargs,
-            **{"namespace": DEFAULT_KEYSPACE_NAME},
-        }
+        token=token, api_endpoint=api_endpoint, namespace=DEFAULT_KEYSPACE_NAME
     )
-    explicit_ks_client = AstraDB(
-        **{
-            **astra_db_credentials_kwargs,
-            **{"namespace": None},
-        }
-    )
+    explicit_ks_client = AstraDB(token=token, api_endpoint=api_endpoint, namespace=None)
+
     assert unspecified_ks_client.base_path == explicit_ks_client.base_path
 
 


### PR DESCRIPTION
Note that this applies specifically to the AstraDB (and async version) classes - for the Collection classes, one can provide either an astra_db instance already initialized OR pass a (token + endpoint). So those have been left as is.