### PR TITLE
Sl overridable copy methods

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -2128,8 +2128,10 @@ class AstraDB:
         # Store the API token
         self.token = token
 
+        self.api_endpoint = api_endpoint
+
         # Set the Base URL for the API calls
-        self.base_url = api_endpoint.strip("/")
+        self.base_url = self.api_endpoint.strip("/")
 
         # Set the API version and path from the call
         self.api_path = (api_path or DEFAULT_JSON_API_PATH).strip("/")
@@ -2413,8 +2415,10 @@ class AsyncAstraDB:
         # Store the API token
         self.token = token
 
+        self.api_endpoint = api_endpoint
+
         # Set the Base URL for the API calls
-        self.base_url = api_endpoint.strip("/")
+        self.base_url = self.api_endpoint.strip("/")
 
         # Set the API version and path from the call
         self.api_path = (api_path or DEFAULT_JSON_API_PATH).strip("/")

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -51,6 +51,10 @@ class Collection:
     def namespace(self) -> str:
         return self._astra_db_collection.astra_db.namespace
 
+    @property
+    def name(self) -> str:
+        return self._astra_db_collection.collection_name
+
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}[_astra_db_collection="{self._astra_db_collection}"]'
 
@@ -305,6 +309,10 @@ class AsyncCollection:
     @property
     def namespace(self) -> str:
         return self._astra_db_collection.astra_db.namespace
+
+    @property
+    def name(self) -> str:
+        return self._astra_db_collection.collection_name
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}[_astra_db_collection="{self._astra_db_collection}"]'

--- a/astrapy/idiomatic/database.py
+++ b/astrapy/idiomatic/database.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Type, TypedDict, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Type, Union, TYPE_CHECKING
 
 from astrapy.db import AstraDB, AsyncAstraDB
 from astrapy.idiomatic.utils import raise_unsupported_parameter, unsupported
@@ -72,16 +72,6 @@ def _recast_api_collection_dict(api_coll_dict: Dict[str, Any]) -> Dict[str, Any]
     return recast_dict
 
 
