### PR TITLE
custom payload serialization for httpx to block NaNs

### DIFF
--- a/astrapy/core/utils.py
+++ b/astrapy/core/utils.py
@@ -23,6 +23,7 @@ from typing import (
     TypedDict,
     Union,
 )
+import json
 import time
 import datetime
 import logging
@@ -209,7 +210,7 @@ def make_request(
         method=method,
         url=f"{base_url}{path}",
         params=url_params,
-        json=json_data,
+        content=json.dumps(json_data, allow_nan=False, separators=(",", ":")).encode(),
         timeout=timeout or DEFAULT_TIMEOUT,
         headers=request_headers,
     )
@@ -263,7 +264,7 @@ async def amake_request(
         method=method,
         url=f"{base_url}{path}",
         params=url_params,
-        json=json_data,
+        content=json.dumps(json_data, allow_nan=False, separators=(",", ":")).encode(),
         timeout=timeout or DEFAULT_TIMEOUT,
         headers=request_headers,
     )

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -36,7 +36,7 @@ class TestTimeoutAsync:
             await async_empty_collection.count_documents(
                 {}, upper_bound=150, max_time_ms=1
             )
-        assert exc.value.timeout_type == "read"
+        assert exc.value.timeout_type in {"connect", "read"}
         assert exc.value.endpoint is not None
         assert exc.value.raw_payload is not None
 
@@ -58,7 +58,7 @@ class TestTimeoutAsync:
                 namespace=async_database.namespace,
                 max_time_ms=1,
             )
-        assert exc.value.timeout_type == "read"
+        assert exc.value.timeout_type in {"connect", "read"}
         assert exc.value.endpoint is not None
         assert exc.value.raw_payload is not None
 

--- a/tests/idiomatic/integration/test_timeout_sync.py
+++ b/tests/idiomatic/integration/test_timeout_sync.py
@@ -34,7 +34,7 @@ class TestTimeoutSync:
 
         with pytest.raises(DataAPITimeoutException) as exc:
             sync_empty_collection.count_documents({}, upper_bound=150, max_time_ms=1)
-        assert exc.value.timeout_type == "read"
+        assert exc.value.timeout_type in {"connect", "read"}
         assert exc.value.endpoint is not None
         assert exc.value.raw_payload is not None
 
@@ -56,7 +56,7 @@ class TestTimeoutSync:
                 namespace=sync_database.namespace,
                 max_time_ms=1,
             )
-        assert exc.value.timeout_type == "read"
+        assert exc.value.timeout_type in {"connect", "read"}
         assert exc.value.endpoint is not None
         assert exc.value.raw_payload is not None
 


### PR DESCRIPTION
`Nan` is not a valid JSON token. Sadly for some reason the JSON serialization in python [does not complain](https://stackoverflow.com/questions/6601812/sending-nan-in-json?rq=3), but astrapy should since the Data API is strictly JSON.

This PR addresses this problem.