### PR TITLE
DML for idiomatic + necessary changes around

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -570,6 +570,7 @@ class AstraDBCollection:
         sort: Optional[Dict[str, Any]] = {},
         filter: Optional[Dict[str, Any]] = None,
         options: Optional[Dict[str, Any]] = None,
+        projection: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Find a single document and update it.
@@ -587,6 +588,7 @@ class AstraDBCollection:
             update=update,
             options=options,
             sort=sort,
+            projection=projection,
         )
 
         response = self._request(
@@ -617,7 +619,7 @@ class AstraDBCollection:
                 update operation, or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._recast_as_sort_projection(
+        sort, projection = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -627,6 +629,7 @@ class AstraDBCollection:
             update=update,
             filter=filter,
             sort=sort,
+            projection=projection,
         )
 
         return cast(Union[API_DOC, None], raw_find_result["data"]["document"])
@@ -1624,6 +1627,7 @@ class AsyncAstraDBCollection:
         sort: Optional[Dict[str, Any]] = {},
         filter: Optional[Dict[str, Any]] = None,
         options: Optional[Dict[str, Any]] = None,
+        projection: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Find a single document and update it.
@@ -1641,6 +1645,7 @@ class AsyncAstraDBCollection:
             update=update,
             options=options,
             sort=sort,
+            projection=projection,
         )
 
         response = await self._request(
@@ -1671,7 +1676,7 @@ class AsyncAstraDBCollection:
                 update operation, or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._recast_as_sort_projection(
+        sort, projection = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )
@@ -1681,6 +1686,7 @@ class AsyncAstraDBCollection:
             update=update,
             filter=filter,
             sort=sort,
+            projection=projection,
         )
 
         return cast(Union[API_DOC, None], raw_find_result["data"]["document"])

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -973,6 +973,23 @@ class AstraDBCollection:
 
         return response
 
