### PR TITLE
Adjust and test for TRACE logging

### DIFF
--- a/astrapy/utils.py
+++ b/astrapy/utils.py
@@ -14,7 +14,7 @@ from astrapy.types import API_RESPONSE
 class CustomLogger(logging.Logger):
     def trace(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.isEnabledFor(5):
-            self._log(5, msg, *args, **kwargs)
+            self._log(5, msg, args, **kwargs)
 
 
 # Add a new TRACE logging level
@@ -22,10 +22,6 @@ logging.addLevelName(5, "TRACE")
 
 # Tell the logging system to use your custom logger
 logging.setLoggerClass(CustomLogger)
-
-# Now you can use the trace method on your logger instances
-logger = logging.getLogger(__name__)
-logger.trace("This is a trace message")  # type: ignore
 
 
 logger = logging.getLogger(__name__)

--- a/tests/astrapy/test_logging.py
+++ b/tests/astrapy/test_logging.py
@@ -1,0 +1,48 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the "TRACE" custom logging level
+"""
+
+import logging
+
+import pytest
+
+from ..conftest import AstraDBCredentials
+from astrapy.db import AstraDB
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.describe("should obey the 'TRACE' logging level when requested")
+def test_trace_logging_trace(
+    caplog: pytest.LogCaptureFixture,
+    astra_db_credentials_kwargs: AstraDBCredentials,
+) -> None:
+    astra_db = AstraDB(**astra_db_credentials_kwargs)
+    with caplog.at_level(10):
+        astra_db.get_collections()
+        for record in caplog.records:
+            assert record.levelname != "TRACE"
+    caplog.clear()
+    # TRACE is level 5:
+    with caplog.at_level(5):
+        astra_db.get_collections()
+        trace_records = [
+            record for record in caplog.records if record.levelname == "TRACE"
+        ]
+        assert len(trace_records) == 1
+        assert "findCollections" in trace_records[0].msg


### PR DESCRIPTION
Fixes #191 .

Besides fixing the trace-logging command (which was erroring due to there being an `*args` where just `args` should have been), this also adds a specific test to see that such logging is working and indeed obeyed.

All test _would_ pass - at least locally for me, except the (unrelated) `__version__` autodetect logic fails on my poetry environment (detecting a much-too-old 0.6.2), so that the expected deprecation warnings are ("not yet") raised and a few tests fail because of that.
