### PR TITLE
More management methods

### DIFF
--- a/astrapy/db.py
+++ b/astrapy/db.py
@@ -211,6 +211,13 @@ class AstraDBCollection:
         response = restore_from_api(direct_response)
         return response
 
+    def post_raw_request(self, body: Dict[str, Any]) -> API_RESPONSE:
+        return self._request(
+            method=http_methods.POST,
+            path=self.base_path,
+            json_data=body,
+        )
+
     def _get(
         self, path: Optional[str] = None, options: Optional[Dict[str, Any]] = None
     ) -> Optional[API_RESPONSE]:
@@ -1280,6 +1287,13 @@ class AsyncAstraDBCollection:
         response = restore_from_api(adirect_response)
         return response
 
+    async def post_raw_request(self, body: Dict[str, Any]) -> API_RESPONSE:
+        return await self._request(
+            method=http_methods.POST,
+            path=self.base_path,
+            json_data=body,
+        )
+
     async def _get(
         self, path: Optional[str] = None, options: Optional[Dict[str, Any]] = None
     ) -> Optional[API_RESPONSE]:
@@ -2290,6 +2304,13 @@ class AstraDB:
         response = restore_from_api(direct_response)
         return response
 
+    def post_raw_request(self, body: Dict[str, Any]) -> API_RESPONSE:
+        return self._request(
+            method=http_methods.POST,
+            path=self.base_path,
+            json_data=body,
+        )
+
     def collection(self, collection_name: str) -> AstraDBCollection:
         """
         Retrieve a collection from the database.
@@ -2587,6 +2608,13 @@ class AsyncAstraDB:
         )
         response = restore_from_api(adirect_response)
         return response
+
+    async def post_raw_request(self, body: Dict[str, Any]) -> API_RESPONSE:
+        return await self._request(
+            method=http_methods.POST,
+            path=self.base_path,
+            json_data=body,
+        )
 
     async def collection(self, collection_name: str) -> AsyncAstraDBCollection:
         """

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -98,6 +98,14 @@ class Collection:
         else:
             return False
 
