### PR TITLE
Adapt to latest choices in API semantics

### DIFF
--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -342,10 +342,10 @@ class Collection:
         projection: Optional[ProjectionType] = None,
         sort: Optional[Dict[str, Any]] = None,
         upsert: bool = False,
-        return_document: ReturnDocument = ReturnDocument.BEFORE,
+        return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
         options = {
-            "returnDocument": return_document.value,
+            "returnDocument": return_document,
             "upsert": upsert,
         }
         fo_response = self._astra_db_collection.find_one_and_replace(
@@ -403,10 +403,10 @@ class Collection:
         projection: Optional[ProjectionType] = None,
         sort: Optional[Dict[str, Any]] = None,
         upsert: bool = False,
-        return_document: ReturnDocument = ReturnDocument.BEFORE,
+        return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
         options = {
-            "returnDocument": return_document.value,
+            "returnDocument": return_document,
             "upsert": upsert,
         }
         fo_response = self._astra_db_collection.find_one_and_update(
@@ -875,10 +875,10 @@ class AsyncCollection:
         projection: Optional[ProjectionType] = None,
         sort: Optional[Dict[str, Any]] = None,
         upsert: bool = False,
-        return_document: ReturnDocument = ReturnDocument.BEFORE,
+        return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
         options = {
-            "returnDocument": return_document.value,
+            "returnDocument": return_document,
             "upsert": upsert,
         }
         fo_response = await self._astra_db_collection.find_one_and_replace(
@@ -936,10 +936,10 @@ class AsyncCollection:
         projection: Optional[ProjectionType] = None,
         sort: Optional[Dict[str, Any]] = None,
         upsert: bool = False,
-        return_document: ReturnDocument = ReturnDocument.BEFORE,
+        return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
         options = {
-            "returnDocument": return_document.value,
+            "returnDocument": return_document,
             "upsert": upsert,
         }
         fo_response = await self._astra_db_collection.find_one_and_update(

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -22,8 +22,10 @@ from typing import Any, Dict, Iterable, List, Optional, Union, TYPE_CHECKING
 from astrapy.db import AstraDBCollection, AsyncAstraDBCollection
 from astrapy.idiomatic.types import (
     DocumentType,
+    FilterType,
     ProjectionType,
     ReturnDocument,
+    SortType,
     normalize_optional_projection,
 )
 from astrapy.idiomatic.database import AsyncDatabase, Database
@@ -260,12 +262,12 @@ class Collection:
 
     def find(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
         *,
         projection: Optional[ProjectionType] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> Cursor:
         return (
             Cursor(
@@ -280,12 +282,12 @@ class Collection:
 
     def find_one(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
         *,
         projection: Optional[ProjectionType] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> Union[DocumentType, None]:
         fo_cursor = self.find(
             filter=filter,
@@ -304,7 +306,7 @@ class Collection:
         self,
         key: str,
         *,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
     ) -> List[Any]:
         return self.find(
             filter=filter,
@@ -340,7 +342,7 @@ class Collection:
         replacement: DocumentType,
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
         upsert: bool = False,
         return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
@@ -401,7 +403,7 @@ class Collection:
         update: Dict[str, Any],
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
         upsert: bool = False,
         return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
@@ -483,7 +485,7 @@ class Collection:
         filter: Dict[str, Any],
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> Union[DocumentType, None]:
         _projection = normalize_optional_projection(projection, ensure_fields={"_id"})
         target_document = self.find_one(
@@ -792,12 +794,12 @@ class AsyncCollection:
 
     def find(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
         *,
         projection: Optional[ProjectionType] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> AsyncCursor:
         return (
             AsyncCursor(
@@ -812,12 +814,12 @@ class AsyncCollection:
 
     async def find_one(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
         *,
         projection: Optional[ProjectionType] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> Union[DocumentType, None]:
         fo_cursor = self.find(
             filter=filter,
@@ -836,7 +838,7 @@ class AsyncCollection:
         self,
         key: str,
         *,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[FilterType] = None,
     ) -> List[Any]:
         cursor = self.find(
             filter=filter,
@@ -873,7 +875,7 @@ class AsyncCollection:
         replacement: DocumentType,
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
         upsert: bool = False,
         return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
@@ -934,7 +936,7 @@ class AsyncCollection:
         update: Dict[str, Any],
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
         upsert: bool = False,
         return_document: str = ReturnDocument.BEFORE,
     ) -> Union[DocumentType, None]:
@@ -1016,7 +1018,7 @@ class AsyncCollection:
         filter: Dict[str, Any],
         *,
         projection: Optional[ProjectionType] = None,
-        sort: Optional[Dict[str, Any]] = None,
+        sort: Optional[SortType] = None,
     ) -> Union[DocumentType, None]:
         _projection = normalize_optional_projection(projection, ensure_fields={"_id"})
         target_document = await self.find_one(

--- a/astrapy/idiomatic/collection.py
+++ b/astrapy/idiomatic/collection.py
@@ -254,7 +254,7 @@ class Collection:
             ]
             return InsertManyResult(
                 # if we are here, cim_responses are all dicts (no exceptions)
-                raw_result=cim_responses,  # type: ignore[arg-type]
+                raw_results=cim_responses,  # type: ignore[arg-type]
                 inserted_ids=inserted_ids,
             )
 
@@ -314,14 +314,20 @@ class Collection:
     def count_documents(
         self,
         filter: Dict[str, Any],
+        upper_bound: int,
     ) -> int:
         cd_response = self._astra_db_collection.count_documents(filter=filter)
         if "count" in cd_response.get("status", {}):
             count: int = cd_response["status"]["count"]
             if cd_response["status"].get("moreData", False):
-                raise ValueError(f"Document count exceeds {count}")
+                raise ValueError(
+                    f"Document count exceeds {count}, the maximum allowed by the server"
+                )
             else:
-                return count
+                if count > upper_bound:
+                    raise ValueError("Document count exceeds required upper bound")
+                else:
+                    return count
         else:
             raise ValueError(
                 "Could not complete a count_documents operation. "
@@ -505,13 +511,13 @@ class Collection:
             if deleted_count == -1:
                 return DeleteResult(
                     deleted_count=None,
-                    raw_result=do_response,
+                    raw_results=[do_response],
                 )
             else:
                 # expected a non-negative integer:
                 return DeleteResult(
                     deleted_count=deleted_count,
-                    raw_result=do_response,
+                    raw_results=[do_response],
                 )
         else:
             raise ValueError(
@@ -535,13 +541,13 @@ class Collection:
             if deleted_count == -1:
                 return DeleteResult(
                     deleted_count=None,
-                    raw_result=dm_responses,
+                    raw_results=dm_responses,
                 )
             else:
                 # per API specs, deleted_count has to be a non-negative integer.
                 return DeleteResult(
                     deleted_count=deleted_count,
-                    raw_result=dm_responses,
+                    raw_results=dm_responses,
                 )
         else:
             raise ValueError(
@@ -780,7 +786,7 @@ class AsyncCollection:
             ]
             return InsertManyResult(
                 # if we are here, cim_responses are all dicts (no exceptions)
-                raw_result=cim_responses,  # type: ignore[arg-type]
+                raw_results=cim_responses,  # type: ignore[arg-type]
                 inserted_ids=inserted_ids,
             )
 
@@ -841,14 +847,20 @@ class AsyncCollection:
     async def count_documents(
         self,
         filter: Dict[str, Any],
+        upper_bound: int,
     ) -> int:
         cd_response = await self._astra_db_collection.count_documents(filter=filter)
         if "count" in cd_response.get("status", {}):
             count: int = cd_response["status"]["count"]
             if cd_response["status"].get("moreData", False):
-                raise ValueError(f"Document count exceeds {count}")
+                raise ValueError(
+                    f"Document count exceeds {count}, the maximum allowed by the server"
+                )
             else:
-                return count
+                if count > upper_bound:
+                    raise ValueError("Document count exceeds required upper bound")
+                else:
+                    return count
         else:
             raise ValueError(
                 "Could not complete a count_documents operation. "
@@ -1034,13 +1046,13 @@ class AsyncCollection:
             if deleted_count == -1:
                 return DeleteResult(
                     deleted_count=None,
-                    raw_result=do_response,
+                    raw_results=[do_response],
                 )
             else:
                 # expected a non-negative integer:
                 return DeleteResult(
                     deleted_count=deleted_count,
-                    raw_result=do_response,
+                    raw_results=[do_response],
                 )
         else:
             raise ValueError(
@@ -1068,13 +1080,13 @@ class AsyncCollection:
             if deleted_count == -1:
                 return DeleteResult(
                     deleted_count=None,
-                    raw_result=dm_responses,
+                    raw_results=dm_responses,
                 )
             else:
                 # per API specs, deleted_count has to be a non-negative integer.
                 return DeleteResult(
                     deleted_count=deleted_count,
-                    raw_result=dm_responses,
+                    raw_results=dm_responses,
                 )
         else:
             raise ValueError(

--- a/astrapy/idiomatic/operations.py
+++ b/astrapy/idiomatic/operations.py
@@ -86,7 +86,7 @@ class InsertOne(BaseOperation):
     ) -> BulkWriteResult:
         op_result = collection.insert_one(document=self.document)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=1,
             matched_count=0,
@@ -117,7 +117,7 @@ class InsertMany(BaseOperation):
             ordered=self.ordered,
         )
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=0,
             inserted_count=len(op_result.inserted_ids),
             matched_count=0,
@@ -159,7 +159,7 @@ class UpdateOne(BaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -201,7 +201,7 @@ class UpdateMany(BaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -243,7 +243,7 @@ class ReplaceOne(BaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -268,7 +268,7 @@ class DeleteOne(BaseOperation):
     ) -> BulkWriteResult:
         op_result = collection.delete_one(filter=self.filter)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=op_result.deleted_count,
             inserted_count=0,
             matched_count=0,
@@ -293,7 +293,7 @@ class DeleteMany(BaseOperation):
     ) -> BulkWriteResult:
         op_result = collection.delete_many(filter=self.filter)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=op_result.deleted_count,
             inserted_count=0,
             matched_count=0,
@@ -325,7 +325,7 @@ class AsyncInsertOne(AsyncBaseOperation):
     ) -> BulkWriteResult:
         op_result = await collection.insert_one(document=self.document)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=1,
             matched_count=0,
@@ -356,7 +356,7 @@ class AsyncInsertMany(AsyncBaseOperation):
             ordered=self.ordered,
         )
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=0,
             inserted_count=len(op_result.inserted_ids),
             matched_count=0,
@@ -398,7 +398,7 @@ class AsyncUpdateOne(AsyncBaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -440,7 +440,7 @@ class AsyncUpdateMany(AsyncBaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -482,7 +482,7 @@ class AsyncReplaceOne(AsyncBaseOperation):
         else:
             upserted_ids = {}
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: [op_result.raw_result]},
             deleted_count=0,
             inserted_count=inserted_count,
             matched_count=matched_count,
@@ -507,7 +507,7 @@ class AsyncDeleteOne(AsyncBaseOperation):
     ) -> BulkWriteResult:
         op_result = await collection.delete_one(filter=self.filter)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=op_result.deleted_count,
             inserted_count=0,
             matched_count=0,
@@ -532,7 +532,7 @@ class AsyncDeleteMany(AsyncBaseOperation):
     ) -> BulkWriteResult:
         op_result = await collection.delete_many(filter=self.filter)
         return BulkWriteResult(
-            bulk_api_results={index_in_bulk_write: op_result.raw_result},
+            bulk_api_results={index_in_bulk_write: op_result.raw_results},
             deleted_count=op_result.deleted_count,
             inserted_count=0,
             matched_count=0,

--- a/astrapy/idiomatic/results.py
+++ b/astrapy/idiomatic/results.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -25,12 +25,13 @@ class DeleteResult:
 
     Attributes:
         deleted_count: number of deleted documents
-        raw_result: response/responses from the Data API call.
+        raw_results: response/responses from the Data API call.
             Depending on the exact delete method being used, this
             can be a list of raw responses or a single raw response.
     """
+
     deleted_count: Optional[int]
-    raw_result: Union[Dict[str, Any], List[Dict[str, Any]]]
+    raw_results: List[Dict[str, Any]]
 
 
 @dataclass
@@ -42,6 +43,7 @@ class InsertOneResult:
         raw_result: response from the Data API call
         inserted_id: the ID of the inserted document
     """
+
     raw_result: Dict[str, Any]
     inserted_id: Any
 
@@ -52,10 +54,11 @@ class InsertManyResult:
     Class that represents the result of insert_many operations.
 
     Attributes:
-        raw_result: response from the Data API call
+        raw_results: response from the Data API call
         inserted_ids: list of the IDs of the inserted documents
     """
-    raw_result: List[Dict[str, Any]]
+
+    raw_results: List[Dict[str, Any]]
     inserted_ids: List[Any]
 
 
@@ -74,6 +77,7 @@ class UpdateResult:
         and optionally "upserted" containing the ID of an upserted document.
 
     """
+
     raw_result: Dict[str, Any]
     update_info: Dict[str, Any]
 
@@ -97,7 +101,8 @@ class BulkWriteResult:
         upserted_count: number of upserted documents
         upserted_ids: a (sparse) map from indices to ID of the upserted document
     """
-    bulk_api_results: Dict[int, Union[Dict[str, Any], List[Dict[str, Any]]]]
+
+    bulk_api_results: Dict[int, List[Dict[str, Any]]]
     deleted_count: Optional[int]
     inserted_count: int
     matched_count: int

--- a/astrapy/idiomatic/results.py
+++ b/astrapy/idiomatic/results.py
@@ -28,11 +28,9 @@ class DeleteResult:
         raw_result: response/responses from the Data API call.
             Depending on the exact delete method being used, this
             can be a list of raw responses or a single raw response.
-        acknowledged: whether the server acknowledged the write operation
     """
     deleted_count: Optional[int]
     raw_result: Union[Dict[str, Any], List[Dict[str, Any]]]
-    acknowledged: bool = True
 
 
 @dataclass
@@ -43,11 +41,9 @@ class InsertOneResult:
     Attributes:
         raw_result: response from the Data API call
         inserted_id: the ID of the inserted document
-        acknowledged: whether the server acknowledged the write operation
     """
     raw_result: Dict[str, Any]
     inserted_id: Any
-    acknowledged: bool = True
 
 
 @dataclass
@@ -58,11 +54,9 @@ class InsertManyResult:
     Attributes:
         raw_result: response from the Data API call
         inserted_ids: list of the IDs of the inserted documents
-        acknowledged: whether the server acknowledged the write operation
     """
     raw_result: List[Dict[str, Any]]
     inserted_ids: List[Any]
-    acknowledged: bool = True
 
 
 @dataclass
@@ -73,7 +67,6 @@ class UpdateResult:
     Attributes:
         raw_result: response from the Data API call
         update_info: a dictionary reporting about the update
-        acknowledged: whether the server acknowledged the write operation
 
     Note:
         the "update_info" field has the following fields: "n" (int),
@@ -83,7 +76,6 @@ class UpdateResult:
     """
     raw_result: Dict[str, Any]
     update_info: Dict[str, Any]
-    acknowledged: bool = True
 
 
 @dataclass
@@ -104,7 +96,6 @@ class BulkWriteResult:
         modified_count: number of modified documents
         upserted_count: number of upserted documents
         upserted_ids: a (sparse) map from indices to ID of the upserted document
-        acknowledged: whether the server acknowledged the write operation
     """
     bulk_api_results: Dict[int, Union[Dict[str, Any], List[Dict[str, Any]]]]
     deleted_count: Optional[int]
@@ -113,4 +104,3 @@ class BulkWriteResult:
     modified_count: int
     upserted_count: int
     upserted_ids: Dict[int, Any]
-    acknowledged: bool = True

--- a/astrapy/idiomatic/results.py
+++ b/astrapy/idiomatic/results.py
@@ -20,6 +20,16 @@ from typing import Any, Dict, List, Optional, Union
 
 @dataclass
 class DeleteResult:
+    """
+    Class that represents the result of delete operations.
+
+    Attributes:
+        deleted_count: number of deleted documents
+        raw_result: response/responses from the Data API call.
+            Depending on the exact delete method being used, this
+            can be a list of raw responses or a single raw response.
+        acknowledged: whether the server acknowledged the write operation
+    """
     deleted_count: Optional[int]
     raw_result: Union[Dict[str, Any], List[Dict[str, Any]]]
     acknowledged: bool = True
@@ -27,6 +37,14 @@ class DeleteResult:
 
 @dataclass
 class InsertOneResult:
+    """
+    Class that represents the result of insert_one operations.
+
+    Attributes:
+        raw_result: response from the Data API call
+        inserted_id: the ID of the inserted document
+        acknowledged: whether the server acknowledged the write operation
+    """
     raw_result: Dict[str, Any]
     inserted_id: Any
     acknowledged: bool = True
@@ -34,6 +52,14 @@ class InsertOneResult:
 
 @dataclass
 class InsertManyResult:
+    """
+    Class that represents the result of insert_many operations.
+
+    Attributes:
+        raw_result: response from the Data API call
+        inserted_ids: list of the IDs of the inserted documents
+        acknowledged: whether the server acknowledged the write operation
+    """
     raw_result: List[Dict[str, Any]]
     inserted_ids: List[Any]
     acknowledged: bool = True
@@ -41,6 +67,20 @@ class InsertManyResult:
 
 @dataclass
 class UpdateResult:
+    """
+    Class that represents the result of any update operation.
+
+    Attributes:
+        raw_result: response from the Data API call
+        update_info: a dictionary reporting about the update
+        acknowledged: whether the server acknowledged the write operation
+
+    Note:
+        the "update_info" field has the following fields: "n" (int),
+        "updatedExisting" (bool), "ok" (float), "nModified" (int)
+        and optionally "upserted" containing the ID of an upserted document.
+
+    """
     raw_result: Dict[str, Any]
     update_info: Dict[str, Any]
     acknowledged: bool = True
@@ -48,6 +88,24 @@ class UpdateResult:
 
 @dataclass
 class BulkWriteResult:
+    """
+    Class that represents the result of a bulk write operations.
+
+    Indices in the maps below refer to the position of each write operation
+    in the list of operations passed to the bulk_write command.
+
+    The numeric counts refer to the whole of the bulk write.
+
+    Attributes:
+        bulk_api_results: a map from indices to the corresponding raw responses
+        deleted_count: number of deleted documents
+        inserted_count: number of inserted documents
+        matched_count: number of matched documents
+        modified_count: number of modified documents
+        upserted_count: number of upserted documents
+        upserted_ids: a (sparse) map from indices to ID of the upserted document
+        acknowledged: whether the server acknowledged the write operation
+    """
     bulk_api_results: Dict[int, Union[Dict[str, Any], List[Dict[str, Any]]]]
     deleted_count: Optional[int]
     inserted_count: int

--- a/astrapy/idiomatic/types.py
+++ b/astrapy/idiomatic/types.py
@@ -23,6 +23,11 @@ ProjectionType = Union[Iterable[str], Dict[str, bool]]
 
 
 class ReturnDocument(Enum):
+    """
+    Admitted values for the `return_document` parameter in 
+    `find_one_and_replace` and `find_one_and_update` collection
+    methods.
+    """
     BEFORE = "before"
     AFTER = "after"
 

--- a/astrapy/idiomatic/types.py
+++ b/astrapy/idiomatic/types.py
@@ -24,10 +24,11 @@ ProjectionType = Union[Iterable[str], Dict[str, bool]]
 
 class ReturnDocument(Enum):
     """
-    Admitted values for the `return_document` parameter in 
+    Admitted values for the `return_document` parameter in
     `find_one_and_replace` and `find_one_and_update` collection
     methods.
     """
+
     BEFORE = "before"
     AFTER = "after"
 

--- a/astrapy/idiomatic/types.py
+++ b/astrapy/idiomatic/types.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, Iterable, Optional, Union
 
 DocumentType = Dict[str, Any]
 ProjectionType = Union[Iterable[str], Dict[str, bool]]
+SortType = Dict[str, Any]
+FilterType = Dict[str, Any]
 
 
 class ReturnDocument:

--- a/astrapy/idiomatic/types.py
+++ b/astrapy/idiomatic/types.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any, Dict, Iterable, Optional, Union
 
 
@@ -22,15 +21,31 @@ DocumentType = Dict[str, Any]
 ProjectionType = Union[Iterable[str], Dict[str, bool]]
 
 
-class ReturnDocument(Enum):
+class ReturnDocument:
     """
     Admitted values for the `return_document` parameter in
     `find_one_and_replace` and `find_one_and_update` collection
     methods.
     """
 
+    def __init__(self) -> None:
+        raise NotImplementedError
+
     BEFORE = "before"
     AFTER = "after"
+
+
+class SortDocuments:
+    """
+    Admitted values for the `sort` parameter in the find collection methods,
+    e.g. `sort={"field": SortDocuments.ASCENDING}`.
+    """
+
+    def __init__(self) -> None:
+        raise NotImplementedError
+
+    ASCENDING = 1
+    DESCENDING = -1
 
 
 def normalize_optional_projection(

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -21,7 +21,7 @@ from astrapy.results import DeleteResult, InsertOneResult
 from astrapy.api import APIRequestError
 from astrapy.idiomatic.types import DocumentType
 from astrapy.idiomatic.cursors import AsyncCursor
-from astrapy.idiomatic.types import ReturnDocument
+from astrapy.idiomatic.types import ReturnDocument, SortDocuments
 from astrapy.idiomatic.operations import (
     AsyncInsertOne,
     AsyncInsertMany,
@@ -190,7 +190,7 @@ class TestDMLAsync:
         await async_empty_collection.insert_many([{"seq": i} for i in range(30)])
         Nski = 1
         Nlim = 28
-        Nsor = {"seq": -1}
+        Nsor = {"seq": SortDocuments.DESCENDING}
         Nfil = {"seq": {"$exists": True}}
 
         async def _alist(acursor: AsyncCursor) -> List[DocumentType]:

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -64,7 +64,6 @@ class TestDMLAsync:
     ) -> None:
         io_result1 = await async_empty_collection.insert_one({"doc": 1, "group": "A"})
         assert isinstance(io_result1, InsertOneResult)
-        assert io_result1.acknowledged is True
         io_result2 = await async_empty_collection.insert_one(
             {"_id": "xxx", "doc": 2, "group": "B"}
         )
@@ -82,7 +81,6 @@ class TestDMLAsync:
         assert await async_empty_collection.count_documents(filter={}) == 3
         do_result1 = await async_empty_collection.delete_one({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 1
         assert await async_empty_collection.count_documents(filter={}) == 2
 
@@ -97,7 +95,6 @@ class TestDMLAsync:
         assert await async_empty_collection.count_documents(filter={}) == 3
         do_result1 = await async_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 2
         assert await async_empty_collection.count_documents(filter={}) == 1
 
@@ -112,7 +109,6 @@ class TestDMLAsync:
         assert (await async_empty_collection.count_documents(filter={})) == 3
         do_result1 = await async_empty_collection.delete_many({})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count is None
         assert (await async_empty_collection.count_documents(filter={})) == 0
 
@@ -130,7 +126,6 @@ class TestDMLAsync:
         assert (await async_empty_collection.count_documents(filter={})) == 60
         do_result1 = await async_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 50
         assert (await async_empty_collection.count_documents(filter={})) == 10
 

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -17,7 +17,7 @@ import pytest
 from astrapy import Collection
 from astrapy.results import DeleteResult, InsertOneResult
 from astrapy.api import APIRequestError
-from astrapy.idiomatic.types import ReturnDocument
+from astrapy.idiomatic.types import ReturnDocument, SortDocuments
 from astrapy.idiomatic.operations import (
     InsertOne,
     InsertMany,
@@ -144,7 +144,7 @@ class TestDMLSync:
         sync_empty_collection.insert_many([{"seq": i} for i in range(30)])
         Nski = 1
         Nlim = 28
-        Nsor = {"seq": -1}
+        Nsor = {"seq": SortDocuments.DESCENDING}
         Nfil = {"seq": {"$exists": True}}
 
         # case 0000 of find-pattern matrix

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -60,7 +60,6 @@ class TestDMLSync:
     ) -> None:
         io_result1 = sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         assert isinstance(io_result1, InsertOneResult)
-        assert io_result1.acknowledged is True
         io_result2 = sync_empty_collection.insert_one(
             {"_id": "xxx", "doc": 2, "group": "B"}
         )
@@ -78,7 +77,6 @@ class TestDMLSync:
         assert sync_empty_collection.count_documents(filter={}) == 3
         do_result1 = sync_empty_collection.delete_one({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 1
         assert sync_empty_collection.count_documents(filter={}) == 2
 
@@ -93,7 +91,6 @@ class TestDMLSync:
         assert sync_empty_collection.count_documents(filter={}) == 3
         do_result1 = sync_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 2
         assert sync_empty_collection.count_documents(filter={}) == 1
 
@@ -108,7 +105,6 @@ class TestDMLSync:
         assert sync_empty_collection.count_documents(filter={}) == 3
         do_result1 = sync_empty_collection.delete_many({})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count is None
         assert sync_empty_collection.count_documents(filter={}) == 0
 
@@ -122,7 +118,6 @@ class TestDMLSync:
         assert sync_empty_collection.count_documents(filter={}) == 60
         do_result1 = sync_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
-        assert do_result1.acknowledged is True
         assert do_result1.deleted_count == 50
         assert sync_empty_collection.count_documents(filter={}) == 10
 

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -35,23 +35,33 @@ class TestDMLSync:
         self,
         sync_empty_collection: Collection,
     ) -> None:
-        assert sync_empty_collection.count_documents(filter={}) == 0
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 0
         sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         sync_empty_collection.insert_one({"doc": 2, "group": "B"})
         sync_empty_collection.insert_one({"doc": 3, "group": "A"})
-        assert sync_empty_collection.count_documents(filter={}) == 3
-        assert sync_empty_collection.count_documents(filter={"group": "A"}) == 2
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 3
+        assert (
+            sync_empty_collection.count_documents(
+                filter={"group": "A"}, upper_bound=100
+            )
+            == 2
+        )
 
     @pytest.mark.describe("test of overflowing collection count_documents, sync")
     def test_collection_overflowing_count_documents_sync(
         self,
         sync_empty_collection: Collection,
     ) -> None:
-        sync_empty_collection.insert_many([{"a": i} for i in range(999)])
-        assert sync_empty_collection.count_documents(filter={}) == 999
-        sync_empty_collection.insert_many([{"b": i} for i in range(2)])
+        sync_empty_collection.insert_many([{"a": i} for i in range(900)])
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=950) == 900
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=2000) == 900
         with pytest.raises(ValueError):
-            assert sync_empty_collection.count_documents(filter={})
+            sync_empty_collection.count_documents(filter={}, upper_bound=100) == 900
+        sync_empty_collection.insert_many([{"b": i} for i in range(200)])
+        with pytest.raises(ValueError):
+            assert sync_empty_collection.count_documents(filter={}, upper_bound=100)
+        with pytest.raises(ValueError):
+            assert sync_empty_collection.count_documents(filter={}, upper_bound=2000)
 
     @pytest.mark.describe("test of collection insert_one, sync")
     def test_collection_insert_one_sync(
@@ -64,7 +74,12 @@ class TestDMLSync:
             {"_id": "xxx", "doc": 2, "group": "B"}
         )
         assert io_result2.inserted_id == "xxx"
-        assert sync_empty_collection.count_documents(filter={"group": "A"}) == 1
+        assert (
+            sync_empty_collection.count_documents(
+                filter={"group": "A"}, upper_bound=100
+            )
+            == 1
+        )
 
     @pytest.mark.describe("test of collection delete_one, sync")
     def test_collection_delete_one_sync(
@@ -74,11 +89,11 @@ class TestDMLSync:
         sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         sync_empty_collection.insert_one({"doc": 2, "group": "B"})
         sync_empty_collection.insert_one({"doc": 3, "group": "A"})
-        assert sync_empty_collection.count_documents(filter={}) == 3
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 3
         do_result1 = sync_empty_collection.delete_one({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
         assert do_result1.deleted_count == 1
-        assert sync_empty_collection.count_documents(filter={}) == 2
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 2
 
     @pytest.mark.describe("test of collection delete_many, sync")
     def test_collection_delete_many_sync(
@@ -88,11 +103,11 @@ class TestDMLSync:
         sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         sync_empty_collection.insert_one({"doc": 2, "group": "B"})
         sync_empty_collection.insert_one({"doc": 3, "group": "A"})
-        assert sync_empty_collection.count_documents(filter={}) == 3
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 3
         do_result1 = sync_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
         assert do_result1.deleted_count == 2
-        assert sync_empty_collection.count_documents(filter={}) == 1
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 1
 
     @pytest.mark.describe("test of collection truncating delete_many, sync")
     def test_collection_truncating_delete_many_sync(
@@ -102,11 +117,11 @@ class TestDMLSync:
         sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         sync_empty_collection.insert_one({"doc": 2, "group": "B"})
         sync_empty_collection.insert_one({"doc": 3, "group": "A"})
-        assert sync_empty_collection.count_documents(filter={}) == 3
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 3
         do_result1 = sync_empty_collection.delete_many({})
         assert isinstance(do_result1, DeleteResult)
         assert do_result1.deleted_count is None
-        assert sync_empty_collection.count_documents(filter={}) == 0
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 0
 
     @pytest.mark.describe("test of collection chunk-requiring delete_many, sync")
     def test_collection_chunked_delete_many_sync(
@@ -115,11 +130,11 @@ class TestDMLSync:
     ) -> None:
         sync_empty_collection.insert_many([{"doc": i, "group": "A"} for i in range(50)])
         sync_empty_collection.insert_many([{"doc": i, "group": "B"} for i in range(10)])
-        assert sync_empty_collection.count_documents(filter={}) == 60
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 60
         do_result1 = sync_empty_collection.delete_many({"group": "A"})
         assert isinstance(do_result1, DeleteResult)
         assert do_result1.deleted_count == 50
-        assert sync_empty_collection.count_documents(filter={}) == 10
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 10
 
     @pytest.mark.describe("test of collection find, sync")
     def test_collection_find_sync(
@@ -508,43 +523,43 @@ class TestDMLSync:
 
         resp0000 = col.find_one_and_replace({"f": 0}, {"r": 1})
         assert resp0000 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp0001 = col.find_one_and_replace({"f": 0}, {"r": 1}, sort={"x": 1})
         assert resp0001 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp0010 = col.find_one_and_replace({"f": 0}, {"r": 1}, upsert=True)
         assert resp0010 is None
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp0011 = col.find_one_and_replace(
             {"f": 0}, {"r": 1}, upsert=True, sort={"x": 1}
         )
         assert resp0011 is None
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
         resp0100 = col.find_one_and_replace({"f": 0}, {"r": 1})
         assert resp0100 is not None
         assert resp0100["f"] == 0
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
         resp0101 = col.find_one_and_replace({"f": 0}, {"r": 1}, sort={"x": 1})
         assert resp0101 is not None
         assert resp0101["f"] == 0
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
         resp0110 = col.find_one_and_replace({"f": 0}, {"r": 1}, upsert=True)
         assert resp0110 is not None
         assert resp0110["f"] == 0
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -553,27 +568,27 @@ class TestDMLSync:
         )
         assert resp0111 is not None
         assert resp0111["f"] == 0
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp1000 = col.find_one_and_replace(
             {"f": 0}, {"r": 1}, return_document=ReturnDocument.AFTER
         )
         assert resp1000 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp1001 = col.find_one_and_replace(
             {"f": 0}, {"r": 1}, sort={"x": 1}, return_document=ReturnDocument.AFTER
         )
         assert resp1001 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp1010 = col.find_one_and_replace(
             {"f": 0}, {"r": 1}, upsert=True, return_document=ReturnDocument.AFTER
         )
         assert resp1010 is not None
         assert resp1010["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp1011 = col.find_one_and_replace(
@@ -585,7 +600,7 @@ class TestDMLSync:
         )
         assert resp1011 is not None
         assert resp1011["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -594,7 +609,7 @@ class TestDMLSync:
         )
         assert resp1100 is not None
         assert resp1100["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -603,7 +618,7 @@ class TestDMLSync:
         )
         assert resp1101 is not None
         assert resp1101["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -612,7 +627,7 @@ class TestDMLSync:
         )
         assert resp1110 is not None
         assert resp1110["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -625,7 +640,7 @@ class TestDMLSync:
         )
         assert resp1111 is not None
         assert resp1111["r"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         # projection
@@ -755,26 +770,26 @@ class TestDMLSync:
         sync_empty_collection.insert_one({"doc": 1, "group": "A"})
         sync_empty_collection.insert_one({"doc": 2, "group": "B"})
         sync_empty_collection.insert_one({"doc": 3, "group": "A"})
-        assert sync_empty_collection.count_documents(filter={}) == 3
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 3
 
         fo_result1 = sync_empty_collection.find_one_and_delete({"group": "A"})
         assert fo_result1 is not None
         assert set(fo_result1.keys()) == {"_id", "doc", "group"}
-        assert sync_empty_collection.count_documents(filter={}) == 2
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 2
 
         fo_result2 = sync_empty_collection.find_one_and_delete(
             {"group": "B"}, projection=["doc"]
         )
         assert fo_result2 is not None
         assert set(fo_result2.keys()) == {"_id", "doc"}
-        assert sync_empty_collection.count_documents(filter={}) == 1
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 1
 
         fo_result3 = sync_empty_collection.find_one_and_delete(
             {"group": "A"}, projection={"_id": False, "group": False}
         )
         assert fo_result3 is not None
         assert set(fo_result3.keys()) == {"_id", "doc"}
-        assert sync_empty_collection.count_documents(filter={}) == 0
+        assert sync_empty_collection.count_documents(filter={}, upper_bound=100) == 0
 
         fo_result4 = sync_empty_collection.find_one_and_delete({}, sort={"f": 1})
         assert fo_result4 is None
@@ -788,22 +803,22 @@ class TestDMLSync:
 
         resp0000 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}})
         assert resp0000 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp0001 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, sort={"x": 1})
         assert resp0001 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp0010 = col.find_one_and_update({"f": 0}, {"$set": {"n": 1}}, upsert=True)
         assert resp0010 is None
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp0011 = col.find_one_and_update(
             {"f": 0}, {"$set": {"n": 1}}, upsert=True, sort={"x": 1}
         )
         assert resp0011 is None
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -811,7 +826,7 @@ class TestDMLSync:
         assert resp0100 is not None
         assert resp0100["f"] == 0
         assert "n" not in resp0100
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -819,7 +834,7 @@ class TestDMLSync:
         assert resp0101 is not None
         assert resp0101["f"] == 0
         assert "n" not in resp0101
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -827,7 +842,7 @@ class TestDMLSync:
         assert resp0110 is not None
         assert resp0110["f"] == 0
         assert "n" not in resp0110
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -837,14 +852,14 @@ class TestDMLSync:
         assert resp0111 is not None
         assert resp0111["f"] == 0
         assert "n" not in resp0111
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp1000 = col.find_one_and_update(
             {"f": 0}, {"$set": {"n": 1}}, return_document=ReturnDocument.AFTER
         )
         assert resp1000 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp1001 = col.find_one_and_update(
             {"f": 0},
@@ -853,7 +868,7 @@ class TestDMLSync:
             return_document=ReturnDocument.AFTER,
         )
         assert resp1001 is None
-        assert col.count_documents({}) == 0
+        assert col.count_documents({}, upper_bound=100) == 0
 
         resp1010 = col.find_one_and_update(
             {"f": 0},
@@ -863,7 +878,7 @@ class TestDMLSync:
         )
         assert resp1010 is not None
         assert resp1010["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         resp1011 = col.find_one_and_update(
@@ -875,7 +890,7 @@ class TestDMLSync:
         )
         assert resp1011 is not None
         assert resp1011["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -884,7 +899,7 @@ class TestDMLSync:
         )
         assert resp1100 is not None
         assert resp1100["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -896,7 +911,7 @@ class TestDMLSync:
         )
         assert resp1101 is not None
         assert resp1101["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -908,7 +923,7 @@ class TestDMLSync:
         )
         assert resp1110 is not None
         assert resp1110["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         col.insert_one({"f": 0})
@@ -921,7 +936,7 @@ class TestDMLSync:
         )
         assert resp1111 is not None
         assert resp1111["n"] == 1
-        assert col.count_documents({}) == 1
+        assert col.count_documents({}, upper_bound=100) == 1
         col.delete_many({})
 
         # projection

--- a/tests/idiomatic/unit/test_bulk_write_results.py
+++ b/tests/idiomatic/unit/test_bulk_write_results.py
@@ -22,7 +22,7 @@ class TestBulkWriteResults:
     @pytest.mark.describe("test of reduction of bulk write results")
     def test_reduce_bulk_write_results(self) -> None:
         bwr1 = BulkWriteResult(
-            bulk_api_results={1: {"seq1": 1}},
+            bulk_api_results={1: [{"seq1": 1}]},
             deleted_count=100,
             inserted_count=200,
             matched_count=300,
@@ -40,7 +40,7 @@ class TestBulkWriteResults:
             upserted_ids={2: {"useq2": 2}},
         )
         bwr3 = BulkWriteResult(
-            bulk_api_results={3: {"seq3": 3}},
+            bulk_api_results={3: [{"seq3": 3}]},
             deleted_count=1,
             inserted_count=2,
             matched_count=3,
@@ -51,7 +51,7 @@ class TestBulkWriteResults:
 
         reduced_a = reduce_bulk_write_results([bwr1, bwr2, bwr3])
         expected_a = BulkWriteResult(
-            bulk_api_results={1: {"seq1": 1}, 3: {"seq3": 3}},
+            bulk_api_results={1: [{"seq1": 1}], 3: [{"seq3": 3}]},
             deleted_count=111,
             inserted_count=222,
             matched_count=333,


### PR DESCRIPTION
- reformulate count_documents with upper_bound
- uniform raw_result => raw_results (and always as a list) for delete and insert many
- uniform list[raw results] for all bulk write result objects
- enums made into static objects (less prescriptive)
- removed "acknowledge=True" hardcoded from "result" dataclasses