### PR TITLE
Database metadata through name, id, region

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -952,6 +952,18 @@ class AstraDBCollection:
             )
 
         return clear_response
+    
+    def drop(self) -> API_RESPONSE:
+        """
+        Drop the collection, deleting all documents
+        Returns:
+            dict: The response from the database.
+        """
+        drop_response = self.database.delete_collection(
+            collection_name=self.collection_name
+        )
+
+        return drop_response
 
     def delete_subdocument(self, id: str, subdoc: str) -> API_RESPONSE:
         """

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -959,7 +959,7 @@ class AstraDBCollection:
         Returns:
             dict: The response from the database.
         """
-        drop_response = self.database.delete_collection(
+        drop_response = self.database.drop_collection(
             collection_name=self.collection_name
         )
 
@@ -2369,7 +2369,7 @@ class AstraDB:
         # Get the instance object as the return of the call
         return AstraDBCollection(astra_db=self, collection_name=collection_name)
 
-    def delete_collection(self, collection_name: str) -> API_RESPONSE:
+    def drop_collection(self, collection_name: str) -> API_RESPONSE:
         """
         Delete a collection from the database.
         Args:
@@ -2675,7 +2675,7 @@ class AsyncAstraDB:
         # Get the instance object as the return of the call
         return AsyncAstraDBCollection(astra_db=self, collection_name=collection_name)
 
-    async def delete_collection(self, collection_name: str) -> API_RESPONSE:
+    async def drop_collection(self, collection_name: str) -> API_RESPONSE:
         """
         Delete a collection from the database.
         Args:

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -64,6 +64,16 @@ from astrapy.types import (
     AsyncPaginableRequestMethod,
 )
 
+client_options = {
+            'token': "",
+            'api_endpoint': "",
+            'api_path': "",
+            'api_version': "",
+            'namespace': "",
+            'caller_name': "",
+            'caller_version': ""
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -2127,6 +2137,7 @@ class AstraDB:
             caller_name (str, optional): identity of the caller ("my_framework")
             caller_version (str, optional): version of the caller code ("1.0.3")
         """
+
         self.caller_name = caller_name
         self.caller_version = caller_version
 
@@ -2154,7 +2165,6 @@ class AstraDB:
         # Set the namespace
         self.namespace = namespace
 
-
         # Finally, construct the full base path
         self.base_path = f"/{self.api_path}/{self.api_version}/{self.namespace}"
 
@@ -2166,10 +2176,11 @@ class AstraDB:
             details = astraDBOps.get_database(database=self.dbid)
             self.name = details['info']['name']
             self.region = details['info']['region']
-            print (self.region)
         else:
             self.name = ""
             self.region = ""
+        
+        self.client_options = client_options
 
     def __repr__(self) -> str:
         return f'AstraDB[endpoint="{self.base_url}", keyspace="{self.namespace}"]'

--- a/tests/astrapy/test_async_db_ddl.py
+++ b/tests/astrapy/test_async_db_ddl.py
@@ -97,7 +97,7 @@ async def test_create_use_destroy_nonvector_collection(async_db: AsyncAstraDB) -
     auto_id = [id for id in ids if id not in {"second", "last"}][0]
     await col.delete_one(auto_id)
     assert (await col.find_one(filter={"name": "c"}))["data"]["document"] is None
-    del_res = await async_db.delete_collection(
+    del_res = await async_db.drop_collection(
         TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME
     )
     assert del_res["status"]["ok"] == 1
@@ -113,7 +113,7 @@ async def test_create_use_destroy_vector_collection(async_db: AsyncAstraDB) -> N
         collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
     )
     assert isinstance(col, AsyncAstraDBCollection)
-    del_res = await async_db.delete_collection(
+    del_res = await async_db.drop_collection(
         collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
     )
     assert del_res["status"]["ok"] == 1

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -96,6 +96,14 @@ def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
     del_res = db.delete_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
     assert del_res["status"]["ok"] == 1
 
+@pytest.mark.describe("should get information about the database")
+def test_db_info(db: AstraDB) -> None:
+    name = db.name
+    region = db.region
+    id = db.dbid
+    assert name is not None
+    assert region is not None
+    assert id is not None
 
 @pytest.mark.skipif(
     int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
@@ -113,8 +121,13 @@ def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
     assert del_res["status"]["ok"] == 1
 
 
+
 @pytest.mark.describe("should get all collections")
 def test_get_collections(db: AstraDB, readonly_v_collection: AstraDBCollection) -> None:
     res = db.get_collections()
     assert res["status"]["collections"] is not None
     assert readonly_v_collection.collection_name in res["status"]["collections"]
+
+@pytest.mark.describe("should get database information")
+def test_database_(db: AstraDB, readonly_v_collection: AstraDBCollection) -> None:
+    res = db.get_collections()

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -101,9 +101,11 @@ def test_db_info(db: AstraDB) -> None:
     name = db.name
     region = db.region
     id = db.dbid
+    client_options = db.client_options
     assert name is not None
     assert region is not None
     assert id is not None
+    assert client_options is not None
 
 @pytest.mark.skipif(
     int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -93,7 +93,7 @@ def test_create_use_destroy_nonvector_collection(db: AstraDB) -> None:
     auto_id = [id for id in ids if id not in {"second", "last"}][0]
     col.delete(auto_id)
     assert col.find_one(filter={"name": "c"})["data"]["document"] is None
-    del_res = db.delete_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
+    del_res = db.drop_collection(TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME)
     assert del_res["status"]["ok"] == 1
 
 @pytest.mark.describe("should get information about the database")
@@ -117,7 +117,7 @@ def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
         collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
     )
     assert isinstance(col, AstraDBCollection)
-    del_res = db.delete_collection(
+    del_res = db.drop_collection(
         collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
     )
     assert del_res["status"]["ok"] == 1

--- a/tests/astrapy/test_db_ddl.py
+++ b/tests/astrapy/test_db_ddl.py
@@ -122,6 +122,20 @@ def test_create_use_destroy_vector_collection(db: AstraDB) -> None:
     )
     assert del_res["status"]["ok"] == 1
 
+@pytest.mark.skipif(
+    int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 1,
+    reason="collection-deletion tests are suppressed",
+)
+@pytest.mark.describe("should create and destroy a vector collection using collection drop method")
+def test_create_destroy_from_collection_drop(db: AstraDB) -> None:
+    col = db.create_collection(
+        collection_name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
+    )
+    assert isinstance(col, AstraDBCollection)
+    del_res = col.drop()
+
+    assert del_res["status"]["ok"] == 1
+
 
 
 @pytest.mark.describe("should get all collections")

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -1277,6 +1277,16 @@ def test_unsupported_operation(
         writable_v_collection.aggregate()
 
 
+@pytest.mark.describe("check database metainfo for collection")
+def test_unsupported_operation(
+    writable_v_collection: AstraDBCollection,
+) -> None:
+    assert writable_v_collection.database != None
+    assert writable_v_collection.full_name != None
+    assert writable_v_collection.name != None
+
+
+
 @pytest.mark.describe("store and retrieve dates and datetimes correctly")
 def test_insert_find_with_dates(
     writable_v_collection: AstraDBCollection,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,7 @@ def readonly_v_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     yield collection
 
     if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        db.delete_collection(TEST_READONLY_VECTOR_COLLECTION)
+        db.drop_collection(TEST_READONLY_VECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="session")
@@ -190,7 +190,7 @@ def writable_v_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     yield collection
 
     if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        db.delete_collection(TEST_WRITABLE_VECTOR_COLLECTION)
+        db.drop_collection(TEST_WRITABLE_VECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="function")
@@ -223,7 +223,7 @@ def writable_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     yield collection
 
     if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        db.delete_collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
+        db.drop_collection(TEST_WRITABLE_NONVECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="function")
@@ -248,7 +248,7 @@ def allowindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     yield collection
 
     if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        db.delete_collection(TEST_WRITABLE_ALLOWINDEX_NONVECTOR_COLLECTION)
+        db.drop_collection(TEST_WRITABLE_ALLOWINDEX_NONVECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="function")
@@ -277,7 +277,7 @@ def denyindex_nonv_collection(db: AstraDB) -> Iterable[AstraDBCollection]:
     yield collection
 
     if int(os.getenv("TEST_SKIP_COLLECTION_DELETE", "0")) == 0:
-        db.delete_collection(TEST_WRITABLE_DENYINDEX_NONVECTOR_COLLECTION)
+        db.drop_collection(TEST_WRITABLE_DENYINDEX_NONVECTOR_COLLECTION)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Added dbops calls to the astraDB creation to gather name, id, and region.  Exposed through attributes:
astradb.name
astradb.region
astradb.id

Additionally added "name, full_name" to collections as well as the database
col.name
col.fullname
col.database

Also added client_options at the DB level.  It is set outside the class so we could expose it at the collection level or within the asyncs.

Also added collection.drop() and changed db.delete_collection() to db.drop_collection()

Tests for everything, everything is passing.

Document with needed items: https://docs.google.com/spreadsheets/d/1ykhgGAqgxdnGJfOWevGDCcD3K6cZPxlGtN99bZTt_S4/edit#gid=2080544998