-class DatabaseConstructorParams(TypedDict):
-    api_endpoint: str
-    token: str
-    namespace: Optional[str]
-    caller_name: Optional[str]
-    caller_version: Optional[str]
-    api_path: Optional[str]
-    api_version: Optional[str]
-
-
 class Database:
     def __init__(
         self,
@@ -94,15 +84,6 @@ class Database:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> None:
-        self._constructor_params: DatabaseConstructorParams = {
-            "api_endpoint": api_endpoint,
-            "token": token,
-            "namespace": namespace,
-            "caller_name": caller_name,
-            "caller_version": caller_version,
-            "api_path": api_path,
-            "api_version": api_version,
-        }
         self._astra_db = AstraDB(
             token=token,
             api_endpoint=api_endpoint,
@@ -132,14 +113,46 @@ class Database:
     def namespace(self) -> str:
         return self._astra_db.namespace
 
-    def copy(self) -> Database:
+    def copy(
+        self,
+        *,
+        api_endpoint: Optional[str] = None,
+        token: Optional[str] = None,
+        namespace: Optional[str] = None,
+        caller_name: Optional[str] = None,
+        caller_version: Optional[str] = None,
+        api_path: Optional[str] = None,
+        api_version: Optional[str] = None,
+    ) -> Database:
         return Database(
-            **self._constructor_params,
+            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            token=token or self._astra_db.token,
+            namespace=namespace or self._astra_db.namespace,
+            caller_name=caller_name or self._astra_db.caller_name,
+            caller_version=caller_version or self._astra_db.caller_version,
+            api_path=api_path or self._astra_db.api_path,
+            api_version=api_version or self._astra_db.api_version,
         )
 
-    def to_async(self) -> AsyncDatabase:
+    def to_async(
+        self,
+        *,
+        api_endpoint: Optional[str] = None,
+        token: Optional[str] = None,
+        namespace: Optional[str] = None,
+        caller_name: Optional[str] = None,
+        caller_version: Optional[str] = None,
+        api_path: Optional[str] = None,
+        api_version: Optional[str] = None,
+    ) -> AsyncDatabase:
         return AsyncDatabase(
-            **self._constructor_params,
+            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            token=token or self._astra_db.token,
+            namespace=namespace or self._astra_db.namespace,
+            caller_name=caller_name or self._astra_db.caller_name,
+            caller_version=caller_version or self._astra_db.caller_version,
+            api_path=api_path or self._astra_db.api_path,
+            api_version=api_version or self._astra_db.api_version,
         )
 
     def set_caller(
@@ -147,10 +160,10 @@ class Database:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
-        self._astra_db.caller_name = caller_name
-        self._astra_db.caller_version = caller_version
-        self._constructor_params["caller_name"] = caller_name
-        self._constructor_params["caller_version"] = caller_version
+        self._astra_db.set_caller(
+            caller_name=caller_name,
+            caller_version=caller_version,
+        )
 
     def get_collection(
         self, name: str, *, namespace: Optional[str] = None
@@ -158,7 +171,7 @@ class Database:
         # lazy importing here against circular-import error
         from astrapy.idiomatic.collection import Collection
 
-        _namespace = namespace or self._constructor_params["namespace"]
+        _namespace = namespace or self._astra_db.namespace
         return Collection(self, name, namespace=_namespace)
 
     def create_collection(
@@ -311,15 +324,6 @@ class AsyncDatabase:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> None:
-        self._constructor_params: DatabaseConstructorParams = {
-            "api_endpoint": api_endpoint,
-            "token": token,
-            "namespace": namespace,
-            "caller_name": caller_name,
-            "caller_version": caller_version,
-            "api_path": api_path,
-            "api_version": api_version,
-        }
         self._astra_db = AsyncAstraDB(
             token=token,
             api_endpoint=api_endpoint,
@@ -364,14 +368,46 @@ class AsyncDatabase:
     def namespace(self) -> str:
         return self._astra_db.namespace
 
-    def copy(self) -> AsyncDatabase:
+    def copy(
+        self,
+        *,
+        api_endpoint: Optional[str] = None,
+        token: Optional[str] = None,
+        namespace: Optional[str] = None,
+        caller_name: Optional[str] = None,
+        caller_version: Optional[str] = None,
+        api_path: Optional[str] = None,
+        api_version: Optional[str] = None,
+    ) -> AsyncDatabase:
         return AsyncDatabase(
-            **self._constructor_params,
+            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            token=token or self._astra_db.token,
+            namespace=namespace or self._astra_db.namespace,
+            caller_name=caller_name or self._astra_db.caller_name,
+            caller_version=caller_version or self._astra_db.caller_version,
+            api_path=api_path or self._astra_db.api_path,
+            api_version=api_version or self._astra_db.api_version,
         )
 
-    def to_sync(self) -> Database:
+    def to_sync(
+        self,
+        *,
+        api_endpoint: Optional[str] = None,
+        token: Optional[str] = None,
+        namespace: Optional[str] = None,
+        caller_name: Optional[str] = None,
+        caller_version: Optional[str] = None,
+        api_path: Optional[str] = None,
+        api_version: Optional[str] = None,
+    ) -> Database:
         return Database(
-            **self._constructor_params,
+            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            token=token or self._astra_db.token,
+            namespace=namespace or self._astra_db.namespace,
+            caller_name=caller_name or self._astra_db.caller_name,
+            caller_version=caller_version or self._astra_db.caller_version,
+            api_path=api_path or self._astra_db.api_path,
+            api_version=api_version or self._astra_db.api_version,
         )
 
     def set_caller(
@@ -379,10 +415,10 @@ class AsyncDatabase:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
-        self._astra_db.caller_name = caller_name
-        self._astra_db.caller_version = caller_version
-        self._constructor_params["caller_name"] = caller_name
-        self._constructor_params["caller_version"] = caller_version
+        self._astra_db.set_caller(
+            caller_name=caller_name,
+            caller_version=caller_version,
+        )
 
     async def get_collection(
         self, name: str, *, namespace: Optional[str] = None
@@ -390,7 +426,7 @@ class AsyncDatabase:
         # lazy importing here against circular-import error
         from astrapy.idiomatic.collection import AsyncCollection
 
-        _namespace = namespace or self._constructor_params["namespace"]
+        _namespace = namespace or self._astra_db.namespace
         return AsyncCollection(self, name, namespace=_namespace)
 
     async def create_collection(

--- a/tests/idiomatic/unit/test_collections_async.py
+++ b/tests/idiomatic/unit/test_collections_async.py
@@ -52,6 +52,96 @@ class TestCollectionsAsync:
         assert col1 == col1.copy()
         assert col1 == col1.to_sync().to_async()
 
+    @pytest.mark.describe("test of Collection rich copy, async")
+    async def test_rich_copy_collection_async(
+        self,
+        async_database: AsyncDatabase,
+    ) -> None:
+        col1 = AsyncCollection(
+            async_database,
+            "id_test_collection",
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        assert col1 != col1.copy(database=async_database.copy(token="x_t"))
+        assert col1 != col1.copy(name="o")
+        assert col1 != col1.copy(namespace="o")
+        assert col1 != col1.copy(caller_name="o")
+        assert col1 != col1.copy(caller_version="o")
+
+        col2 = col1.copy(
+            database=async_database.copy(token="x_t"),
+            name="other_name",
+            namespace="other_namespace",
+            caller_name="x_n",
+            caller_version="x_v",
+        )
+        assert col2 != col1
+
+        col2.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        col3 = col2.copy(
+            database=async_database,
+            name="id_test_collection",
+            namespace=async_database.namespace,
+        )
+        assert col3 == col1
+
+    @pytest.mark.describe("test of Collection rich conversions, async")
+    async def test_rich_convert_collection_async(
+        self,
+        async_database: AsyncDatabase,
+    ) -> None:
+        col1 = AsyncCollection(
+            async_database,
+            "id_test_collection",
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        assert (
+            col1
+            != col1.to_sync(
+                database=async_database.copy(token="x_t").to_sync()
+            ).to_async()
+        )
+        assert col1 != col1.to_sync(name="o").to_async()
+        assert col1 != col1.to_sync(namespace="o").to_async()
+        assert col1 != col1.to_sync(caller_name="o").to_async()
+        assert col1 != col1.to_sync(caller_version="o").to_async()
+
+        col2s = col1.to_sync(
+            database=async_database.copy(token="x_t").to_sync(),
+            name="other_name",
+            namespace="other_namespace",
+            caller_name="x_n",
+            caller_version="x_v",
+        )
+        assert col2s.to_async() != col1
+
+        col2s.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        col3 = col2s.to_async(
+            database=async_database,
+            name="id_test_collection",
+            namespace=async_database.namespace,
+        )
+        assert col3 == col1
+
+    @pytest.mark.describe("test of Collection database property, async")
+    async def test_collection_database_property_async(
+        self,
+    ) -> None:
+        db1 = AsyncDatabase("a", "t", namespace="ns1")
+        db2 = AsyncDatabase("a", "t", namespace="ns2")
+        col1 = AsyncCollection(db1, "coll")
+        col2 = AsyncCollection(db1, "coll", namespace="ns2")
+        assert col1.database == db1
+        assert col2.database == db2
+
     @pytest.mark.describe("test of Collection set_caller, async")
     async def test_collection_set_caller_async(
         self,

--- a/tests/idiomatic/unit/test_collections_async.py
+++ b/tests/idiomatic/unit/test_collections_async.py
@@ -142,6 +142,14 @@ class TestCollectionsAsync:
         assert col1.database == db1
         assert col2.database == db2
 
+    @pytest.mark.describe("test of Collection name property, async")
+    async def test_collection_name_property_async(
+        self,
+    ) -> None:
+        db1 = AsyncDatabase("a", "t", namespace="ns1")
+        col1 = AsyncCollection(db1, "coll")
+        assert col1.name == "coll"
+
     @pytest.mark.describe("test of Collection set_caller, async")
     async def test_collection_set_caller_async(
         self,

--- a/tests/idiomatic/unit/test_collections_sync.py
+++ b/tests/idiomatic/unit/test_collections_sync.py
@@ -52,6 +52,96 @@ class TestCollectionsSync:
         assert col1 == col1.copy()
         assert col1 == col1.to_async().to_sync()
 
+    @pytest.mark.describe("test of Collection rich copy, sync")
+    def test_rich_copy_collection_sync(
+        self,
+        sync_database: Database,
+    ) -> None:
+        col1 = Collection(
+            sync_database,
+            "id_test_collection",
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        assert col1 != col1.copy(database=sync_database.copy(token="x_t"))
+        assert col1 != col1.copy(name="o")
+        assert col1 != col1.copy(namespace="o")
+        assert col1 != col1.copy(caller_name="o")
+        assert col1 != col1.copy(caller_version="o")
+
+        col2 = col1.copy(
+            database=sync_database.copy(token="x_t"),
+            name="other_name",
+            namespace="other_namespace",
+            caller_name="x_n",
+            caller_version="x_v",
+        )
+        assert col2 != col1
+
+        col2.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        col3 = col2.copy(
+            database=sync_database,
+            name="id_test_collection",
+            namespace=sync_database.namespace,
+        )
+        assert col3 == col1
+
+    @pytest.mark.describe("test of Collection rich conversions, sync")
+    def test_rich_convert_collection_sync(
+        self,
+        sync_database: Database,
+    ) -> None:
+        col1 = Collection(
+            sync_database,
+            "id_test_collection",
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        assert (
+            col1
+            != col1.to_async(
+                database=sync_database.copy(token="x_t").to_async()
+            ).to_sync()
+        )
+        assert col1 != col1.to_async(name="o").to_sync()
+        assert col1 != col1.to_async(namespace="o").to_sync()
+        assert col1 != col1.to_async(caller_name="o").to_sync()
+        assert col1 != col1.to_async(caller_version="o").to_sync()
+
+        col2a = col1.to_async(
+            database=sync_database.copy(token="x_t").to_async(),
+            name="other_name",
+            namespace="other_namespace",
+            caller_name="x_n",
+            caller_version="x_v",
+        )
+        assert col2a.to_sync() != col1
+
+        col2a.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        col3 = col2a.to_sync(
+            database=sync_database,
+            name="id_test_collection",
+            namespace=sync_database.namespace,
+        )
+        assert col3 == col1
+
+    @pytest.mark.describe("test of Collection database property, sync")
+    def test_collection_database_property_sync(
+        self,
+    ) -> None:
+        db1 = Database("a", "t", namespace="ns1")
+        db2 = Database("a", "t", namespace="ns2")
+        col1 = Collection(db1, "coll")
+        col2 = Collection(db1, "coll", namespace="ns2")
+        assert col1.database == db1
+        assert col2.database == db2
+
     @pytest.mark.describe("test of Collection set_caller, sync")
     def test_collection_set_caller_sync(
         self,

--- a/tests/idiomatic/unit/test_collections_sync.py
+++ b/tests/idiomatic/unit/test_collections_sync.py
@@ -142,6 +142,14 @@ class TestCollectionsSync:
         assert col1.database == db1
         assert col2.database == db2
 
+    @pytest.mark.describe("test of Collection name property, sync")
+    def test_collection_name_property_sync(
+        self,
+    ) -> None:
+        db1 = Database("a", "t", namespace="ns1")
+        col1 = Collection(db1, "coll")
+        assert col1.name == "coll"
+
     @pytest.mark.describe("test of Collection set_caller, sync")
     def test_collection_set_caller_sync(
         self,

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -54,6 +54,96 @@ class TestDatabasesAsync:
         assert db1 == db1.copy()
         assert db1 == db1.to_sync().to_async()
 
+    @pytest.mark.describe("test of Database rich copy, async")
+    async def test_rich_copy_database_async(
+        self,
+    ) -> None:
+        db1 = AsyncDatabase(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            caller_name="c_n",
+            caller_version="c_v",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db1 != db1.copy(api_endpoint="x")
+        assert db1 != db1.copy(token="x")
+        assert db1 != db1.copy(namespace="x")
+        assert db1 != db1.copy(caller_name="x")
+        assert db1 != db1.copy(caller_version="x")
+        assert db1 != db1.copy(api_path="x")
+        assert db1 != db1.copy(api_version="x")
+
+        db2 = db1.copy(
+            api_endpoint="x",
+            token="x",
+            namespace="x",
+            caller_name="x_n",
+            caller_version="x_v",
+            api_path="x",
+            api_version="x",
+        )
+        assert db2 != db1
+
+        db2.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        db3 = db2.copy(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db3 == db1
+
+    @pytest.mark.describe("test of Database rich conversions, async")
+    async def test_rich_convert_database_async(
+        self,
+    ) -> None:
+        db1 = AsyncDatabase(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            caller_name="c_n",
+            caller_version="c_v",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db1 != db1.to_sync(api_endpoint="o").to_async()
+        assert db1 != db1.to_sync(token="o").to_async()
+        assert db1 != db1.to_sync(namespace="o").to_async()
+        assert db1 != db1.to_sync(caller_name="o").to_async()
+        assert db1 != db1.to_sync(caller_version="o").to_async()
+        assert db1 != db1.to_sync(api_path="o").to_async()
+        assert db1 != db1.to_sync(api_version="o").to_async()
+
+        db2s = db1.to_sync(
+            api_endpoint="x",
+            token="x",
+            namespace="x",
+            caller_name="x_n",
+            caller_version="x_v",
+            api_path="x",
+            api_version="x",
+        )
+        assert db2s.to_async() != db1
+
+        db2s.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        db3 = db2s.to_async(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db3 == db1
+
     @pytest.mark.describe("test of Database set_caller, async")
     async def test_database_set_caller_async(
         self,

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -54,6 +54,96 @@ class TestDatabasesSync:
         assert db1 == db1.copy()
         assert db1 == db1.to_async().to_sync()
 
+    @pytest.mark.describe("test of Database rich copy, sync")
+    def test_rich_copy_database_sync(
+        self,
+    ) -> None:
+        db1 = Database(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            caller_name="c_n",
+            caller_version="c_v",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db1 != db1.copy(api_endpoint="x")
+        assert db1 != db1.copy(token="x")
+        assert db1 != db1.copy(namespace="x")
+        assert db1 != db1.copy(caller_name="x")
+        assert db1 != db1.copy(caller_version="x")
+        assert db1 != db1.copy(api_path="x")
+        assert db1 != db1.copy(api_version="x")
+
+        db2 = db1.copy(
+            api_endpoint="x",
+            token="x",
+            namespace="x",
+            caller_name="x_n",
+            caller_version="x_v",
+            api_path="x",
+            api_version="x",
+        )
+        assert db2 != db1
+
+        db2.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        db3 = db2.copy(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db3 == db1
+
+    @pytest.mark.describe("test of Database rich conversions, sync")
+    def test_rich_convert_database_sync(
+        self,
+    ) -> None:
+        db1 = Database(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            caller_name="c_n",
+            caller_version="c_v",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db1 != db1.to_async(api_endpoint="o").to_sync()
+        assert db1 != db1.to_async(token="o").to_sync()
+        assert db1 != db1.to_async(namespace="o").to_sync()
+        assert db1 != db1.to_async(caller_name="o").to_sync()
+        assert db1 != db1.to_async(caller_version="o").to_sync()
+        assert db1 != db1.to_async(api_path="o").to_sync()
+        assert db1 != db1.to_async(api_version="o").to_sync()
+
+        db2a = db1.to_async(
+            api_endpoint="x",
+            token="x",
+            namespace="x",
+            caller_name="x_n",
+            caller_version="x_v",
+            api_path="x",
+            api_version="x",
+        )
+        assert db2a.to_sync() != db1
+
+        db2a.set_caller(
+            caller_name="c_n",
+            caller_version="c_v",
+        )
+        db3 = db2a.to_sync(
+            api_endpoint="api_endpoint",
+            token="token",
+            namespace="namespace",
+            api_path="api_path",
+            api_version="api_version",
+        )
+        assert db3 == db1
+
     @pytest.mark.describe("test of Database set_caller, sync")
     def test_database_set_caller_sync(
         self,


### PR DESCRIPTION
Database and Collection get argument in their copy() methods to override arbitrary (constructor) parameters.
Collection expose a .database and a .name property.