+    def chunked_delete_many(self, filter: Dict[str, Any]) -> List[API_RESPONSE]:
+        """
+        Delete many documents from the collection based on a filter condition,
+        chaining several API calls until exhaustion of the documents to delete.
+        Args:
+            filter (dict): Criteria to identify the documents to delete.
+        Returns:
+            List[dict]: The responses from the database from all the calls
+        """
+        responses = []
+        must_proceed = True
+        while must_proceed:
+            dm_response = self.delete_many(filter=filter)
+            responses.append(dm_response)
+            must_proceed = dm_response.get("status", {}).get("moreData", False)
+        return responses
+
     def clear(self) -> API_RESPONSE:
         """
         Clear the collection, deleting all documents
@@ -1971,6 +1988,23 @@ class AsyncAstraDBCollection:
         )
 
         return response
+
+    async def chunked_delete_many(self, filter: Dict[str, Any]) -> List[API_RESPONSE]:
+        """
+        Delete many documents from the collection based on a filter condition,
+        chaining several API calls until exhaustion of the documents to delete.
+        Args:
+            filter (dict): Criteria to identify the documents to delete.
+        Returns:
+            List[dict]: The responses from the database from all the calls
+        """
+        responses = []
+        must_proceed = True
+        while must_proceed:
+            dm_response = await self.delete_many(filter=filter)
+            responses.append(dm_response)
+            must_proceed = dm_response.get("status", {}).get("moreData", False)
+        return responses
 
     async def clear(self) -> API_RESPONSE:
         """

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -879,7 +879,10 @@ class AstraDBCollection:
         return response
 
     def update_many(
-        self, filter: Dict[str, Any], update: Dict[str, Any]
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Updates multiple documents in the collection.
@@ -889,7 +892,12 @@ class AstraDBCollection:
         Returns:
             dict: The response from the database after the update operation.
         """
-        json_query = make_payload(top_level="updateMany", filter=filter, update=update)
+        json_query = make_payload(
+            top_level="updateMany",
+            filter=filter,
+            update=update,
+            options=options,
+        )
 
         response = self._request(
             method=http_methods.POST,
@@ -1910,7 +1918,10 @@ class AsyncAstraDBCollection:
         return response
 
     async def update_many(
-        self, filter: Dict[str, Any], update: Dict[str, Any]
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Updates multiple documents in the collection.
@@ -1920,7 +1931,12 @@ class AsyncAstraDBCollection:
         Returns:
             dict: The response from the database after the update operation.
         """
-        json_query = make_payload(top_level="updateMany", filter=filter, update=update)
+        json_query = make_payload(
+            top_level="updateMany",
+            filter=filter,
+            update=update,
+            options=options,
+        )
 
         response = await self._request(
             method=http_methods.POST,

--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -500,8 +500,9 @@ class AstraDBCollection:
         self,
         replacement: Dict[str, Any],
         *,
-        sort: Optional[Dict[str, Any]] = {},
         filter: Optional[Dict[str, Any]] = None,
+        projection: Optional[Dict[str, Any]] = None,
+        sort: Optional[Dict[str, Any]] = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
@@ -517,6 +518,7 @@ class AstraDBCollection:
         json_query = make_payload(
             top_level="findOneAndReplace",
             filter=filter,
+            projection=projection,
             replacement=replacement,
             options=options,
             sort=sort,
@@ -547,7 +549,7 @@ class AstraDBCollection:
             dict or None: either the matched document or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._recast_as_sort_projection(
+        sort, projection = self._recast_as_sort_projection(
             convert_vector_to_floats(vector),
             fields=fields,
         )
@@ -556,6 +558,7 @@ class AstraDBCollection:
         raw_find_result = self.find_one_and_replace(
             replacement=replacement,
             filter=filter,
+            projection=projection,
             sort=sort,
         )
 
@@ -1551,8 +1554,9 @@ class AsyncAstraDBCollection:
         self,
         replacement: Dict[str, Any],
         *,
-        sort: Optional[Dict[str, Any]] = {},
         filter: Optional[Dict[str, Any]] = None,
+        projection: Optional[Dict[str, Any]] = None,
+        sort: Optional[Dict[str, Any]] = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
@@ -1568,6 +1572,7 @@ class AsyncAstraDBCollection:
         json_query = make_payload(
             top_level="findOneAndReplace",
             filter=filter,
+            projection=projection,
             replacement=replacement,
             options=options,
             sort=sort,
@@ -1598,7 +1603,7 @@ class AsyncAstraDBCollection:
             dict or None: either the matched document or None if nothing found
         """
         # Pre-process the included arguments
-        sort, _ = self._recast_as_sort_projection(
+        sort, projection = self._recast_as_sort_projection(
             vector,
             fields=fields,
         )
@@ -1607,6 +1612,7 @@ class AsyncAstraDBCollection:
         raw_find_result = await self.find_one_and_replace(
             replacement=replacement,
             filter=filter,
+            projection=projection,
             sort=sort,
         )
 

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -385,6 +385,28 @@ class Collection:
                 f"(gotten '${json.dumps(fo_response)}')"
             )
 
+    def update_many(
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        *,
+        upsert: bool = False,
+    ) -> UpdateResult:
+        options = {
+            "upsert": upsert,
+        }
+        um_response = self._astra_db_collection.update_many(
+            update=update,
+            filter=filter,
+            options=options,
+        )
+        um_status = um_response.get("status") or {}
+        _update_info = _prepare_update_info(um_status)
+        return UpdateResult(
+            raw_result=um_status,
+            update_info=_update_info,
+        )
+
     def find_one_and_delete(
         self,
         filter: Dict[str, Any],
@@ -799,6 +821,28 @@ class AsyncCollection:
                 "Could not complete a find_one_and_update operation. "
                 f"(gotten '${json.dumps(fo_response)}')"
             )
+
+    async def update_many(
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        *,
+        upsert: bool = False,
+    ) -> UpdateResult:
+        options = {
+            "upsert": upsert,
+        }
+        um_response = await self._astra_db_collection.update_many(
+            update=update,
+            filter=filter,
+            options=options,
+        )
+        um_status = um_response.get("status") or {}
+        _update_info = _prepare_update_info(um_status)
+        return UpdateResult(
+            raw_result=um_status,
+            update_info=_update_info,
+        )
 
     async def find_one_and_delete(
         self,

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -279,6 +279,39 @@ class Collection:
                 f"(gotten '${json.dumps(fo_response)}')"
             )
 
+    def find_one_and_update(
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        *,
+        projection: Optional[ProjectionType] = None,
+        sort: Optional[Dict[str, Any]] = None,
+        upsert: bool = False,
+        return_document: ReturnDocument = ReturnDocument.BEFORE,
+    ) -> Union[DocumentType, None]:
+        options = {
+            "returnDocument": return_document.value,
+            "upsert": upsert,
+        }
+        fo_response = self._astra_db_collection.find_one_and_update(
+            update=update,
+            filter=filter,
+            projection=normalize_optional_projection(projection),
+            sort=sort,
+            options=options,
+        )
+        if "document" in fo_response.get("data", {}):
+            ret_document = fo_response.get("data", {}).get("document")
+            if ret_document is None:
+                return None
+            else:
+                return ret_document  # type: ignore[no-any-return]
+        else:
+            raise ValueError(
+                "Could not complete a find_one_and_update operation. "
+                f"(gotten '${json.dumps(fo_response)}')"
+            )
+
     def find_one_and_delete(
         self,
         filter: Dict[str, Any],
@@ -602,6 +635,39 @@ class AsyncCollection:
         else:
             raise ValueError(
                 "Could not complete a find_one_and_replace operation. "
+                f"(gotten '${json.dumps(fo_response)}')"
+            )
+
+    async def find_one_and_update(
+        self,
+        filter: Dict[str, Any],
+        update: Dict[str, Any],
+        *,
+        projection: Optional[ProjectionType] = None,
+        sort: Optional[Dict[str, Any]] = None,
+        upsert: bool = False,
+        return_document: ReturnDocument = ReturnDocument.BEFORE,
+    ) -> Union[DocumentType, None]:
+        options = {
+            "returnDocument": return_document.value,
+            "upsert": upsert,
+        }
+        fo_response = await self._astra_db_collection.find_one_and_update(
+            update=update,
+            filter=filter,
+            projection=normalize_optional_projection(projection),
+            sort=sort,
+            options=options,
+        )
+        if "document" in fo_response.get("data", {}):
+            ret_document = fo_response.get("data", {}).get("document")
+            if ret_document is None:
+                return None
+            else:
+                return ret_document  # type: ignore[no-any-return]
+        else:
+            raise ValueError(
+                "Could not complete a find_one_and_update operation. "
                 f"(gotten '${json.dumps(fo_response)}')"
             )
 

--- a/astrapy/idiomatic/cursors.py
+++ b/astrapy/idiomatic/cursors.py
@@ -25,7 +25,11 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from astrapy.idiomatic.types import DocumentType, ProjectionType
+from astrapy.idiomatic.types import (
+    DocumentType,
+    ProjectionType,
+    normalize_optional_projection,
+)
 
 if TYPE_CHECKING:
     from astrapy.idiomatic.collection import AsyncCollection, Collection
@@ -245,15 +249,9 @@ class Cursor(BaseCursor):
         }
 
         # recast parameters for paginated_find call
-        pf_projection: Optional[Dict[str, bool]]
-        if self._projection:
-            if isinstance(self._projection, dict):
-                pf_projection = self._projection
-            else:
-                # an iterable over strings
-                pf_projection = {field: True for field in self._projection}
-        else:
-            pf_projection = None
+        pf_projection: Optional[Dict[str, bool]] = normalize_optional_projection(
+            self._projection
+        )
         pf_sort: Optional[Dict[str, int]]
         if self._sort:
             pf_sort = dict(self._sort)
@@ -345,15 +343,9 @@ class AsyncCursor(BaseCursor):
         }
 
         # recast parameters for paginated_find call
-        pf_projection: Optional[Dict[str, bool]]
-        if self._projection:
-            if isinstance(self._projection, dict):
-                pf_projection = self._projection
-            else:
-                # an iterable over strings
-                pf_projection = {field: True for field in self._projection}
-        else:
-            pf_projection = None
+        pf_projection: Optional[Dict[str, bool]] = normalize_optional_projection(
+            self._projection
+        )
         pf_sort: Optional[Dict[str, int]]
         if self._sort:
             pf_sort = dict(self._sort)

--- a/astrapy/idiomatic/results.py
+++ b/astrapy/idiomatic/results.py
@@ -35,3 +35,10 @@ class InsertOneResult:
 class InsertManyResult:
     inserted_ids: List[Any]
     acknowledged: bool = True
+
+
+@dataclass
+class UpdateResult:
+    raw_result: Dict[str, Any]
+    update_info: Dict[str, Any]
+    acknowledged: bool = True

--- a/astrapy/idiomatic/results.py
+++ b/astrapy/idiomatic/results.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 @dataclass
 class DeleteResult:
     deleted_count: Optional[int]
-    raw_result: Dict[str, Any]
+    raw_result: Union[Dict[str, Any], List[Dict[str, Any]]]
     acknowledged: bool = True
 
 

--- a/astrapy/idiomatic/types.py
+++ b/astrapy/idiomatic/types.py
@@ -14,8 +14,27 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Union
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional, Union
 
 
 DocumentType = Dict[str, Any]
 ProjectionType = Union[Iterable[str], Dict[str, bool]]
+
+
+class ReturnDocument(Enum):
+    BEFORE = "before"
+    AFTER = "after"
+
+
+def normalize_optional_projection(
+    projection: Optional[ProjectionType],
+) -> Optional[Dict[str, bool]]:
+    if projection:
+        if isinstance(projection, dict):
+            return projection
+        else:
+            # an iterable over strings
+            return {field: True for field in projection}
+    else:
+        return None

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -647,6 +647,41 @@ class TestDMLAsync:
         assert set(resp_pr2.keys()) == {"mode"}
         await acol.delete_many({})
 
+    @pytest.mark.describe("test of replace_one, async")
+    async def test_collection_replace_one_async(
+        self,
+        async_empty_collection: AsyncCollection,
+    ) -> None:
+        acol = async_empty_collection
+
+        result1 = await acol.replace_one(filter={"a": 1}, replacement={"b": 2})
+        assert result1.update_info["n"] == 0
+        assert result1.update_info["updatedExisting"] is False
+        assert result1.update_info["nModified"] == 0
+        assert "upserted" not in result1.update_info
+
+        result2 = await acol.replace_one(
+            filter={"a": 1}, replacement={"b": 2}, upsert=True
+        )
+        assert result2.update_info["n"] == 1
+        assert result2.update_info["updatedExisting"] is False
+        assert result2.update_info["nModified"] == 0
+        assert "upserted" in result2.update_info
+
+        result3 = await acol.replace_one(filter={"b": 2}, replacement={"c": 3})
+        assert result3.update_info["n"] == 1
+        assert result3.update_info["updatedExisting"] is True
+        assert result3.update_info["nModified"] == 1
+        assert "upserted" not in result3.update_info
+
+        result4 = await acol.replace_one(
+            filter={"c": 3}, replacement={"d": 4}, upsert=True
+        )
+        assert result4.update_info["n"] == 1
+        assert result4.update_info["updatedExisting"] is True
+        assert result4.update_info["nModified"] == 1
+        assert "upserted" not in result4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, async")
     async def test_collection_find_one_and_delete_sync(
         self,

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -646,3 +646,35 @@ class TestDMLAsync:
         assert resp_pr2 is not None
         assert set(resp_pr2.keys()) == {"mode"}
         await acol.delete_many({})
+
+    @pytest.mark.describe("test of collection find_one_and_delete, async")
+    async def test_collection_find_one_and_delete_sync(
+        self,
+        async_empty_collection: AsyncCollection,
+    ) -> None:
+        await async_empty_collection.insert_one({"doc": 1, "group": "A"})
+        await async_empty_collection.insert_one({"doc": 2, "group": "B"})
+        await async_empty_collection.insert_one({"doc": 3, "group": "A"})
+        assert await async_empty_collection.count_documents(filter={}) == 3
+
+        fo_result1 = await async_empty_collection.find_one_and_delete({"group": "A"})
+        assert fo_result1 is not None
+        assert set(fo_result1.keys()) == {"_id", "doc", "group"}
+        assert await async_empty_collection.count_documents(filter={}) == 2
+
+        fo_result2 = await async_empty_collection.find_one_and_delete(
+            {"group": "B"}, projection=["doc"]
+        )
+        assert fo_result2 is not None
+        assert set(fo_result2.keys()) == {"_id", "doc"}
+        assert await async_empty_collection.count_documents(filter={}) == 1
+
+        fo_result3 = await async_empty_collection.find_one_and_delete(
+            {"group": "A"}, projection={"_id": False, "group": False}
+        )
+        assert fo_result3 is not None
+        assert set(fo_result3.keys()) == {"_id", "doc"}
+        assert await async_empty_collection.count_documents(filter={}) == 0
+
+        fo_result4 = await async_empty_collection.find_one_and_delete({}, sort={"f": 1})
+        assert fo_result4 is None

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -678,3 +678,176 @@ class TestDMLAsync:
 
         fo_result4 = await async_empty_collection.find_one_and_delete({}, sort={"f": 1})
         assert fo_result4 is None
+
+    @pytest.mark.describe("test of find_one_and_update, async")
+    async def test_collection_find_one_and_update_async(
+        self,
+        async_empty_collection: AsyncCollection,
+    ) -> None:
+        acol = async_empty_collection
+
+        resp0000 = await acol.find_one_and_update({"f": 0}, {"$set": {"n": 1}})
+        assert resp0000 is None
+        assert await acol.count_documents({}) == 0
+
+        resp0001 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, sort={"x": 1}
+        )
+        assert resp0001 is None
+        assert await acol.count_documents({}) == 0
+
+        resp0010 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True
+        )
+        assert resp0010 is None
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        resp0011 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True, sort={"x": 1}
+        )
+        assert resp0011 is None
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp0100 = await acol.find_one_and_update({"f": 0}, {"$set": {"n": 1}})
+        assert resp0100 is not None
+        assert resp0100["f"] == 0
+        assert "n" not in resp0100
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp0101 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, sort={"x": 1}
+        )
+        assert resp0101 is not None
+        assert resp0101["f"] == 0
+        assert "n" not in resp0101
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp0110 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True
+        )
+        assert resp0110 is not None
+        assert resp0110["f"] == 0
+        assert "n" not in resp0110
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp0111 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True, sort={"x": 1}
+        )
+        assert resp0111 is not None
+        assert resp0111["f"] == 0
+        assert "n" not in resp0111
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        resp1000 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, return_document=ReturnDocument.AFTER
+        )
+        assert resp1000 is None
+        assert await acol.count_documents({}) == 0
+
+        resp1001 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1001 is None
+        assert await acol.count_documents({}) == 0
+
+        resp1010 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1010 is not None
+        assert resp1010["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        resp1011 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1011 is not None
+        assert resp1011["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp1100 = await acol.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, return_document=ReturnDocument.AFTER
+        )
+        assert resp1100 is not None
+        assert resp1100["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp1101 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1101 is not None
+        assert resp1101["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp1110 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1110 is not None
+        assert resp1110["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        await acol.insert_one({"f": 0})
+        resp1111 = await acol.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1111 is not None
+        assert resp1111["n"] == 1
+        assert await acol.count_documents({}) == 1
+        await acol.delete_many({})
+
+        # projection
+        await acol.insert_one({"f": 100, "name": "apple", "mode": "old"})
+        resp_pr1 = await acol.find_one_and_update(
+            {"f": 100},
+            {"$unset": {"mode": ""}},
+            projection=["mode", "f"],
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp_pr1 is not None
+        assert set(resp_pr1.keys()) == {"_id", "f"}
+        resp_pr2 = await acol.find_one_and_update(
+            {"f": 100},
+            {"$set": {"mode": "re-replaced"}},
+            projection={"name": False, "_id": False},
+            return_document=ReturnDocument.BEFORE,
+        )
+        assert resp_pr2 is not None
+        assert set(resp_pr2.keys()) == {"f"}
+        await acol.delete_many({})

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -682,8 +682,43 @@ class TestDMLAsync:
         assert result4.update_info["nModified"] == 1
         assert "upserted" not in result4.update_info
 
+    @pytest.mark.describe("test of update_one, async")
+    async def test_collection_update_one_async(
+        self,
+        async_empty_collection: AsyncCollection,
+    ) -> None:
+        acol = async_empty_collection
+
+        result1 = await acol.update_one(filter={"a": 1}, update={"$set": {"b": 2}})
+        assert result1.update_info["n"] == 0
+        assert result1.update_info["updatedExisting"] is False
+        assert result1.update_info["nModified"] == 0
+        assert "upserted" not in result1.update_info
+
+        result2 = await acol.update_one(
+            filter={"a": 1}, update={"$set": {"b": 2}}, upsert=True
+        )
+        assert result2.update_info["n"] == 1
+        assert result2.update_info["updatedExisting"] is False
+        assert result2.update_info["nModified"] == 0
+        assert "upserted" in result2.update_info
+
+        result3 = await acol.update_one(filter={"b": 2}, update={"$set": {"c": 3}})
+        assert result3.update_info["n"] == 1
+        assert result3.update_info["updatedExisting"] is True
+        assert result3.update_info["nModified"] == 1
+        assert "upserted" not in result3.update_info
+
+        result4 = await acol.update_one(
+            filter={"c": 3}, update={"$set": {"d": 4}}, upsert=True
+        )
+        assert result4.update_info["n"] == 1
+        assert result4.update_info["updatedExisting"] is True
+        assert result4.update_info["nModified"] == 1
+        assert "upserted" not in result4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, async")
-    async def test_collection_find_one_and_delete_sync(
+    async def test_collection_find_one_and_delete_async(
         self,
         async_empty_collection: AsyncCollection,
     ) -> None:

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -717,6 +717,39 @@ class TestDMLAsync:
         assert result4.update_info["nModified"] == 1
         assert "upserted" not in result4.update_info
 
+    @pytest.mark.describe("test of update_many, async")
+    async def test_collection_update_many_async(
+        self,
+        async_empty_collection: AsyncCollection,
+    ) -> None:
+        acol = async_empty_collection
+        await acol.insert_many([{"a": 1, "seq": i} for i in range(4)])
+        await acol.insert_many([{"a": 2, "seq": i} for i in range(2)])
+
+        resp1 = await acol.update_many({"a": 1}, {"$set": {"n": 1}})
+        assert resp1.update_info["n"] == 4
+        assert resp1.update_info["updatedExisting"] is True
+        assert resp1.update_info["nModified"] == 4
+        assert "upserted" not in resp1.update_info
+
+        resp2 = await acol.update_many({"a": 1}, {"$set": {"n": 2}}, upsert=True)
+        assert resp2.update_info["n"] == 4
+        assert resp2.update_info["updatedExisting"] is True
+        assert resp2.update_info["nModified"] == 4
+        assert "upserted" not in resp2.update_info
+
+        resp3 = await acol.update_many({"a": 3}, {"$set": {"n": 3}})
+        assert resp3.update_info["n"] == 0
+        assert resp3.update_info["updatedExisting"] is False
+        assert resp3.update_info["nModified"] == 0
+        assert "upserted" not in resp3.update_info
+
+        resp4 = await acol.update_many({"a": 3}, {"$set": {"n": 4}}, upsert=True)
+        assert resp4.update_info["n"] == 1
+        assert resp4.update_info["updatedExisting"] is False
+        assert resp4.update_info["nModified"] == 0
+        assert "upserted" in resp4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, async")
     async def test_collection_find_one_and_delete_async(
         self,

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -633,6 +633,37 @@ class TestDMLSync:
         assert set(resp_pr2.keys()) == {"mode"}
         col.delete_many({})
 
+    @pytest.mark.describe("test of replace_one, sync")
+    def test_collection_replace_one_sync(
+        self,
+        sync_empty_collection: Collection,
+    ) -> None:
+        col = sync_empty_collection
+
+        result1 = col.replace_one(filter={"a": 1}, replacement={"b": 2})
+        assert result1.update_info["n"] == 0
+        assert result1.update_info["updatedExisting"] is False
+        assert result1.update_info["nModified"] == 0
+        assert "upserted" not in result1.update_info
+
+        result2 = col.replace_one(filter={"a": 1}, replacement={"b": 2}, upsert=True)
+        assert result2.update_info["n"] == 1
+        assert result2.update_info["updatedExisting"] is False
+        assert result2.update_info["nModified"] == 0
+        assert "upserted" in result2.update_info
+
+        result3 = col.replace_one(filter={"b": 2}, replacement={"c": 3})
+        assert result3.update_info["n"] == 1
+        assert result3.update_info["updatedExisting"] is True
+        assert result3.update_info["nModified"] == 1
+        assert "upserted" not in result3.update_info
+
+        result4 = col.replace_one(filter={"c": 3}, replacement={"d": 4}, upsert=True)
+        assert result4.update_info["n"] == 1
+        assert result4.update_info["updatedExisting"] is True
+        assert result4.update_info["nModified"] == 1
+        assert "upserted" not in result4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, sync")
     def test_collection_find_one_and_delete_sync(
         self,

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -664,3 +664,168 @@ class TestDMLSync:
 
         fo_result4 = sync_empty_collection.find_one_and_delete({}, sort={"f": 1})
         assert fo_result4 is None
+
+    @pytest.mark.describe("test of find_one_and_update, sync")
+    def test_collection_find_one_and_update_sync(
+        self,
+        sync_empty_collection: Collection,
+    ) -> None:
+        col = sync_empty_collection
+
+        resp0000 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}})
+        assert resp0000 is None
+        assert col.count_documents({}) == 0
+
+        resp0001 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, sort={"x": 1})
+        assert resp0001 is None
+        assert col.count_documents({}) == 0
+
+        resp0010 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, upsert=True)
+        assert resp0010 is None
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        resp0011 = col.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True, sort={"x": 1}
+        )
+        assert resp0011 is None
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp0100 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}})
+        assert resp0100 is not None
+        assert resp0100["f"] == 0
+        assert "n" not in resp0100
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp0101 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, sort={"x": 1})
+        assert resp0101 is not None
+        assert resp0101["f"] == 0
+        assert "n" not in resp0101
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp0110 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, upsert=True)
+        assert resp0110 is not None
+        assert resp0110["f"] == 0
+        assert "n" not in resp0110
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp0111 = col.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, upsert=True, sort={"x": 1}
+        )
+        assert resp0111 is not None
+        assert resp0111["f"] == 0
+        assert "n" not in resp0111
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        resp1000 = col.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, return_document=ReturnDocument.AFTER
+        )
+        assert resp1000 is None
+        assert col.count_documents({}) == 0
+
+        resp1001 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1001 is None
+        assert col.count_documents({}) == 0
+
+        resp1010 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1010 is not None
+        assert resp1010["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        resp1011 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1011 is not None
+        assert resp1011["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp1100 = col.find_one_and_update(
+            {"f": 0}, {"$set": {"n": 1}}, return_document=ReturnDocument.AFTER
+        )
+        assert resp1100 is not None
+        assert resp1100["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp1101 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1101 is not None
+        assert resp1101["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp1110 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1110 is not None
+        assert resp1110["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        col.insert_one({"f": 0})
+        resp1111 = col.find_one_and_update(
+            {"f": 0},
+            {"$set": {"n": 1}},
+            upsert=True,
+            sort={"x": 1},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp1111 is not None
+        assert resp1111["n"] == 1
+        assert col.count_documents({}) == 1
+        col.delete_many({})
+
+        # projection
+        col.insert_one({"f": 100, "name": "apple", "mode": "old"})
+        resp_pr1 = col.find_one_and_update(
+            {"f": 100},
+            {"$unset": {"mode": ""}},
+            projection=["mode", "f"],
+            return_document=ReturnDocument.AFTER,
+        )
+        assert resp_pr1 is not None
+        assert set(resp_pr1.keys()) == {"_id", "f"}
+        resp_pr2 = col.find_one_and_update(
+            {"f": 100},
+            {"$set": {"mode": "re-replaced"}},
+            projection={"name": False, "_id": False},
+            return_document=ReturnDocument.BEFORE,
+        )
+        assert resp_pr2 is not None
+        assert set(resp_pr2.keys()) == {"f"}
+        col.delete_many({})

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -664,6 +664,41 @@ class TestDMLSync:
         assert result4.update_info["nModified"] == 1
         assert "upserted" not in result4.update_info
 
+    @pytest.mark.describe("test of update_one, sync")
+    def test_collection_update_one_sync(
+        self,
+        sync_empty_collection: Collection,
+    ) -> None:
+        col = sync_empty_collection
+
+        result1 = col.update_one(filter={"a": 1}, update={"$set": {"b": 2}})
+        assert result1.update_info["n"] == 0
+        assert result1.update_info["updatedExisting"] is False
+        assert result1.update_info["nModified"] == 0
+        assert "upserted" not in result1.update_info
+
+        result2 = col.update_one(
+            filter={"a": 1}, update={"$set": {"b": 2}}, upsert=True
+        )
+        assert result2.update_info["n"] == 1
+        assert result2.update_info["updatedExisting"] is False
+        assert result2.update_info["nModified"] == 0
+        assert "upserted" in result2.update_info
+
+        result3 = col.update_one(filter={"b": 2}, update={"$set": {"c": 3}})
+        assert result3.update_info["n"] == 1
+        assert result3.update_info["updatedExisting"] is True
+        assert result3.update_info["nModified"] == 1
+        assert "upserted" not in result3.update_info
+
+        result4 = col.update_one(
+            filter={"c": 3}, update={"$set": {"d": 4}}, upsert=True
+        )
+        assert result4.update_info["n"] == 1
+        assert result4.update_info["updatedExisting"] is True
+        assert result4.update_info["nModified"] == 1
+        assert "upserted" not in result4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, sync")
     def test_collection_find_one_and_delete_sync(
         self,

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -632,3 +632,35 @@ class TestDMLSync:
         assert resp_pr2 is not None
         assert set(resp_pr2.keys()) == {"mode"}
         col.delete_many({})
+
+    @pytest.mark.describe("test of collection find_one_and_delete, sync")
+    def test_collection_find_one_and_delete_sync(
+        self,
+        sync_empty_collection: Collection,
+    ) -> None:
+        sync_empty_collection.insert_one({"doc": 1, "group": "A"})
+        sync_empty_collection.insert_one({"doc": 2, "group": "B"})
+        sync_empty_collection.insert_one({"doc": 3, "group": "A"})
+        assert sync_empty_collection.count_documents(filter={}) == 3
+
+        fo_result1 = sync_empty_collection.find_one_and_delete({"group": "A"})
+        assert fo_result1 is not None
+        assert set(fo_result1.keys()) == {"_id", "doc", "group"}
+        assert sync_empty_collection.count_documents(filter={}) == 2
+
+        fo_result2 = sync_empty_collection.find_one_and_delete(
+            {"group": "B"}, projection=["doc"]
+        )
+        assert fo_result2 is not None
+        assert set(fo_result2.keys()) == {"_id", "doc"}
+        assert sync_empty_collection.count_documents(filter={}) == 1
+
+        fo_result3 = sync_empty_collection.find_one_and_delete(
+            {"group": "A"}, projection={"_id": False, "group": False}
+        )
+        assert fo_result3 is not None
+        assert set(fo_result3.keys()) == {"_id", "doc"}
+        assert sync_empty_collection.count_documents(filter={}) == 0
+
+        fo_result4 = sync_empty_collection.find_one_and_delete({}, sort={"f": 1})
+        assert fo_result4 is None

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -699,6 +699,39 @@ class TestDMLSync:
         assert result4.update_info["nModified"] == 1
         assert "upserted" not in result4.update_info
 
+    @pytest.mark.describe("test of update_many, sync")
+    def test_collection_update_many_sync(
+        self,
+        sync_empty_collection: Collection,
+    ) -> None:
+        col = sync_empty_collection
+        col.insert_many([{"a": 1, "seq": i} for i in range(4)])
+        col.insert_many([{"a": 2, "seq": i} for i in range(2)])
+
+        resp1 = col.update_many({"a": 1}, {"$set": {"n": 1}})
+        assert resp1.update_info["n"] == 4
+        assert resp1.update_info["updatedExisting"] is True
+        assert resp1.update_info["nModified"] == 4
+        assert "upserted" not in resp1.update_info
+
+        resp2 = col.update_many({"a": 1}, {"$set": {"n": 2}}, upsert=True)
+        assert resp2.update_info["n"] == 4
+        assert resp2.update_info["updatedExisting"] is True
+        assert resp2.update_info["nModified"] == 4
+        assert "upserted" not in resp2.update_info
+
+        resp3 = col.update_many({"a": 3}, {"$set": {"n": 3}})
+        assert resp3.update_info["n"] == 0
+        assert resp3.update_info["updatedExisting"] is False
+        assert resp3.update_info["nModified"] == 0
+        assert "upserted" not in resp3.update_info
+
+        resp4 = col.update_many({"a": 3}, {"$set": {"n": 4}}, upsert=True)
+        assert resp4.update_info["n"] == 1
+        assert resp4.update_info["updatedExisting"] is False
+        assert resp4.update_info["nModified"] == 0
+        assert "upserted" in resp4.update_info
+
     @pytest.mark.describe("test of collection find_one_and_delete, sync")
     def test_collection_find_one_and_delete_sync(
         self,


### PR DESCRIPTION
- `chunked_delete_many` utility at astrapy level
- delete_many
- adding projection to (astrapy-level) `(vector_)find_one_and_replace` and `(vector_)find_one_and_update`
- find_one_and_replace
- find_one_and_delete
- find_one_and_update
- replace_one
- update_one
- update_many