### PR TITLE
adding the forgotten tests for user agent

### DIFF
--- a/tests/astrapy/test_user_agent.py
+++ b/tests/astrapy/test_user_agent.py
@@ -22,7 +22,13 @@ from pytest_httpserver import HTTPServer
 
 from astrapy import __version__
 from astrapy.utils import compose_user_agent, package_name
-from astrapy.db import AstraDB
+from astrapy.db import (
+    AstraDB,
+    AstraDBCollection,
+    AsyncAstraDB,
+    AsyncAstraDBCollection,
+)
+from astrapy.ops import AstraDBOps
 
 
 logger = logging.getLogger(__name__)
@@ -48,8 +54,8 @@ def test_compose_user_agent() -> None:
     )
 
 
-@pytest.mark.describe("test user-agent in the standard way for AstraDB")
-def test_useragent_astradb_standard(httpserver: HTTPServer) -> None:
+@pytest.mark.describe("test user-agent for AstraDB")
+def test_useragent_astradb(httpserver: HTTPServer) -> None:
     root_endpoint = httpserver.url_for("/")
     my_db = AstraDB(
         token="token",
@@ -57,7 +63,6 @@ def test_useragent_astradb_standard(httpserver: HTTPServer) -> None:
         namespace="ns",
     )
     expected_url = f"{my_db.base_path}"
-
     httpserver.expect_request(
         expected_url,
         method="POST",
@@ -65,5 +70,143 @@ def test_useragent_astradb_standard(httpserver: HTTPServer) -> None:
             "user-agent": compose_user_agent(caller_name=None, caller_version=None)
         },
     ).respond_with_data("{}")
-
     my_db.get_collections()
+
+    my_db.set_caller(caller_name="CN", caller_version="CV")
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name="CN", caller_version="CV")
+        },
+    ).respond_with_data("{}")
+    my_db.get_collections()
+
+
+@pytest.mark.describe("test user-agent for AstraDBCollection")
+def test_useragent_astradbcollection(httpserver: HTTPServer) -> None:
+    root_endpoint = httpserver.url_for("/")
+    my_coll = AstraDBCollection(
+        "c1",
+        token="token",
+        api_endpoint=root_endpoint,
+        namespace="ns",
+    )
+    expected_url = f"{my_coll.base_path}"
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name=None, caller_version=None)
+        },
+    ).respond_with_data("{}")
+    my_coll.find()
+
+    my_coll.set_caller(caller_name="CN", caller_version="CV")
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name="CN", caller_version="CV")
+        },
+    ).respond_with_data("{}")
+    my_coll.find()
+
+
+@pytest.mark.describe("test user-agent for AstraDB (async)")
+async def test_useragent_astradb_async(httpserver: HTTPServer) -> None:
+    root_endpoint = httpserver.url_for("/")
+    my_db = AsyncAstraDB(
+        token="token",
+        api_endpoint=root_endpoint,
+        namespace="ns",
+    )
+    expected_url = f"{my_db.base_path}"
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name=None, caller_version=None)
+        },
+    ).respond_with_data("{}")
+    await my_db.get_collections()
+
+    my_db.set_caller(caller_name="CN", caller_version="CV")
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name="CN", caller_version="CV")
+        },
+    ).respond_with_data("{}")
+    await my_db.get_collections()
+
+
+@pytest.mark.describe("test user-agent for AstraDBCollection (async)")
+async def test_useragent_astradbcollection_async(httpserver: HTTPServer) -> None:
+    root_endpoint = httpserver.url_for("/")
+    my_coll = AsyncAstraDBCollection(
+        "c1",
+        token="token",
+        api_endpoint=root_endpoint,
+        namespace="ns",
+    )
+    expected_url = f"{my_coll.base_path}"
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name=None, caller_version=None)
+        },
+    ).respond_with_data("{}")
+    await my_coll.find()
+
+    my_coll.set_caller(caller_name="CN", caller_version="CV")
+    httpserver.expect_request(
+        expected_url,
+        method="POST",
+        headers={
+            "user-agent": compose_user_agent(caller_name="CN", caller_version="CV")
+        },
+    ).respond_with_data("{}")
+    await my_coll.find()
+
+
+@pytest.mark.describe("test user-agent for AstraDBOps")
+def test_useragent_astradbops(httpserver: HTTPServer) -> None:
+    root_endpoint = httpserver.url_for("/")
+    my_ops = AstraDBOps(
+        token="token",
+    )
+    # A TWEAK (pending resolution of #197)
+    my_ops.base_url = my_ops.base_url.replace(
+        "https://api.astra.datastax.com/",
+        root_endpoint,  # such as "http://localhost:44385/"
+    )
+
+    # this is to have the right relative path for httpserver ("/v2/databases")
+    expected_url = (
+        my_ops.base_url.replace(
+            root_endpoint,
+            "/",
+        )
+        + "/databases"
+    )
+    httpserver.expect_request(
+        expected_url,
+        method="GET",
+        headers={
+            "user-agent": compose_user_agent(caller_name=None, caller_version=None)
+        },
+    ).respond_with_data("{}")
+    my_ops.get_databases()
+
+    my_ops.set_caller(caller_name="CN", caller_version="CV")
+    httpserver.expect_request(
+        expected_url,
+        method="GET",
+        headers={
+            "user-agent": compose_user_agent(caller_name="CN", caller_version="CV")
+        },
+    ).respond_with_data("{}")
+    my_ops.get_databases()


### PR DESCRIPTION
It turns out that when submitting the caller-identity PR I forgot to check in the latest test for the user-agent requests. Here it is, sorry about that.