### PR TITLE
Pymongo codec options

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -113,6 +113,9 @@ class AstraDBCollection:
         self.collection_name = collection_name
         self.base_path = f"{self.astra_db.base_path}/{self.collection_name}"
 
+        # Set read concern to "NEAREST"
+        self.read_preference = "NEAREST"
+
     def __repr__(self) -> str:
         return f'AstraDBCollection[astra_db="{self.astra_db}", collection_name="{self.collection_name}"]'
 
@@ -2269,6 +2272,7 @@ class AstraDB:
             path=f"{self.base_path}",
             json_data={"createCollection": jsondata},
         )
+
 
         # Get the instance object as the return of the call
         return AstraDBCollection(astra_db=self, collection_name=collection_name)

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -115,6 +115,7 @@ class AstraDBCollection:
 
         # Set read concern to "NEAREST"
         self.read_preference = "NEAREST"
+        self.codec_options = []
 
     def __repr__(self) -> str:
         return f'AstraDBCollection[astra_db="{self.astra_db}", collection_name="{self.collection_name}"]'

--- a/tests/astrapy/test_db_dml.py
+++ b/tests/astrapy/test_db_dml.py
@@ -1274,6 +1274,12 @@ def test_unsupported_operation(
     with pytest.raises(Exception):
         writeable_v_collection.aggregate()
 
+@pytest.mark.describe("test read preference")
+def test_read_preference(
+    writable_v_collection: AstraDBCollection,
+) -> None:
+    assert writable_v_collection.read_preference is not None
+
 @pytest.mark.describe("store and retrieve dates and datetimes correctly")
 def test_insert_find_with_dates(
     writable_v_collection: AstraDBCollection,
@@ -1398,3 +1404,5 @@ def test_collection_indexing_deny(
     with pytest.raises(APIRequestError):
         # id not indexed (raised only with some operators, such as $nin)
         denyindex_nonv_collection.find_one({"_id": {"$nin": ["1", "2"]}})
+
+    


### PR DESCRIPTION
Adding codec_options to the collection level.  Currently an empty list because we don't support those items.