### PR TITLE
Mongodb collection drop function

### DIFF
--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -90,6 +90,9 @@ class Collection:
             caller_version=caller_version,
         )
 
+    def drop(self, collection_name: str) -> API_RESPONSE:
+        return self.astra_db.delete_collection(collection_name)
+
     @unsupported
     def find_raw_batches(*pargs: Any, **kwargs: Any) -> Any: ...
 
@@ -196,6 +199,10 @@ class AsyncCollection:
             caller_name=caller_name,
             caller_version=caller_version,
         )
+
+    async def drop(self, collection_name: str) -> API_RESPONSE:
+        return await self.astra_db.delete_collection(collection_name)
+
 
     @unsupported
     async def find_raw_batches(*pargs: Any, **kwargs: Any) -> Any: ...

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -91,7 +91,7 @@ class Collection:
         )
 
     def drop(self, collection_name: str) -> API_RESPONSE:
-        return self.astra_db.delete_collection(collection_name)
+        return self.database.delete_collection(collection_name)
 
     @unsupported
     def find_raw_batches(*pargs: Any, **kwargs: Any) -> Any: ...
@@ -201,7 +201,7 @@ class AsyncCollection:
         )
 
     async def drop(self, collection_name: str) -> API_RESPONSE:
-        return await self.astra_db.delete_collection(collection_name)
+        return await self.database.delete_collection(collection_name)
 
 
     @unsupported

--- a/tests/idiomatic/conftest.py
+++ b/tests/idiomatic/conftest.py
@@ -9,6 +9,7 @@ from astrapy import AsyncCollection, AsyncDatabase, Collection, Database
 
 TEST_COLLECTION_INSTANCE_NAME = "test_coll_instance"
 TEST_COLLECTION_NAME = "id_test_collection"
+TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"
 
 ASTRA_DB_SECONDARY_KEYSPACE = os.environ.get("ASTRA_DB_SECONDARY_KEYSPACE")
 

--- a/tests/idiomatic/integration/test_collections_async.py
+++ b/tests/idiomatic/integration/test_collections_async.py
@@ -16,6 +16,8 @@ import pytest
 
 from astrapy import AsyncCollection, AsyncDatabase
 
+TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"
+TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME = "ephemeral_non_v_col"
 
 class TestCollectionsAsync:
     @pytest.mark.describe("test of instantiating Collection, async")
@@ -73,6 +75,17 @@ class TestCollectionsAsync:
             caller_version="c_v1",
         )
         assert col1 == col2
+
+    @pytest.mark.describe("should create and destroy a vector collection using collection drop (async)")
+    async def test_create_destroy_collection(self, async_database: AsyncDatabase) -> None:
+        col = await async_database.create_collection(
+            name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
+        )
+        assert isinstance(col, AsyncCollection)
+        del_res = await col.drop(
+            TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
+        )
+        assert del_res["status"]["ok"] == 1
 
     @pytest.mark.describe("test errors for unsupported Collection methods, async")
     async def test_collection_unsupported_methods_async(

--- a/tests/idiomatic/integration/test_collections_async.py
+++ b/tests/idiomatic/integration/test_collections_async.py
@@ -16,9 +16,6 @@ import pytest
 
 from astrapy import AsyncCollection, AsyncDatabase
 
-TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME = "ephemeral_v_col"
-TEST_CREATE_DELETE_NONVECTOR_COLLECTION_NAME = "ephemeral_non_v_col"
-
 class TestCollectionsAsync:
     @pytest.mark.describe("test of instantiating Collection, async")
     async def test_instantiate_collection_async(
@@ -75,17 +72,6 @@ class TestCollectionsAsync:
             caller_version="c_v1",
         )
         assert col1 == col2
-
-    @pytest.mark.describe("should create and destroy a vector collection using collection drop (async)")
-    async def test_create_destroy_collection(self, async_database: AsyncDatabase) -> None:
-        col = await async_database.create_collection(
-            name=TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME, dimension=2
-        )
-        assert isinstance(col, AsyncCollection)
-        del_res = await col.drop(
-            TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
-        )
-        assert del_res["status"]["ok"] == 1
 
     @pytest.mark.describe("test errors for unsupported Collection methods, async")
     async def test_collection_unsupported_methods_async(

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -35,16 +35,6 @@ class TestDDLAsync:
         assert col1 == col2
         await async_database.drop_collection(TEST_LOCAL_COLLECTION_NAME)
 
-    @pytest.mark.describe("should create and destroy a vector collection using collection drop (async)")
-    async def async_test_create_destroy_collection(self, async_database: AsyncDatabase) -> None:
-        col = await async_database.create_collection(
-            name="test_col_drop", dimension=2
-        )
-        assert isinstance(col, AsyncCollection)
-        del_res = await col.drop(
-            "test_col_drop"
-        )
-        assert del_res["status"]["ok"] == 1
 
     @pytest.mark.describe("test of Database list_collections, async")
     async def test_database_list_collections_async(

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from ..conftest import ASTRA_DB_SECONDARY_KEYSPACE, TEST_COLLECTION_NAME
+from ..conftest import ASTRA_DB_SECONDARY_KEYSPACE, TEST_COLLECTION_NAME, TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
 from astrapy import AsyncCollection, AsyncDatabase
 
 
@@ -34,6 +34,17 @@ class TestDDLAsync:
         col2 = await async_database.get_collection(TEST_LOCAL_COLLECTION_NAME)
         assert col1 == col2
         await async_database.drop_collection(TEST_LOCAL_COLLECTION_NAME)
+
+    @pytest.mark.describe("should create and destroy a vector collection using collection drop (async)")
+    async def async_test_create_destroy_collection(self, async_database: AsyncDatabase) -> None:
+        col = await async_database.create_collection(
+            name="test_col_drop", dimension=2
+        )
+        assert isinstance(col, AsyncCollection)
+        del_res = await col.drop(
+            "test_col_drop"
+        )
+        assert del_res["status"]["ok"] == 1
 
     @pytest.mark.describe("test of Database list_collections, async")
     async def test_database_list_collections_async(

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -14,9 +14,8 @@
 
 import pytest
 
-from ..conftest import ASTRA_DB_SECONDARY_KEYSPACE, TEST_COLLECTION_NAME
+from ..conftest import ASTRA_DB_SECONDARY_KEYSPACE, TEST_COLLECTION_NAME, TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
 from astrapy import Collection, Database
-
 
 class TestDDLSync:
     @pytest.mark.describe("test of collection creation, get, and then drop, sync")
@@ -34,6 +33,18 @@ class TestDDLSync:
         col2 = sync_database.get_collection(TEST_LOCAL_COLLECTION_NAME)
         assert col1 == col2
         sync_database.drop_collection(TEST_LOCAL_COLLECTION_NAME)
+
+    @pytest.mark.describe("should create and destroy a vector collection using collection drop ")
+    def test_create_destroy_collection(self, sync_database: Database) -> None:
+        col = sync_database.create_collection(
+            name="TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME", dimension=2
+        )
+        assert isinstance(col, Collection)
+        del_res = col.drop(
+            TEST_CREATE_DELETE_VECTOR_COLLECTION_NAME
+        )
+        assert del_res["status"]["ok"] == 1
+
 
     @pytest.mark.describe("test of Database list_collections, sync")
     def test_database_list_collections_sync(


### PR DESCRIPTION
Adding a function for a collection to drop itself: collection.drop(COLLECTION_NAME).

Added a test to validate that it's working.  It *seems* like a ddl sort of thing so that's where I put it.