+    def __call__(self, *pargs: Any, **kwargs: Any) -> None:
+        raise TypeError(
+            f"'{self.__class__.__name__}' object is not callable. If you "
+            f"meant to call the '{self.name}' method on a "
+            f"'{self.database.__class__.__name__}' object "
+            "it is failing because no such method exists."
+        )
+
     def copy(
         self,
         *,
@@ -569,6 +577,14 @@ class AsyncCollection:
             return self._astra_db_collection == other._astra_db_collection
         else:
             return False
+
+    def __call__(self, *pargs: Any, **kwargs: Any) -> None:
+        raise TypeError(
+            f"'{self.__class__.__name__}' object is not callable. If you "
+            f"meant to call the '{self.name}' method on a "
+            f"'{self.database.__class__.__name__}' object "
+            "it is failing because no such method exists."
+        )
 
     def copy(
         self,

--- a/astrapy/idiomatic/database.py
+++ b/astrapy/idiomatic/database.py
@@ -305,11 +305,11 @@ class AsyncDatabase:
             caller_version=caller_version,
         )
 
-    async def __getattr__(self, collection_name: str) -> AsyncCollection:
-        return await self.get_collection(name=collection_name)
+    def __getattr__(self, collection_name: str) -> AsyncCollection:
+        return self.to_sync().get_collection(name=collection_name).to_async()
 
-    async def __getitem__(self, collection_name: str) -> AsyncCollection:
-        return await self.get_collection(name=collection_name)
+    def __getitem__(self, collection_name: str) -> AsyncCollection:
+        return self.to_sync().get_collection(name=collection_name).to_async()
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}[_astra_db={self._astra_db}"]'

--- a/astrapy/idiomatic/database.py
+++ b/astrapy/idiomatic/database.py
@@ -282,6 +282,23 @@ class Database:
             # we know this is a list of strings
             return gc_response["status"]["collections"]  # type: ignore[no-any-return]
 
+    def command(
+        self,
+        body: Dict[str, Any],
+        *,
+        namespace: Optional[str] = None,
+        collection_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if namespace:
+            _client = self._astra_db.copy(namespace=namespace)
+        else:
+            _client = self._astra_db
+        if collection_name:
+            _collection = _client.collection(collection_name)
+            return _collection.post_raw_request(body=body)
+        else:
+            return _client.post_raw_request(body=body)
+
 
 class AsyncDatabase:
     def __init__(
@@ -504,3 +521,20 @@ class AsyncDatabase:
         else:
             # we know this is a list of strings
             return gc_response["status"]["collections"]  # type: ignore[no-any-return]
+
+    async def command(
+        self,
+        body: Dict[str, Any],
+        *,
+        namespace: Optional[str] = None,
+        collection_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if namespace:
+            _client = self._astra_db.copy(namespace=namespace)
+        else:
+            _client = self._astra_db
+        if collection_name:
+            _collection = await _client.collection(collection_name)
+            return await _collection.post_raw_request(body=body)
+        else:
+            return await _client.post_raw_request(body=body)

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -160,3 +160,34 @@ class TestDDLAsync:
             TEST_LOCAL_COLLECTION_NAME2
             not in await database_on_secondary.list_collection_names()
         )
+
+    @pytest.mark.describe("test of collection command, async")
+    async def test_collection_command_async(
+        self,
+        async_database: AsyncDatabase,
+        async_collection: AsyncCollection,
+    ) -> None:
+        cmd1 = await async_database.command(
+            {"countDocuments": {}}, collection_name=async_collection.name
+        )
+        assert isinstance(cmd1, dict)
+        assert isinstance(cmd1["status"]["count"], int)
+        cmd2 = await async_database.copy(namespace="...").command(
+            {"countDocuments": {}},
+            namespace=async_collection.namespace,
+            collection_name=async_collection.name,
+        )
+        assert cmd2 == cmd1
+
+    @pytest.mark.describe("test of database command, async")
+    async def test_database_command_async(
+        self,
+        async_database: AsyncDatabase,
+    ) -> None:
+        cmd1 = await async_database.command({"findCollections": {}})
+        assert isinstance(cmd1, dict)
+        assert isinstance(cmd1["status"]["collections"], list)
+        cmd2 = await async_database.copy(namespace="...").command(
+            {"findCollections": {}}, namespace=async_database.namespace
+        )
+        assert cmd2 == cmd1

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -157,3 +157,34 @@ class TestDDLSync:
             TEST_LOCAL_COLLECTION_NAME2
             not in database_on_secondary.list_collection_names()
         )
+
+    @pytest.mark.describe("test of collection command, sync")
+    def test_collection_command_sync(
+        self,
+        sync_database: Database,
+        sync_collection: Collection,
+    ) -> None:
+        cmd1 = sync_database.command(
+            {"countDocuments": {}}, collection_name=sync_collection.name
+        )
+        assert isinstance(cmd1, dict)
+        assert isinstance(cmd1["status"]["count"], int)
+        cmd2 = sync_database.copy(namespace="...").command(
+            {"countDocuments": {}},
+            namespace=sync_collection.namespace,
+            collection_name=sync_collection.name,
+        )
+        assert cmd2 == cmd1
+
+    @pytest.mark.describe("test of database command, sync")
+    def test_database_command_sync(
+        self,
+        sync_database: Database,
+    ) -> None:
+        cmd1 = sync_database.command({"findCollections": {}})
+        assert isinstance(cmd1, dict)
+        assert isinstance(cmd1["status"]["collections"], list)
+        cmd2 = sync_database.copy(namespace="...").command(
+            {"findCollections": {}}, namespace=sync_database.namespace
+        )
+        assert cmd2 == cmd1

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -174,10 +174,8 @@ class TestDatabasesAsync:
         collection = await async_database.get_collection(TEST_COLLECTION_INSTANCE_NAME)
         assert collection == async_collection_instance
 
-        assert (
-            await getattr(async_database, TEST_COLLECTION_INSTANCE_NAME) == collection
-        )
-        assert await async_database[TEST_COLLECTION_INSTANCE_NAME] == collection
+        assert getattr(async_database, TEST_COLLECTION_INSTANCE_NAME) == collection
+        assert async_database[TEST_COLLECTION_INSTANCE_NAME] == collection
 
         NAMESPACE_2 = "other_namespace"
         collection_ns2 = await async_database.get_collection(


### PR DESCRIPTION
- better error messages against `database.xyz()` calls
- `database.command()`
- `database` and `collections` have `.with_options()`