### PR TITLE
Fixed bug in parsing endpoint domain names containing hyphens

### DIFF
--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -75,7 +75,7 @@ api_endpoint_parser = re.compile(
     r".datastax.com"
 )
 
-generic_api_url_matcher = re.compile(r"^https?:\/\/[a-zA-Z0-9.]+(\:[0-9]{1,6}){0,1}$")
+generic_api_url_matcher = re.compile(r"^https?:\/\/[a-zA-Z0-9\-.]+(\:[0-9]{1,6}){0,1}$")
 
 
 DEV_OPS_URL_MAP = {

--- a/tests/core/test_admin.py
+++ b/tests/core/test_admin.py
@@ -1,0 +1,67 @@
+import pytest
+
+from astrapy.admin import parse_generic_api_url
+
+
+@pytest.mark.describe("should parse an http endpoint")
+def test_parse_http_endpoint() -> None:
+    raw_api_endpoint = "http://127.0.0.1"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://127.0.0.1"
+
+
+@pytest.mark.describe("should parse an https endpoint")
+def test_parse_https_endpoint() -> None:
+    raw_api_endpoint = "https://127.0.0.1"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "https://127.0.0.1"
+
+
+@pytest.mark.describe("should parse an http endpoint with port")
+def test_parse_http_endpoint_with_port() -> None:
+    raw_api_endpoint = "http://127.0.0.1:8080"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://127.0.0.1:8080"
+
+
+@pytest.mark.describe("should parse an ip-based endpoint")
+def test_parse_endpoint_ip() -> None:
+    raw_api_endpoint = "http://127.0.0.1"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://127.0.0.1"
+
+
+@pytest.mark.describe("should strip trailing slash")
+def test_strip_slash() -> None:
+    raw_api_endpoint = "http://127.0.0.1/"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://127.0.0.1"
+
+
+@pytest.mark.describe("should parse a domain-based endpoint without hyphen")
+def test_parse_endpoint_domain_without_hyphen() -> None:
+    raw_api_endpoint = "http://my.domain"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://my.domain"
+
+
+@pytest.mark.describe("should parse a domain-based endpoint with hyphen")
+def test_parse_endpoint_domain_with_hyphen() -> None:
+    raw_api_endpoint = "http://my-example.domain"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint == "http://my-example.domain"
+
+
+@pytest.mark.describe("should fail to parse an invalid endpoint")
+def test_fail_parse_invalid_endpoint() -> None:
+    raw_api_endpoint = "http://%$foo/"
+    parsed_api_endpoint = parse_generic_api_url(raw_api_endpoint)
+
+    assert parsed_api_endpoint is None


### PR DESCRIPTION
I recently encountered an issue with a user who is running the Data API against a DSE cluster. This Data API is behind a domain name containing a dash. For example:

```python
from astrapy import DataAPIClient
from astrapy.constants import Environment

client = DataAPIClient(token="Cassandra:...:...", environment=Environment.DSE)
db = client.get_database_by_api_endpoint("https://example-domain.com", namespace="default_namespace")
```

would fail as astrapy is unable to parse the endpoint. This PR adjusts the regular expression to include hyphens. This could technically result in invalid domain names being parsed (hyphens are not allowed at the start of domain names), but solves the immediate issue. I've also added tests to validate the endpoint parsing is working as expected.