### PR TITLE
SL "embedding headers provider" refactoring

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 (master)
 ========
+Support for multiple-header embedding api keys:
+    - `EmbeddingHeadersProvider` classes for `embedding_api_key` parameter
+    - AWS header provider in addition to the regular one-header one
+    - adapt CI to cover this setup
 Testing:
     - restructure CI to fully support HCD alongside Astra DB
     - add details for testing new embedding providers

--- a/README.md
+++ b/README.md
@@ -350,7 +350,13 @@ Remove logging noise with:
 poetry run pytest [...] -o log_cli=0
 ```
 
-Do not drop collections (core):
+Increase logging level to `TRACE` (i.e. level `5`):
+
+```
+poetry run pytest [...] -o log_cli=1 --log-cli-level=5
+```
+
+Do not drop collections (valid for core):
 
 ```
 TEST_SKIP_COLLECTION_DELETE=1 poetry run pytest [...]

--- a/astrapy/api_commander.py
+++ b/astrapy/api_commander.py
@@ -19,11 +19,15 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import httpx
 
+from astrapy.authentication import (
+    EMBEDDING_HEADER_API_KEY,
+    EMBEDDING_HEADER_AWS_ACCESS_ID,
+    EMBEDDING_HEADER_AWS_SECRET_ID,
+)
 from astrapy.core.defaults import (
     DEFAULT_AUTH_HEADER,
     DEFAULT_DEV_OPS_AUTH_HEADER,
     DEFAULT_TIMEOUT,
-    DEFAULT_VECTORIZE_SECRET_HEADER,
 )
 from astrapy.core.utils import (
     TimeoutInfoWideType,
@@ -44,11 +48,13 @@ from astrapy.exceptions import (
     to_dataapi_timeout_exception,
 )
 
-DEFAULT_REDACTED_HEADER_NAMES = [
+DEFAULT_REDACTED_HEADER_NAMES = {
     DEFAULT_AUTH_HEADER,
     DEFAULT_DEV_OPS_AUTH_HEADER,
-    DEFAULT_VECTORIZE_SECRET_HEADER,
-]
+    EMBEDDING_HEADER_AWS_ACCESS_ID,
+    EMBEDDING_HEADER_AWS_SECRET_ID,
+    EMBEDDING_HEADER_API_KEY,
+}
 
 
 def full_user_agent(

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -79,7 +79,7 @@ class CollectionAPIOptions(BaseAPIOptions):
             much sense.
         embedding_api_key: an optional API key for interacting with the collection.
             If an embedding service is configured, and this attribute is set,
-            each Data API call will include a "x-embedding-api-key" header
+            each Data API call will include an Embedding API Key header
             with the value of this attribute.
     """
 

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -48,7 +48,7 @@ class BaseAPIOptions:
             return self.__class__(
                 **{
                     **default.__dict__,
-                    **{k: v for k, v in self.__dict__.items() if v is not None},
+                    **{k: v for k, v in self.__dict__.items() if bool(v)},
                 }
             )
         else:
@@ -59,7 +59,7 @@ class BaseAPIOptions:
             return self.__class__(
                 **{
                     **self.__dict__,
-                    **{k: v for k, v in override.__dict__.items() if v is not None},
+                    **{k: v for k, v in override.__dict__.items() if bool(v)},
                 }
             )
         else:

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -14,8 +14,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, TypeVar
+
+from astrapy.authentication import (
+    EmbeddingHeadersProvider,
+    StaticEmbeddingHeadersProvider,
+)
 
 AO = TypeVar("AO", bound="BaseAPIOptions")
 
@@ -77,10 +82,15 @@ class CollectionAPIOptions(BaseAPIOptions):
             `find`, `delete_many`, `insert_many` and so on), it is strongly suggested
             to provide a specific timeout as the default one likely wouldn't make
             much sense.
-        embedding_api_key: an optional API key for interacting with the collection.
-            If an embedding service is configured, and this attribute is set,
-            each Data API call will include an Embedding API Key header
-            with the value of this attribute.
+        embedding_api_key: an `astrapy.authentication.EmbeddingHeadersProvider`
+            object, encoding embedding-related API keys that will be passed
+            as headers when interacting with the collection (on each Data API request).
+            The default value is `StaticEmbeddingHeadersProvider(None)`, i.e.
+            no embedding-specific headers, whereas if the collection is configured
+            with an embedding service other choices for this parameter can be
+            meaningfully supplied. is configured for the collection,
     """
 
-    embedding_api_key: Optional[str] = None
+    embedding_api_key: EmbeddingHeadersProvider = field(
+        default_factory=lambda: StaticEmbeddingHeadersProvider(None)
+    )

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -44,22 +44,54 @@ class BaseAPIOptions:
     max_time_ms: Optional[int] = None
 
     def with_default(self: AO, default: Optional[BaseAPIOptions]) -> AO:
+        """
+        Return a new instance created by completing this instance with a default
+        API options object.
+
+        In other words, `optA.with_default(optB)` will take fields from optA
+        when possible and draw defaults from optB when optA has them set to anything
+        evaluating to False. (This relies on the __bool__ definition of the values,
+        such as that of the EmbeddingHeadersTokenProvider instances)
+
+        Args:
+            default: an API options instance to draw defaults from.
+
+        Returns:
+            a new instance of this class obtained by merging this one and the default.
+        """
         if default:
+            default_dict = default.__dict__
             return self.__class__(
                 **{
-                    **default.__dict__,
-                    **{k: v for k, v in self.__dict__.items() if bool(v)},
+                    k: self_v or default_dict.get(k)
+                    for k, self_v in self.__dict__.items()
                 }
             )
         else:
             return self
 
     def with_override(self: AO, override: Optional[BaseAPIOptions]) -> AO:
+        """
+        Return a new instance created by overriding the members of this instance
+        with those taken from a supplied "override" API options object.
+
+        In other words, `optA.with_default(optB)` will take fields from optB
+        when possible and fall back to optA when optB has them set to anything
+        evaluating to False. (This relies on the __bool__ definition of the values,
+        such as that of the EmbeddingHeadersTokenProvider instances)
+
+        Args:
+            override: an API options instance to preferentially draw fields from.
+
+        Returns:
+            a new instance of this class obtained by merging the override and this one.
+        """
         if override:
+            self_dict = self.__dict__
             return self.__class__(
                 **{
-                    **self.__dict__,
-                    **{k: v for k, v in override.__dict__.items() if bool(v)},
+                    k: override_v or self_dict.get(k)
+                    for k, override_v in override.__dict__.items()
                 }
             )
         else:

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -245,7 +245,10 @@ class StaticEmbeddingHeadersProvider(EmbeddingHeadersProvider):
         self.embedding_api_key = embedding_api_key
 
     def __repr__(self) -> str:
-        return "(none)" if self.embedding_api_key is None else "(api key)"
+        if self.embedding_api_key is None:
+            return f"{self.__class__.__name__}(empty)"
+        else:
+            return f'{self.__class__.__name__}("{self.embedding_api_key[:5]}...")'
 
     def get_headers(self) -> Dict[str, str]:
         if self.embedding_api_key is not None:
@@ -302,7 +305,7 @@ class AWSEmbeddingHeadersProvider(EmbeddingHeadersProvider):
         self.embedding_secret_id = embedding_secret_id
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        return f'{self.__class__.__name__}("{self.embedding_access_id[:3]}...", "{self.embedding_secret_id[:3]}...")'
 
     def get_headers(self) -> Dict[str, str]:
         return {

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import base64
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any, Dict, Optional, Union
 
 
 def coerce_token_provider(token: Any) -> TokenProvider:
@@ -150,3 +150,63 @@ class UsernamePasswordTokenProvider(TokenProvider):
 
     def get_token(self) -> str:
         return self.token
+
+
+class EmbeddingHeadersProvider(ABC):
+    """
+    TODO
+    """
+
+    def __eq__(self, other: Any) -> bool:
+        my_headers = self.get_headers()
+        if isinstance(other, EmbeddingHeadersProvider):
+            return other.get_headers() == my_headers
+        else:
+            return False
+
+    @abstractmethod
+    def __repr__(self) -> str: ...
+
+    @abstractmethod
+    def get_headers(self) -> Dict[str, str]:
+        """
+        TODO
+        """
+        ...
+
+
+class StaticEmbeddingHeadersProvider(EmbeddingHeadersProvider):
+    """
+    TODO
+    """
+
+    def __init__(self, embedding_api_key: Optional[str]) -> None:
+        self.embedding_api_key = embedding_api_key
+
+    def __repr__(self) -> str:
+        return "(none)" if self.embedding_api_key is None else "(api key)"
+
+    def get_headers(self) -> Dict[str, str]:
+        if self.embedding_api_key is not None:
+            return {"X-Embedding-Api-Key": self.embedding_api_key}
+        else:
+            return {}
+
+
+class AWSEmbeddingHeadersProvider(EmbeddingHeadersProvider):
+    """
+    TODO
+    """
+
+    def __init__(self, *, embedding_access_id: str, embedding_secret_id: str) -> None:
+        self.embedding_access_id = embedding_access_id
+        self.embedding_secret_id = embedding_secret_id
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__
+
+    def get_headers(self) -> Dict[str, str]:
+        return {
+            "X-Embedding-Access-Id": self.embedding_access_id,
+            "X-Embedding-Secret-Id": self.embedding_secret_id,
+        }

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -67,14 +67,6 @@ class TokenProvider(ABC):
     @abstractmethod
     def __repr__(self) -> str: ...
 
-    @abstractmethod
-    def get_token(self) -> Union[str, None]:
-        """
-        Produce a string for direct use as token in a subsequent API request,
-        or None for no token.
-        """
-        ...
-
     def __or__(self, other: TokenProvider) -> TokenProvider:
         """
         Implement the logic as for "token_str_a or token_str_b" for the TokenProvider,
@@ -94,6 +86,14 @@ class TokenProvider(ABC):
         similarly as for the __or__ method.
         """
         return self.get_token() is not None
+
+    @abstractmethod
+    def get_token(self) -> Union[str, None]:
+        """
+        Produce a string for direct use as token in a subsequent API request,
+        or None for no token.
+        """
+        ...
 
 
 class StaticTokenProvider(TokenProvider):
@@ -185,6 +185,13 @@ class EmbeddingHeadersProvider(ABC):
 
     @abstractmethod
     def __repr__(self) -> str: ...
+
+    def __bool__(self) -> bool:
+        """
+        All headers providers evaluate to True unless they yield the empty dict.
+        This method enables the override mechanism in APIOptions.
+        """
+        return self.get_headers() != {}
 
     @abstractmethod
     def get_headers(self) -> Dict[str, str]:

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -18,12 +18,25 @@ import base64
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Union
 
+EMBEDDING_HEADER_AWS_ACCESS_ID = "X-Embedding-Access-Id"
+EMBEDDING_HEADER_AWS_SECRET_ID = "X-Embedding-Secret-Id"
+EMBEDDING_HEADER_API_KEY = "X-Embedding-Api-Key"
+
 
 def coerce_token_provider(token: Any) -> TokenProvider:
     if isinstance(token, TokenProvider):
         return token
     else:
         return StaticTokenProvider(token)
+
+
+def coerce_embedding_headers_provider(
+    embedding_api_key: Any,
+) -> EmbeddingHeadersProvider:
+    if isinstance(embedding_api_key, EmbeddingHeadersProvider):
+        return embedding_api_key
+    else:
+        return StaticEmbeddingHeadersProvider(embedding_api_key)
 
 
 class TokenProvider(ABC):
@@ -188,7 +201,7 @@ class StaticEmbeddingHeadersProvider(EmbeddingHeadersProvider):
 
     def get_headers(self) -> Dict[str, str]:
         if self.embedding_api_key is not None:
-            return {"X-Embedding-Api-Key": self.embedding_api_key}
+            return {EMBEDDING_HEADER_API_KEY: self.embedding_api_key}
         else:
             return {}
 
@@ -207,6 +220,6 @@ class AWSEmbeddingHeadersProvider(EmbeddingHeadersProvider):
 
     def get_headers(self) -> Dict[str, str]:
         return {
-            "X-Embedding-Access-Id": self.embedding_access_id,
-            "X-Embedding-Secret-Id": self.embedding_secret_id,
+            EMBEDDING_HEADER_AWS_ACCESS_ID: self.embedding_access_id,
+            EMBEDDING_HEADER_AWS_SECRET_ID: self.embedding_secret_id,
         }

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -346,7 +346,7 @@ class Collection:
                 collection existing in the same namespace.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
@@ -408,7 +408,7 @@ class Collection:
                 If not specified, the database's working namespace is used.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
@@ -2759,7 +2759,7 @@ class AsyncCollection:
                 collection existing in the same namespace.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
@@ -2821,7 +2821,7 @@ class AsyncCollection:
                 If not specified, the database's working namespace is used.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -280,7 +280,8 @@ class Collection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.namespace}", database={self.database})'
+            f'namespace="{self.namespace}", database={self.database}, '
+            f"api_options={self.api_options})"
         )
 
     def __eq__(self, other: Any) -> bool:
@@ -2697,7 +2698,8 @@ class AsyncCollection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.namespace}", database={self.database})'
+            f'namespace="{self.namespace}", database={self.database}, '
+            f"api_options={self.api_options})"
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -337,10 +337,15 @@ class Collection:
             name: the name of the collection. This parameter is useful to
                 quickly spawn Collection instances each pointing to a different
                 collection existing in the same namespace.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value
@@ -399,10 +404,15 @@ class Collection:
                 collection on the database.
             namespace: this is the namespace to which the collection belongs.
                 If not specified, the database's working namespace is used.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value
@@ -2744,10 +2754,15 @@ class AsyncCollection:
             name: the name of the collection. This parameter is useful to
                 quickly spawn AsyncCollection instances each pointing to a different
                 collection existing in the same namespace.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value
@@ -2806,10 +2821,15 @@ class AsyncCollection:
                 collection on the database.
             namespace: this is the namespace to which the collection belongs.
                 If not specified, the database's working namespace is used.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -24,6 +24,7 @@ import deprecation
 
 from astrapy import __version__
 from astrapy.api_options import CollectionAPIOptions
+from astrapy.authentication import coerce_embedding_headers_provider
 from astrapy.constants import (
     DocumentType,
     FilterType,
@@ -34,10 +35,7 @@ from astrapy.constants import (
     normalize_optional_projection,
 )
 from astrapy.core.db import AstraDBCollection, AsyncAstraDBCollection
-from astrapy.core.defaults import (
-    DEFAULT_INSERT_NUM_DOCUMENTS,
-    DEFAULT_VECTORIZE_SECRET_HEADER,
-)
+from astrapy.core.defaults import DEFAULT_INSERT_NUM_DOCUMENTS
 from astrapy.cursors import AsyncCursor, Cursor
 from astrapy.database import AsyncDatabase, Database
 from astrapy.exceptions import (
@@ -66,6 +64,7 @@ from astrapy.results import (
 )
 
 if TYPE_CHECKING:
+    from astrapy.authentication import EmbeddingHeadersProvider
     from astrapy.operations import AsyncBaseOperation, BaseOperation
 
 
@@ -264,13 +263,7 @@ class Collection:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        additional_headers = {
-            k: v
-            for k, v in {
-                DEFAULT_VECTORIZE_SECRET_HEADER: self.api_options.embedding_api_key,
-            }.items()
-            if v is not None
-        }
+        additional_headers = self.api_options.embedding_api_key.get_headers()
         self._astra_db_collection: AstraDBCollection = AstraDBCollection(
             collection_name=name,
             astra_db=database._astra_db,
@@ -332,7 +325,7 @@ class Collection:
         self,
         *,
         name: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
@@ -371,7 +364,7 @@ class Collection:
         """
 
         _api_options = CollectionAPIOptions(
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
         )
 
@@ -388,7 +381,7 @@ class Collection:
         database: Optional[AsyncDatabase] = None,
         name: Optional[str] = None,
         namespace: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
@@ -431,7 +424,7 @@ class Collection:
         """
 
         _api_options = CollectionAPIOptions(
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
         )
 
@@ -2677,13 +2670,7 @@ class AsyncCollection:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        additional_headers = {
-            k: v
-            for k, v in {
-                DEFAULT_VECTORIZE_SECRET_HEADER: self.api_options.embedding_api_key,
-            }.items()
-            if v is not None
-        }
+        additional_headers = self.api_options.embedding_api_key.get_headers()
         self._astra_db_collection: AsyncAstraDBCollection = AsyncAstraDBCollection(
             collection_name=name,
             astra_db=database._astra_db,
@@ -2745,7 +2732,7 @@ class AsyncCollection:
         self,
         *,
         name: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
@@ -2784,7 +2771,7 @@ class AsyncCollection:
         """
 
         _api_options = CollectionAPIOptions(
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
         )
 
@@ -2801,7 +2788,7 @@ class AsyncCollection:
         database: Optional[Database] = None,
         name: Optional[str] = None,
         namespace: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
@@ -2844,7 +2831,7 @@ class AsyncCollection:
         """
 
         _api_options = CollectionAPIOptions(
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
         )
 

--- a/astrapy/core/defaults.py
+++ b/astrapy/core/defaults.py
@@ -31,4 +31,5 @@ DEFAULT_REGION = "us-east1"
 MAX_INSERT_NUM_DOCUMENTS = 100
 DEFAULT_INSERT_NUM_DOCUMENTS = 50
 
+# These are backported by hand from idiomatic, tolerable duplication
 DEFAULT_VECTORIZE_SECRET_HEADER = "x-embedding-api-key"

--- a/astrapy/core/defaults.py
+++ b/astrapy/core/defaults.py
@@ -31,11 +31,13 @@ DEFAULT_REGION = "us-east1"
 MAX_INSERT_NUM_DOCUMENTS = 100
 DEFAULT_INSERT_NUM_DOCUMENTS = 50
 
-# These are repeated by hand from idiomatic, tolerable duplication
+# Some of these are repeated by hand from idiomatic, tolerable duplication
 # as long as `core` is in place:
-DEFAULT_VECTORIZE_SECRET_HEADER = "x-embedding-api-key"
-
-
-# "X-Embedding-Access-Id"
-# "X-Embedding-Secret-Id"
-# "X-Embedding-Api-Key"
+#   (the case must match, so that secrets are effectively masked)
+DEFAULT_REDACTED_HEADERS = {
+    DEFAULT_DEV_OPS_AUTH_HEADER,
+    DEFAULT_AUTH_HEADER,
+    "X-Embedding-Api-Key",
+    "X-Embedding-Access-Id",
+    "X-Embedding-Secret-Id",
+}

--- a/astrapy/core/defaults.py
+++ b/astrapy/core/defaults.py
@@ -31,5 +31,11 @@ DEFAULT_REGION = "us-east1"
 MAX_INSERT_NUM_DOCUMENTS = 100
 DEFAULT_INSERT_NUM_DOCUMENTS = 50
 
-# These are backported by hand from idiomatic, tolerable duplication
+# These are repeated by hand from idiomatic, tolerable duplication
+# as long as `core` is in place:
 DEFAULT_VECTORIZE_SECRET_HEADER = "x-embedding-api-key"
+
+
+# "X-Embedding-Access-Id"
+# "X-Embedding-Secret-Id"
+# "X-Embedding-Api-Key"

--- a/astrapy/core/utils.py
+++ b/astrapy/core/utils.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import copy
 import datetime
 import json
 import logging
@@ -25,11 +24,7 @@ import httpx
 
 from astrapy import __version__
 from astrapy.core.core_types import API_RESPONSE
-from astrapy.core.defaults import (
-    DEFAULT_AUTH_HEADER,
-    DEFAULT_TIMEOUT,
-    DEFAULT_VECTORIZE_SECRET_HEADER,
-)
+from astrapy.core.defaults import DEFAULT_REDACTED_HEADERS, DEFAULT_TIMEOUT
 from astrapy.core.ids import UUID, ObjectId
 
 
@@ -97,11 +92,10 @@ def log_request(
     logger.debug(f"Request params: {params}")
 
     # Redact known secrets from the request headers
-    headers_log = copy.deepcopy(headers)
-    if DEFAULT_AUTH_HEADER in headers_log:
-        headers_log[DEFAULT_AUTH_HEADER] = "***"
-    if DEFAULT_VECTORIZE_SECRET_HEADER in headers_log:
-        headers_log[DEFAULT_VECTORIZE_SECRET_HEADER] = "***"
+    headers_log = {
+        hdr_k: hdr_v if hdr_k not in DEFAULT_REDACTED_HEADERS else "***"
+        for hdr_k, hdr_v in headers.items()
+    }
 
     logger.debug(f"Request headers: {headers_log}")
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -438,7 +438,7 @@ class Database:
                 is specified, the general setting for this database is used.
         embedding_api_key: an optional API key for interacting with the collection.
             If an embedding service is configured, and this attribute is set,
-            each Data API call will include a "x-embedding-api-key" header
+            each Data API call will include an Embedding API Key header
             with the value of this attribute.
         collection_max_time_ms: a default timeout, in millisecond, for the duration of each
             operation on the collection. Individual timeouts can be provided to
@@ -541,7 +541,7 @@ class Database:
             max_time_ms: a timeout, in milliseconds, for the underlying HTTP request.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
@@ -1266,7 +1266,7 @@ class AsyncDatabase:
                 is specified, the setting for this database is used.
         embedding_api_key: an optional API key for interacting with the collection.
             If an embedding service is configured, and this attribute is set,
-            each Data API call will include a "x-embedding-api-key" header
+            each Data API call will include an Embedding API Key header
             with the value of this attribute.
         collection_max_time_ms: a default timeout, in millisecond, for the duration of each
             operation on the collection. Individual timeouts can be provided to
@@ -1372,7 +1372,7 @@ class AsyncDatabase:
             max_time_ms: a timeout, in milliseconds, for the underlying HTTP request.
             embedding_api_key: an optional API key for interacting with the collection.
                 If an embedding service is configured, and this attribute is set,
-                each Data API call will include a "x-embedding-api-key" header
+                each Data API call will include an Embedding API Key header
                 with the value of this attribute.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -439,10 +439,15 @@ class Database:
             name: the name of the collection.
             namespace: the namespace containing the collection. If no namespace
                 is specified, the general setting for this database is used.
-        embedding_api_key: an optional API key for interacting with the collection.
-            If an embedding service is configured, and this attribute is set,
-            each Data API call will include an Embedding API Key header
-            with the value of this attribute.
+        embedding_api_key: optional API key(s) for interacting with the collection.
+            If an embedding service is configured, and this parameter is not None,
+            each Data API call will include the necessary embedding-related headers
+            as specified by this parameter. If a string is passed, it translates
+            into the one "embedding api key" header
+            (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+            For some vectorize providers/models, if using header-based authentication,
+            specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+            should be supplied.
         collection_max_time_ms: a default timeout, in millisecond, for the duration of each
             operation on the collection. Individual timeouts can be provided to
             each collection method call and will take precedence, with this value
@@ -542,10 +547,15 @@ class Database:
                 preexisting collections, the command will succeed or fail
                 depending on whether the options match or not.
             max_time_ms: a timeout, in milliseconds, for the underlying HTTP request.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value
@@ -1267,10 +1277,15 @@ class AsyncDatabase:
             name: the name of the collection.
             namespace: the namespace containing the collection. If no namespace
                 is specified, the setting for this database is used.
-        embedding_api_key: an optional API key for interacting with the collection.
-            If an embedding service is configured, and this attribute is set,
-            each Data API call will include an Embedding API Key header
-            with the value of this attribute.
+        embedding_api_key: optional API key(s) for interacting with the collection.
+            If an embedding service is configured, and this parameter is not None,
+            each Data API call will include the necessary embedding-related headers
+            as specified by this parameter. If a string is passed, it translates
+            into the one "embedding api key" header
+            (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+            For some vectorize providers/models, if using header-based authentication,
+            specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+            should be supplied.
         collection_max_time_ms: a default timeout, in millisecond, for the duration of each
             operation on the collection. Individual timeouts can be provided to
             each collection method call and will take precedence, with this value
@@ -1373,10 +1388,15 @@ class AsyncDatabase:
                 preexisting collections, the command will succeed or fail
                 depending on whether the options match or not.
             max_time_ms: a timeout, in milliseconds, for the underlying HTTP request.
-            embedding_api_key: an optional API key for interacting with the collection.
-                If an embedding service is configured, and this attribute is set,
-                each Data API call will include an Embedding API Key header
-                with the value of this attribute.
+            embedding_api_key: optional API key(s) for interacting with the collection.
+                If an embedding service is configured, and this parameter is not None,
+                each Data API call will include the necessary embedding-related headers
+                as specified by this parameter. If a string is passed, it translates
+                into the one "embedding api key" header
+                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                For some vectorize providers/models, if using header-based authentication,
+                specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
+                should be supplied.
             collection_max_time_ms: a default timeout, in millisecond, for the duration of each
                 operation on the collection. Individual timeouts can be provided to
                 each collection method call and will take precedence, with this value

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -25,7 +25,10 @@ from astrapy.admin import (
     parse_api_endpoint,
 )
 from astrapy.api_options import CollectionAPIOptions
-from astrapy.authentication import coerce_token_provider
+from astrapy.authentication import (
+    coerce_embedding_headers_provider,
+    coerce_token_provider,
+)
 from astrapy.constants import Environment
 from astrapy.core.db import AstraDB, AsyncAstraDB
 from astrapy.cursors import AsyncCommandCursor, CommandCursor
@@ -46,7 +49,7 @@ from astrapy.info import (
 
 if TYPE_CHECKING:
     from astrapy.admin import DatabaseAdmin
-    from astrapy.authentication import TokenProvider
+    from astrapy.authentication import EmbeddingHeadersProvider, TokenProvider
     from astrapy.collection import AsyncCollection, Collection
 
 
@@ -419,7 +422,7 @@ class Database:
         name: str,
         *,
         namespace: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
     ) -> Collection:
         """
@@ -475,7 +478,7 @@ class Database:
             name,
             namespace=_namespace,
             api_options=CollectionAPIOptions(
-                embedding_api_key=embedding_api_key,
+                embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
                 max_time_ms=collection_max_time_ms,
             ),
         )
@@ -494,7 +497,7 @@ class Database:
         additional_options: Optional[Dict[str, Any]] = None,
         check_exists: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
     ) -> Collection:
         """
@@ -626,7 +629,7 @@ class Database:
         return self.get_collection(
             name,
             namespace=namespace,
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             collection_max_time_ms=collection_max_time_ms,
         )
 
@@ -1247,7 +1250,7 @@ class AsyncDatabase:
         name: str,
         *,
         namespace: Optional[str] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
     ) -> AsyncCollection:
         """
@@ -1306,7 +1309,7 @@ class AsyncDatabase:
             name,
             namespace=_namespace,
             api_options=CollectionAPIOptions(
-                embedding_api_key=embedding_api_key,
+                embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
                 max_time_ms=collection_max_time_ms,
             ),
         )
@@ -1325,7 +1328,7 @@ class AsyncDatabase:
         additional_options: Optional[Dict[str, Any]] = None,
         check_exists: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
     ) -> AsyncCollection:
         """
@@ -1460,7 +1463,7 @@ class AsyncDatabase:
         return await self.get_collection(
             name,
             namespace=namespace,
-            embedding_api_key=embedding_api_key,
+            embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             collection_max_time_ms=collection_max_time_ms,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astrapy"
-version = "1.3.1"
+version = "1.3.2"
 description = "AstraPy is a Pythonic SDK for DataStax Astra and its Data API"
 authors = [
     "Stefano Lottini <stefano.lottini@datastax.com>",

--- a/tests/vectorize_idiomatic/query_providers.py
+++ b/tests/vectorize_idiomatic/query_providers.py
@@ -42,7 +42,9 @@ def desc_param(param_data: Dict[str, Any]) -> str:
             assert isinstance(validation_op, list) and len(validation_op) > 1
             return f"number, {' / '.join(str(v) for v in validation_op)}"
         else:
-            raise ValueError(f"Unknown number validation spec: '{json.dumps(validation)}'")
+            raise ValueError(
+                f"Unknown number validation spec: '{json.dumps(validation)}'"
+            )
     elif param_data["type"].lower() == "boolean":
         return "bool"
     else:

--- a/tests/vectorize_idiomatic/query_providers.py
+++ b/tests/vectorize_idiomatic/query_providers.py
@@ -27,14 +27,22 @@ def desc_param(param_data: Dict[str, Any]) -> str:
     if param_data["type"].lower() == "string":
         return "str"
     elif param_data["type"].lower() == "number":
-        validation = param_data.get("validation", {}).get("numericRange")
-        assert isinstance(validation, list) and len(validation) == 2
-        range_desc = f"[{validation[0]} : {validation[1]}]"
-        if "defaultValue" in param_data:
-            range_desc2 = f"{range_desc} (default={param_data['defaultValue']})"
+        validation = param_data.get("validation", {})
+        if "numericRange" in validation:
+            validation_nr = validation["numericRange"]
+            assert isinstance(validation_nr, list) and len(validation_nr) == 2
+            range_desc = f"[{validation_nr[0]} : {validation_nr[1]}]"
+            if "defaultValue" in param_data:
+                range_desc2 = f"{range_desc} (default={param_data['defaultValue']})"
+            else:
+                range_desc2 = range_desc
+            return f"number, {range_desc2}"
+        elif "options" in validation:
+            validation_op = validation["options"]
+            assert isinstance(validation_op, list) and len(validation_op) > 1
+            return f"number, {' / '.join(str(v) for v in validation_op)}"
         else:
-            range_desc2 = range_desc
-        return f"number, {range_desc2}"
+            raise ValueError(f"Unknown number validation spec: '{json.dumps(validation)}'")
     elif param_data["type"].lower() == "boolean":
         return "bool"
     else:

--- a/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
+++ b/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
@@ -1,0 +1,67 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from astrapy.authentication import (
+    EMBEDDING_HEADER_API_KEY,
+    EMBEDDING_HEADER_AWS_ACCESS_ID,
+    EMBEDDING_HEADER_AWS_SECRET_ID,
+    AWSEmbeddingHeadersProvider,
+    StaticEmbeddingHeadersProvider,
+    coerce_embedding_headers_provider,
+)
+
+
+class TestEmbeddingHeadersProvider:
+    @pytest.mark.describe("test of headers from StaticEmbeddingHeadersProvider")
+    def test_embeddingheadersprovider_static(self) -> None:
+        ehp = StaticEmbeddingHeadersProvider("x")
+        assert {k.lower(): v for k, v in ehp.get_headers().items()} == {
+            EMBEDDING_HEADER_API_KEY.lower(): "x"
+        }
+
+    @pytest.mark.describe("test of headers from empty StaticEmbeddingHeadersProvider")
+    def test_embeddingheadersprovider_null(self) -> None:
+        ehp = StaticEmbeddingHeadersProvider(None)
+        assert ehp.get_headers() == {}
+
+    @pytest.mark.describe("test of headers from AWSEmbeddingHeadersProvider")
+    def test_embeddingheadersprovider_aws(self) -> None:
+        ehp = AWSEmbeddingHeadersProvider(
+            embedding_access_id="x",
+            embedding_secret_id="y",
+        )
+        gen_headers_lower = {k.lower(): v for k, v in ehp.get_headers().items()}
+        exp_headers_lower = {
+            EMBEDDING_HEADER_AWS_ACCESS_ID.lower(): "x",
+            EMBEDDING_HEADER_AWS_SECRET_ID.lower(): "y",
+        }
+        assert gen_headers_lower == exp_headers_lower
+
+    @pytest.mark.describe("test of embedding headers provider coercion")
+    def test_embeddingheadersprovider_coercion(self) -> None:
+        """This doubles as equality test."""
+        ehp_s = StaticEmbeddingHeadersProvider("x")
+        ehp_n = StaticEmbeddingHeadersProvider(None)
+        ehp_a = AWSEmbeddingHeadersProvider(
+            embedding_access_id="x",
+            embedding_secret_id="y",
+        )
+        assert coerce_embedding_headers_provider(ehp_s) == ehp_s
+        assert coerce_embedding_headers_provider(ehp_n) == ehp_n
+        assert coerce_embedding_headers_provider(ehp_a) == ehp_a
+
+        assert coerce_embedding_headers_provider("x") == ehp_s
+        assert coerce_embedding_headers_provider(None) == ehp_n

--- a/tests/vectorize_idiomatic/vectorize_models.py
+++ b/tests/vectorize_idiomatic/vectorize_models.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from astrapy.authentication import EMBEDDING_HEADER_API_KEY
 from astrapy.info import CollectionVectorServiceOptions
 
 from .live_provider_info import live_provider_info
@@ -191,7 +192,7 @@ def live_test_models() -> Iterable[Dict[str, Any]]:
                         assert auth_type_desc["tokens"] == []
                     elif auth_type_name == "HEADER":
                         assert {t["accepted"] for t in auth_type_desc["tokens"]} == {
-                            "x-embedding-api-key"
+                            EMBEDDING_HEADER_API_KEY
                         }
                     elif auth_type_name == "SHARED_SECRET":
                         assert {t["accepted"] for t in auth_type_desc["tokens"]} == {


### PR DESCRIPTION
Promote the "embedding_api_key" parameter (e.g. to get_collection, create_collection) to allow for instances of a newly-created class, to accommodate for arbitrary and customizable set of auth headers for the various vectorize providers.

Fully backward-compatible.
