### PR TITLE
Toward 1.4.0 (findEmbeddingProviders; HCD namespace idioms; region/endpoint in DatabaseAdmin)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-(master)
+v. 1.4.0
 ========
 DatabaseAdmin classes retain a reference to the Async/Database instance that spawned it, if any
     - introduced a spawner_database parameter to database admin constructors

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 (master)
 ========
+DatabaseAdmin classes retain a reference to the Async/Database instance that spawned it, if any
+    - introduced a spawner_database parameter to database admin constructors
+    - database admin can retroactively set the db's working namespace upon creation of same
+    - Idiom `database = client.get_database(...); database.get_database_admin().create_namespace("the_namespace", update_db_namespace=True)`
 Database (and AsyncDatabase) classes admit null namespace:
     - default to "default_namespace" only for Astra, otherwise null
     - as long as null, most operations are unavailable and error out
@@ -16,11 +20,13 @@ Testing:
     - restructure CI to fully support HCD alongside Astra DB
     - add details for testing new embedding providers
 
+
 v. 1.3.1
 ========
 Fixed bug in parsing endpoint domain names containing hyphens (#287), by @bradfordcp
 Added isort for source code formatting
 Updated abstractions diagram in README for non-Astra environments
+
 
 v. 1.3.0
 ========
@@ -46,6 +52,7 @@ Remove several long-deprecated methods from **core API** (i.e. internal changes)
     AstraDB.truncate_collection       => AstraDBCollection.clear
     AsyncAstraDB.truncate_collection  => AsyncAstraDBCollectionclear
 Add support for null tokens in the core library
+
 
 v. 1.2.1
 ========

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 (master)
 ========
+Database (and AsyncDatabase) classes admit null namespace:
+    - default to "default_namespace" only for Astra, otherwise null
+    - as long as null, most operations are unavailable and error out
+    - a `use_namespace` method to (mutably) set the working namespace on a database instance
+AstraDBDatabaseAdmin class is fully region-aware:
+    - can be instantiated with an endpoint (also `id` parameter aliased to `api_endpoint`)
+    - requires a region to be specified with an ID, unless auto-guess can be done
+VectorizeOps: support for find_embedding_providers Database method
 Support for multiple-header embedding api keys:
     - `EmbeddingHeadersProvider` classes for `embedding_api_key` parameter
     - AWS header provider in addition to the regular one-header one

--- a/README.md
+++ b/README.md
@@ -483,6 +483,11 @@ from astrapy.info import (
     CollectionVectorOptions,
     CollectionOptions,
     CollectionDescriptor,
+    EmbeddingProviderParameter,
+    EmbeddingProviderModel,
+    EmbeddingProviderToken,
+    EmbeddingProviderAuthentication,
+    EmbeddingProvider,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ from astrapy.info import (
     EmbeddingProviderToken,
     EmbeddingProviderAuthentication,
     EmbeddingProvider,
+    FindEmbeddingProvidersResult,
 )
 ```
 

--- a/astrapy/__init__.py
+++ b/astrapy/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import importlib.metadata
 import os
 

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -2529,7 +2529,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
-            >>> admin_for_my_db.list_embedding_providers()
+            >>> admin_for_my_db.find_embedding_providers()
+            FindEmbeddingProvidersResult(embedding_providers=..., openai, ...)
+            >>> admin_for_my_db.find_embedding_providers().embedding_providers
             {
                 'openai': EmbeddingProvider(
                     display_name='OpenAI',
@@ -2571,7 +2573,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
-            >>> admin_for_my_db.list_embedding_providers()
+            >>> admin_for_my_db.find_embedding_providers()
+            FindEmbeddingProvidersResult(embedding_providers=..., openai, ...)
+            >>> admin_for_my_db.find_embedding_providers().embedding_providers
             {
                 'openai': EmbeddingProvider(
                     display_name='OpenAI',
@@ -3192,7 +3196,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
-            >>> admin_for_my_db.list_embedding_providers()
+            >>> admin_for_my_db.find_embedding_providers()
+            FindEmbeddingProvidersResult(embedding_providers=..., openai, ...)
+            >>> admin_for_my_db.find_embedding_providers().embedding_providers
             {
                 'openai': EmbeddingProvider(
                     display_name='OpenAI',
@@ -3234,7 +3240,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
-            >>> admin_for_my_db.list_embedding_providers()
+            >>> admin_for_my_db.find_embedding_providers()
+            FindEmbeddingProvidersResult(embedding_providers=..., openai, ...)
+            >>> admin_for_my_db.find_embedding_providers().embedding_providers
             {
                 'openai': EmbeddingProvider(
                     display_name='OpenAI',

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -3048,7 +3048,8 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
                 This can be either a literal token string or a subclass of
                 `astrapy.authentication.TokenProvider`.
             namespace: an optional namespace to set in the resulting Database.
-                If not provided, the default namespace is used.
+                If not provided, no namespace is set, limiting what the Database
+                can do until setting it with e.g. a `useNamespace` method call.
             api_path: path to append to the API Endpoint. In typical usage, this
                 should be left to its default of "".
             api_version: version specifier to append to the API path. In typical

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -39,7 +39,7 @@ from astrapy.exceptions import (
     ops_recast_method_sync,
     to_dataapi_timeout_exception,
 )
-from astrapy.info import AdminDatabaseInfo, DatabaseInfo, EmbeddingProvidersDescriptor
+from astrapy.info import AdminDatabaseInfo, DatabaseInfo, EmbeddingProvider
 
 if TYPE_CHECKING:
     from astrapy import AsyncDatabase, Database
@@ -2728,7 +2728,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
 
     def find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
-    ) -> EmbeddingProvidersDescriptor:
+    ) -> Dict[str, EmbeddingProvider]:
         """
         Query the API for the full information on available embedding providers.
 
@@ -2756,6 +2756,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished getting list of embedding providers")
-            return EmbeddingProvidersDescriptor.from_dict(
-                fe_response["status"]["embeddingProviders"]
-            )
+            return {
+                ep_name: EmbeddingProvider.from_dict(ep_dict)
+                for ep_name, ep_dict in fe_response["status"][
+                    "embeddingProviders"
+                ].items()
+            }

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -41,7 +41,7 @@ from astrapy.exceptions import (
     ops_recast_method_sync,
     to_dataapi_timeout_exception,
 )
-from astrapy.info import AdminDatabaseInfo, DatabaseInfo, EmbeddingProvider
+from astrapy.info import AdminDatabaseInfo, DatabaseInfo, FindEmbeddingProvidersResult
 
 if TYPE_CHECKING:
     from astrapy import AsyncDatabase, Database
@@ -1453,14 +1453,14 @@ class DatabaseAdmin(ABC):
     @abstractmethod
     def find_embedding_providers(
         self, *pargs: Any, **kwargs: Any
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """Query the Data API for the available embedding providers."""
         ...
 
     @abstractmethod
     async def async_find_embedding_providers(
         self, *pargs: Any, **kwargs: Any
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """
         Query the Data API for the available embedding providers.
         (Async version of the method.)
@@ -2517,7 +2517,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
 
     def find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """
         Query the API for the full information on available embedding providers.
 
@@ -2525,7 +2525,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             max_time_ms: a timeout, in milliseconds, for the DevOps API request.
 
         Returns:
-            An `EmbeddingProvidersDescriptor` object with the complete information
+            A `FindEmbeddingProvidersResult` object with the complete information
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
@@ -2554,16 +2554,11 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished getting list of embedding providers")
-            return {
-                ep_name: EmbeddingProvider.from_dict(ep_dict)
-                for ep_name, ep_dict in fe_response["status"][
-                    "embeddingProviders"
-                ].items()
-            }
+            return FindEmbeddingProvidersResult.from_dict(fe_response["status"])
 
     async def async_find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """
         Query the API for the full information on available embedding providers.
         Async version of the method, for use in an asyncio context.
@@ -2572,7 +2567,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             max_time_ms: a timeout, in milliseconds, for the DevOps API request.
 
         Returns:
-            An `EmbeddingProvidersDescriptor` object with the complete information
+            A `FindEmbeddingProvidersResult` object with the complete information
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
@@ -2601,12 +2596,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished getting list of embedding providers, async")
-            return {
-                ep_name: EmbeddingProvider.from_dict(ep_dict)
-                for ep_name, ep_dict in fe_response["status"][
-                    "embeddingProviders"
-                ].items()
-            }
+            return FindEmbeddingProvidersResult.from_dict(fe_response["status"])
 
 
 class DataAPIDatabaseAdmin(DatabaseAdmin):
@@ -3190,7 +3180,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
 
     def find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """
         Query the API for the full information on available embedding providers.
 
@@ -3198,7 +3188,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             max_time_ms: a timeout, in milliseconds, for the DevOps API request.
 
         Returns:
-            An `EmbeddingProvidersDescriptor` object with the complete information
+            A `FindEmbeddingProvidersResult` object with the complete information
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
@@ -3227,16 +3217,11 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished getting list of embedding providers")
-            return {
-                ep_name: EmbeddingProvider.from_dict(ep_dict)
-                for ep_name, ep_dict in fe_response["status"][
-                    "embeddingProviders"
-                ].items()
-            }
+            return FindEmbeddingProvidersResult.from_dict(fe_response["status"])
 
     async def async_find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
-    ) -> Dict[str, EmbeddingProvider]:
+    ) -> FindEmbeddingProvidersResult:
         """
         Query the API for the full information on available embedding providers.
         Async version of the method, for use in an asyncio context.
@@ -3245,7 +3230,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             max_time_ms: a timeout, in milliseconds, for the DevOps API request.
 
         Returns:
-            An `EmbeddingProvidersDescriptor` object with the complete information
+            A `FindEmbeddingProvidersResult` object with the complete information
             returned by the API about available embedding providers
 
         Example (output abridged and indented for clarity):
@@ -3274,9 +3259,4 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished getting list of embedding providers, async")
-            return {
-                ep_name: EmbeddingProvider.from_dict(ep_dict)
-                for ep_name, ep_dict in fe_response["status"][
-                    "embeddingProviders"
-                ].items()
-            }
+            return FindEmbeddingProvidersResult.from_dict(fe_response["status"])

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -271,7 +271,7 @@ async def async_fetch_raw_database_info_from_id_token(
 def fetch_database_info(
     api_endpoint: str,
     token: Optional[str],
-    namespace: str,
+    namespace: Optional[str],
     max_time_ms: Optional[int] = None,
 ) -> Optional[DatabaseInfo]:
     """
@@ -281,6 +281,7 @@ def fetch_database_info(
         api_endpoint: a full API endpoint for the Data Api.
         token: a valid token to access the database information.
         namespace: the desired namespace that will be used in the result.
+            If not specified, the resulting database info will show it as None.
         max_time_ms: a timeout, in milliseconds, for waiting on a response.
 
     Returns:
@@ -298,7 +299,7 @@ def fetch_database_info(
             max_time_ms=max_time_ms,
         )
         raw_info = gd_response["info"]
-        if namespace not in raw_info["keyspaces"]:
+        if namespace is not None and namespace not in raw_info["keyspaces"]:
             raise DevOpsAPIException(f"Namespace {namespace} not found on DB.")
         else:
             return DatabaseInfo(
@@ -316,7 +317,7 @@ def fetch_database_info(
 async def async_fetch_database_info(
     api_endpoint: str,
     token: Optional[str],
-    namespace: str,
+    namespace: Optional[str],
     max_time_ms: Optional[int] = None,
 ) -> Optional[DatabaseInfo]:
     """
@@ -327,6 +328,7 @@ async def async_fetch_database_info(
         api_endpoint: a full API endpoint for the Data Api.
         token: a valid token to access the database information.
         namespace: the desired namespace that will be used in the result.
+            If not specified, the resulting database info will show it as None.
         max_time_ms: a timeout, in milliseconds, for waiting on a response.
 
     Returns:
@@ -344,7 +346,7 @@ async def async_fetch_database_info(
             max_time_ms=max_time_ms,
         )
         raw_info = gd_response["info"]
-        if namespace not in raw_info["keyspaces"]:
+        if namespace is not None and namespace not in raw_info["keyspaces"]:
             raise DevOpsAPIException(f"Namespace {namespace} not found on DB.")
         else:
             return DatabaseInfo(

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -1393,7 +1393,13 @@ class DatabaseAdmin(ABC):
         ...
 
     @abstractmethod
-    def create_namespace(self, name: str, *pargs: Any, **kwargs: Any) -> Dict[str, Any]:
+    def create_namespace(
+        self,
+        name: str,
+        *,
+        update_db_namespace: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
         """
         Create a namespace in the database, returning {'ok': 1} if successful.
         """
@@ -1416,7 +1422,7 @@ class DatabaseAdmin(ABC):
 
     @abstractmethod
     async def async_create_namespace(
-        self, name: str, *pargs: Any, **kwargs: Any
+        self, name: str, *, update_db_namespace: Optional[bool] = None, **kwargs: Any
     ) -> Dict[str, Any]:
         """
         Create a namespace in the database, returning {'ok': 1} if successful.
@@ -1997,7 +2003,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         name: str,
         *,
         wait_until_active: bool = True,
+        update_db_namespace: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """
         Create a namespace in this database as requested,
@@ -2013,6 +2021,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
                 creation request to the DevOps API, and it will be responsibility
                 of the caller to check the database status/namespace availability
                 before working with it.
+            update_db_namespace: if True, the `Database` or `AsyncDatabase` class
+                that spawned this DatabaseAdmin, if any, gets updated to work on
+                the newly-created namespace starting when this method returns.
             max_time_ms: a timeout, in milliseconds, for the whole requested
                 operation to complete.
                 Note that a timeout is no guarantee that the creation request
@@ -2062,6 +2073,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             logger.info(
                 f"finished creating namespace '{name}' on '{self._database_id}'"
             )
+            if update_db_namespace:
+                self.spawner_database.use_namespace(name)
             return {"ok": 1}
         else:
             raise DevOpsAPIException(
@@ -2075,7 +2088,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         name: str,
         *,
         wait_until_active: bool = True,
+        update_db_namespace: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """
         Create a namespace in this database as requested,
@@ -2092,6 +2107,9 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
                 creation request to the DevOps API, and it will be responsibility
                 of the caller to check the database status/namespace availability
                 before working with it.
+            update_db_namespace: if True, the `Database` or `AsyncDatabase` class
+                that spawned this DatabaseAdmin, if any, gets updated to work on
+                the newly-created namespace starting when this method returns.
             max_time_ms: a timeout, in milliseconds, for the whole requested
                 operation to complete.
                 Note that a timeout is no guarantee that the creation request
@@ -2143,6 +2161,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             logger.info(
                 f"finished creating namespace '{name}' on '{self._database_id}', async"
             )
+            if update_db_namespace:
+                self.spawner_database.use_namespace(name)
             return {"ok": 1}
         else:
             raise DevOpsAPIException(
@@ -2838,7 +2858,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         name: str,
         *,
         replication_options: Optional[Dict[str, Any]] = None,
+        update_db_namespace: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """
         Create a namespace in the database, returning {'ok': 1} if successful.
@@ -2851,6 +2873,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
                 replication of the namespace (across database nodes). If provided,
                 it must have a structure similar to:
                 `{"class": "SimpleStrategy", "replication_factor": 1}`.
+            update_db_namespace: if True, the `Database` or `AsyncDatabase` class
+                that spawned this DatabaseAdmin, if any, gets updated to work on
+                the newly-created namespace starting when this method returns.
             max_time_ms: a timeout, in milliseconds, for the whole requested
                 operation to complete.
                 Note that a timeout is no guarantee that the creation request
@@ -2893,6 +2918,8 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished creating namespace")
+            if update_db_namespace:
+                self.spawner_database.use_namespace(name)
             return cn_response["status"]  # type: ignore[no-any-return]
 
     def drop_namespace(
@@ -2974,7 +3001,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         name: str,
         *,
         replication_options: Optional[Dict[str, Any]] = None,
+        update_db_namespace: Optional[bool] = None,
         max_time_ms: Optional[int] = None,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """
         Create a namespace in the database, returning {'ok': 1} if successful.
@@ -2988,6 +3017,9 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
                 replication of the namespace (across database nodes). If provided,
                 it must have a structure similar to:
                 `{"class": "SimpleStrategy", "replication_factor": 1}`.
+            update_db_namespace: if True, the `Database` or `AsyncDatabase` class
+                that spawned this DatabaseAdmin, if any, gets updated to work on
+                the newly-created namespace starting when this method returns.
             max_time_ms: a timeout, in milliseconds, for the whole requested
                 operation to complete.
                 Note that a timeout is no guarantee that the creation request
@@ -3032,6 +3064,8 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished creating namespace, async")
+            if update_db_namespace:
+                self.spawner_database.use_namespace(name)
             return cn_response["status"]  # type: ignore[no-any-return]
 
     async def async_drop_namespace(

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -2726,7 +2726,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             api_version=api_version,
         ).to_async()
 
-    def list_embedding_providers(
+    def find_embedding_providers(
         self, *, max_time_ms: Optional[int] = None
     ) -> EmbeddingProvidersDescriptor:
         """

--- a/astrapy/api/__init__.py
+++ b/astrapy/api/__init__.py
@@ -14,6 +14,8 @@
 
 """Core "api" subpackage, exported here to preserve import patterns."""
 
+from __future__ import annotations
+
 from astrapy.core.api import APIRequestError
 
 __all__ = [

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, TypeVar
 
 from astrapy.authentication import (
-    DefaultEmbeddingHeadersProvider,
+    EmbeddingAPIKeyHeadersProvider,
     EmbeddingHeadersProvider,
 )
 
@@ -117,12 +117,12 @@ class CollectionAPIOptions(BaseAPIOptions):
         embedding_api_key: an `astrapy.authentication.EmbeddingHeadersProvider`
             object, encoding embedding-related API keys that will be passed
             as headers when interacting with the collection (on each Data API request).
-            The default value is `DefaultEmbeddingHeadersProvider(None)`, i.e.
+            The default value is `EmbeddingAPIKeyHeadersProvider(None)`, i.e.
             no embedding-specific headers, whereas if the collection is configured
             with an embedding service other choices for this parameter can be
             meaningfully supplied. is configured for the collection,
     """
 
     embedding_api_key: EmbeddingHeadersProvider = field(
-        default_factory=lambda: DefaultEmbeddingHeadersProvider(None)
+        default_factory=lambda: EmbeddingAPIKeyHeadersProvider(None)
     )

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, TypeVar
 
 from astrapy.authentication import (
-    EmbeddingAPIKeyHeadersProvider,
+    EmbeddingAPIKeyHeaderProvider,
     EmbeddingHeadersProvider,
 )
 
@@ -117,12 +117,12 @@ class CollectionAPIOptions(BaseAPIOptions):
         embedding_api_key: an `astrapy.authentication.EmbeddingHeadersProvider`
             object, encoding embedding-related API keys that will be passed
             as headers when interacting with the collection (on each Data API request).
-            The default value is `EmbeddingAPIKeyHeadersProvider(None)`, i.e.
+            The default value is `EmbeddingAPIKeyHeaderProvider(None)`, i.e.
             no embedding-specific headers, whereas if the collection is configured
             with an embedding service other choices for this parameter can be
             meaningfully supplied. is configured for the collection,
     """
 
     embedding_api_key: EmbeddingHeadersProvider = field(
-        default_factory=lambda: EmbeddingAPIKeyHeadersProvider(None)
+        default_factory=lambda: EmbeddingAPIKeyHeaderProvider(None)
     )

--- a/astrapy/api_options.py
+++ b/astrapy/api_options.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass, field
 from typing import Optional, TypeVar
 
 from astrapy.authentication import (
+    DefaultEmbeddingHeadersProvider,
     EmbeddingHeadersProvider,
-    StaticEmbeddingHeadersProvider,
 )
 
 AO = TypeVar("AO", bound="BaseAPIOptions")
@@ -117,12 +117,12 @@ class CollectionAPIOptions(BaseAPIOptions):
         embedding_api_key: an `astrapy.authentication.EmbeddingHeadersProvider`
             object, encoding embedding-related API keys that will be passed
             as headers when interacting with the collection (on each Data API request).
-            The default value is `StaticEmbeddingHeadersProvider(None)`, i.e.
+            The default value is `DefaultEmbeddingHeadersProvider(None)`, i.e.
             no embedding-specific headers, whereas if the collection is configured
             with an embedding service other choices for this parameter can be
             meaningfully supplied. is configured for the collection,
     """
 
     embedding_api_key: EmbeddingHeadersProvider = field(
-        default_factory=lambda: StaticEmbeddingHeadersProvider(None)
+        default_factory=lambda: DefaultEmbeddingHeadersProvider(None)
     )

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -36,7 +36,7 @@ def coerce_embedding_headers_provider(
     if isinstance(embedding_api_key, EmbeddingHeadersProvider):
         return embedding_api_key
     else:
-        return StaticEmbeddingHeadersProvider(embedding_api_key)
+        return DefaultEmbeddingHeadersProvider(embedding_api_key)
 
 
 class TokenProvider(ABC):
@@ -202,7 +202,7 @@ class EmbeddingHeadersProvider(ABC):
         ...
 
 
-class StaticEmbeddingHeadersProvider(EmbeddingHeadersProvider):
+class DefaultEmbeddingHeadersProvider(EmbeddingHeadersProvider):
     """
     A "pass-through" header provider representing the single-header
     (typically "X-Embedding-Api-Key") auth scheme, in use by most of the
@@ -217,9 +217,9 @@ class StaticEmbeddingHeadersProvider(EmbeddingHeadersProvider):
         >>> from astrapy import DataAPIClient
         >>> from astrapy.authentication import (
             CollectionVectorServiceOptions,
-            StaticEmbeddingHeadersProvider,
+            DefaultEmbeddingHeadersProvider,
         )
-        >>> my_emb_api_key = StaticEmbeddingHeadersProvider("abc012...")
+        >>> my_emb_api_key = DefaultEmbeddingHeadersProvider("abc012...")
         >>> service_options = CollectionVectorServiceOptions(
         ...     provider="a-certain-provider",
         ...     model_name="some-embedding-model",

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -305,7 +305,11 @@ class AWSEmbeddingHeadersProvider(EmbeddingHeadersProvider):
         self.embedding_secret_id = embedding_secret_id
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}("{self.embedding_access_id[:3]}...", "{self.embedding_secret_id[:3]}...")'
+        return (
+            f"{self.__class__.__name__}(embedding_access_id="
+            f'"{self.embedding_access_id[:3]}...", '
+            f'embedding_secret_id="{self.embedding_secret_id[:3]}...")'
+        )
 
     def get_headers(self) -> Dict[str, str]:
         return {

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -36,7 +36,7 @@ def coerce_embedding_headers_provider(
     if isinstance(embedding_api_key, EmbeddingHeadersProvider):
         return embedding_api_key
     else:
-        return EmbeddingAPIKeyHeadersProvider(embedding_api_key)
+        return EmbeddingAPIKeyHeaderProvider(embedding_api_key)
 
 
 class TokenProvider(ABC):
@@ -202,7 +202,7 @@ class EmbeddingHeadersProvider(ABC):
         ...
 
 
-class EmbeddingAPIKeyHeadersProvider(EmbeddingHeadersProvider):
+class EmbeddingAPIKeyHeaderProvider(EmbeddingHeadersProvider):
     """
     A "pass-through" header provider representing the single-header
     (typically "X-Embedding-Api-Key") auth scheme, in use by most of the
@@ -217,9 +217,9 @@ class EmbeddingAPIKeyHeadersProvider(EmbeddingHeadersProvider):
         >>> from astrapy import DataAPIClient
         >>> from astrapy.authentication import (
             CollectionVectorServiceOptions,
-            EmbeddingAPIKeyHeadersProvider,
+            EmbeddingAPIKeyHeaderProvider,
         )
-        >>> my_emb_api_key = EmbeddingAPIKeyHeadersProvider("abc012...")
+        >>> my_emb_api_key = EmbeddingAPIKeyHeaderProvider("abc012...")
         >>> service_options = CollectionVectorServiceOptions(
         ...     provider="a-certain-provider",
         ...     model_name="some-embedding-model",

--- a/astrapy/authentication.py
+++ b/astrapy/authentication.py
@@ -36,7 +36,7 @@ def coerce_embedding_headers_provider(
     if isinstance(embedding_api_key, EmbeddingHeadersProvider):
         return embedding_api_key
     else:
-        return DefaultEmbeddingHeadersProvider(embedding_api_key)
+        return EmbeddingAPIKeyHeadersProvider(embedding_api_key)
 
 
 class TokenProvider(ABC):
@@ -202,7 +202,7 @@ class EmbeddingHeadersProvider(ABC):
         ...
 
 
-class DefaultEmbeddingHeadersProvider(EmbeddingHeadersProvider):
+class EmbeddingAPIKeyHeadersProvider(EmbeddingHeadersProvider):
     """
     A "pass-through" header provider representing the single-header
     (typically "X-Embedding-Api-Key") auth scheme, in use by most of the
@@ -217,9 +217,9 @@ class DefaultEmbeddingHeadersProvider(EmbeddingHeadersProvider):
         >>> from astrapy import DataAPIClient
         >>> from astrapy.authentication import (
             CollectionVectorServiceOptions,
-            DefaultEmbeddingHeadersProvider,
+            EmbeddingAPIKeyHeadersProvider,
         )
-        >>> my_emb_api_key = DefaultEmbeddingHeadersProvider("abc012...")
+        >>> my_emb_api_key = EmbeddingAPIKeyHeadersProvider("abc012...")
         >>> service_options = CollectionVectorServiceOptions(
         ...     provider="a-certain-provider",
         ...     model_name="some-embedding-model",

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from astrapy.admin import (
     api_endpoint_parser,

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -230,7 +230,7 @@ class DataAPIClient:
                 (it is left to the default otherwise).
             region: the region to use for connecting to the database. The
                 database must be located in that region.
-                The region cannot be specified when he API endoint is used as `id`.
+                The region cannot be specified when the API endoint is used as `id`.
                 Note that if this parameter is not passed, and cannot be inferred
                 from the API endpoint, an additional DevOps API request is made
                 to determine the default region and use it subsequently.
@@ -279,21 +279,18 @@ class DataAPIClient:
                     api_version=api_version,
                 )
             else:
-                # need to inspect for values?
-                this_db_info: Optional[Dict[str, Any]] = None
                 # handle overrides. Only region is needed (namespace can stay empty)
                 if region:
                     _region = region
                 else:
-                    if this_db_info is None:
-                        logger.info(f"fetching raw database info for {id}")
-                        this_db_info = fetch_raw_database_info_from_id_token(
-                            id=id,
-                            token=self.token_provider.get_token(),
-                            environment=self.environment,
-                            max_time_ms=max_time_ms,
-                        )
-                        logger.info(f"finished fetching raw database info for {id}")
+                    logger.info(f"fetching raw database info for {id}")
+                    this_db_info = fetch_raw_database_info_from_id_token(
+                        id=id,
+                        token=self.token_provider.get_token(),
+                        environment=self.environment,
+                        max_time_ms=max_time_ms,
+                    )
+                    logger.info(f"finished fetching raw database info for {id}")
                     _region = this_db_info["info"]["region"]
 
                 _token = coerce_token_provider(token) or self.token_provider

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -230,8 +230,8 @@ class DataAPIClient:
             token: if supplied, is passed to the Database instead of the client token.
                 This can be either a literal token string or a subclass of
                 `astrapy.authentication.TokenProvider`.
-            namespace: if provided, is passed to the Database
-                (it is left to the default otherwise).
+            namespace: if provided, it is passed to the Database; otherwise
+                the Database class will apply an environment-specific default.
             region: the region to use for connecting to the database. The
                 database must be located in that region.
                 The region cannot be specified when the API endoint is used as `id`.
@@ -385,8 +385,8 @@ class DataAPIClient:
             token: if supplied, is passed to the Database instead of the client token.
                 This can be either a literal token string or a subclass of
                 `astrapy.authentication.TokenProvider`.
-            namespace: if provided, is passed to the Database
-                (it is left to the default otherwise).
+            namespace: if provided, it is passed to the Database; otherwise
+                the Database class will apply an environment-specific default.
             api_path: path to append to the API Endpoint. In typical usage, this
                 should be left to its default of "/api/json".
             api_version: version specifier to append to the API path. In typical

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -343,7 +343,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeaderProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -410,7 +410,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeaderProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -561,7 +561,10 @@ class Collection:
             'default_keyspace'
         """
 
-        return self.database.namespace
+        _namespace = self.database.namespace
+        if _namespace is None:
+            raise ValueError("The collection's DB is set with namespace=None")
+        return _namespace
 
     @property
     def name(self) -> str:
@@ -2761,7 +2764,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeaderProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2828,7 +2831,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeaderProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2981,7 +2984,10 @@ class AsyncCollection:
             'default_keyspace'
         """
 
-        return self.database.namespace
+        _namespace = self.database.namespace
+        if _namespace is None:
+            raise ValueError("The collection's DB is set with namespace=None")
+        return _namespace
 
     @property
     def name(self) -> str:

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -343,7 +343,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -410,7 +410,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2761,7 +2761,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2828,7 +2828,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -343,7 +343,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -410,7 +410,7 @@ class Collection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2761,7 +2761,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -2828,7 +2828,7 @@ class AsyncCollection:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.

--- a/astrapy/core/__init__.py
+++ b/astrapy/core/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -160,11 +160,11 @@ class Database:
         _api_path: Optional[str]
         _api_version: Optional[str]
         if api_path is None:
-            _api_path = API_PATH_ENV_MAP.get(self.environment)
+            _api_path = API_PATH_ENV_MAP[self.environment]
         else:
             _api_path = api_path
         if api_version is None:
-            _api_version = API_VERSION_ENV_MAP.get(self.environment)
+            _api_version = API_VERSION_ENV_MAP[self.environment]
         else:
             _api_version = api_version
         self.token_provider = coerce_token_provider(token)
@@ -982,11 +982,11 @@ class AsyncDatabase:
         _api_path: Optional[str]
         _api_version: Optional[str]
         if api_path is None:
-            _api_path = API_PATH_ENV_MAP.get(self.environment)
+            _api_path = API_PATH_ENV_MAP[self.environment]
         else:
             _api_path = api_path
         if api_version is None:
-            _api_version = API_VERSION_ENV_MAP.get(self.environment)
+            _api_version = API_VERSION_ENV_MAP[self.environment]
         else:
             _api_version = api_version
         #

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -445,7 +445,7 @@ class Database:
             each Data API call will include the necessary embedding-related headers
             as specified by this parameter. If a string is passed, it translates
             into the one "embedding api key" header
-            (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+            (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
             For some vectorize providers/models, if using header-based authentication,
             specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
             should be supplied.
@@ -553,7 +553,7 @@ class Database:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -1284,7 +1284,7 @@ class AsyncDatabase:
             each Data API call will include the necessary embedding-related headers
             as specified by this parameter. If a string is passed, it translates
             into the one "embedding api key" header
-            (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+            (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
             For some vectorize providers/models, if using header-based authentication,
             specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
             should be supplied.
@@ -1395,7 +1395,7 @@ class AsyncDatabase:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.StaticEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -445,7 +445,7 @@ class Database:
             each Data API call will include the necessary embedding-related headers
             as specified by this parameter. If a string is passed, it translates
             into the one "embedding api key" header
-            (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+            (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
             For some vectorize providers/models, if using header-based authentication,
             specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
             should be supplied.
@@ -553,7 +553,7 @@ class Database:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.
@@ -1284,7 +1284,7 @@ class AsyncDatabase:
             each Data API call will include the necessary embedding-related headers
             as specified by this parameter. If a string is passed, it translates
             into the one "embedding api key" header
-            (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+            (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
             For some vectorize providers/models, if using header-based authentication,
             specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
             should be supplied.
@@ -1395,7 +1395,7 @@ class AsyncDatabase:
                 each Data API call will include the necessary embedding-related headers
                 as specified by this parameter. If a string is passed, it translates
                 into the one "embedding api key" header
-                (i.e. `astrapy.authentication.DefaultEmbeddingHeadersProvider`).
+                (i.e. `astrapy.authentication.EmbeddingAPIKeyHeadersProvider`).
                 For some vectorize providers/models, if using header-based authentication,
                 specialized subclasses of `astrapy.authentication.EmbeddingHeadersProvider`
                 should be supplied.

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -359,6 +359,8 @@ class Database:
         """
 
         logger.info(f"setting caller to {caller_name}/{caller_version}")
+        self.caller_name = caller_name
+        self.caller_version = caller_version
         self._astra_db.set_caller(
             caller_name=caller_name,
             caller_version=caller_version,
@@ -1259,6 +1261,8 @@ class AsyncDatabase:
         """
 
         logger.info(f"setting caller to {caller_name}/{caller_version}")
+        self.caller_name = caller_name
+        self.caller_version = caller_version
         self._astra_db.set_caller(
             caller_name=caller_name,
             caller_version=caller_version,

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -983,13 +983,15 @@ class Database:
         from astrapy.admin import AstraDBDatabaseAdmin, DataAPIDatabaseAdmin
 
         if self.environment in Environment.astra_db_values:
-            return AstraDBDatabaseAdmin.from_api_endpoint(
+            return AstraDBDatabaseAdmin(
                 api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
+                environment=self.environment,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
                 dev_ops_url=dev_ops_url,
                 dev_ops_api_version=dev_ops_api_version,
+                spawner_database=self,
             )
         else:
             if dev_ops_url is not None:
@@ -1008,6 +1010,7 @@ class Database:
                 api_version=self.api_version,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
+                spawner_database=self,
             )
 
 
@@ -1927,13 +1930,15 @@ class AsyncDatabase:
         from astrapy.admin import AstraDBDatabaseAdmin, DataAPIDatabaseAdmin
 
         if self.environment in Environment.astra_db_values:
-            return AstraDBDatabaseAdmin.from_api_endpoint(
+            return AstraDBDatabaseAdmin(
                 api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
+                environment=self.environment,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
                 dev_ops_url=dev_ops_url,
                 dev_ops_api_version=dev_ops_api_version,
+                spawner_database=self,
             )
         else:
             if dev_ops_url is not None:
@@ -1952,4 +1957,5 @@ class AsyncDatabase:
                 api_version=self.api_version,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
+                spawner_database=self,
             )

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -168,6 +168,7 @@ class Database:
         else:
             _api_version = api_version
         self.token_provider = coerce_token_provider(token)
+        self.api_endpoint = api_endpoint.strip("/")
         self._astra_db = AstraDB(
             token=self.token_provider.get_token(),
             api_endpoint=api_endpoint,
@@ -187,7 +188,7 @@ class Database:
 
     def __repr__(self) -> str:
         return (
-            f'{self.__class__.__name__}(api_endpoint="{self._astra_db.api_endpoint}", '
+            f'{self.__class__.__name__}(api_endpoint="{self.api_endpoint}", '
             f'token="{str(self.token_provider)[:12]}...", namespace="{self._astra_db.namespace}")'
         )
 
@@ -210,7 +211,7 @@ class Database:
         api_version: Optional[str] = None,
     ) -> Database:
         return Database(
-            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
             namespace=namespace or self._astra_db.namespace,
             caller_name=caller_name or self._astra_db.caller_name,
@@ -301,7 +302,7 @@ class Database:
         """
 
         return AsyncDatabase(
-            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
             namespace=namespace or self._astra_db.namespace,
             caller_name=caller_name or self._astra_db.caller_name,
@@ -357,7 +358,7 @@ class Database:
 
         logger.info("getting database info")
         database_info = fetch_database_info(
-            self._astra_db.api_endpoint,
+            self.api_endpoint,
             token=self.token_provider.get_token(),
             namespace=self.namespace,
         )
@@ -379,7 +380,7 @@ class Database:
             '01234567-89ab-cdef-0123-456789abcdef'
         """
 
-        parsed_api_endpoint = parse_api_endpoint(self._astra_db.api_endpoint)
+        parsed_api_endpoint = parse_api_endpoint(self.api_endpoint)
         if parsed_api_endpoint is not None:
             return parsed_api_endpoint.database_id
         else:
@@ -744,7 +745,7 @@ class Database:
             # we know this is a list of dicts, to marshal into "descriptors"
             logger.info("finished getting collections")
             return CommandCursor(
-                address=self._astra_db.base_url,
+                address=_client.base_url,
                 items=[
                     CollectionDescriptor.from_dict(col_dict)
                     for col_dict in gc_response["status"]["collections"]
@@ -891,7 +892,7 @@ class Database:
 
         if self.environment in Environment.astra_db_values:
             return AstraDBDatabaseAdmin.from_api_endpoint(
-                api_endpoint=self._astra_db.api_endpoint,
+                api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
                 caller_name=self._astra_db.caller_name,
                 caller_version=self._astra_db.caller_version,
@@ -908,7 +909,7 @@ class Database:
                     "Parameter `dev_ops_api_version` not supported outside of Astra DB."
                 )
             return DataAPIDatabaseAdmin(
-                api_endpoint=self._astra_db.api_endpoint,
+                api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
                 environment=self.environment,
                 api_path=self._astra_db.api_path,
@@ -990,6 +991,7 @@ class AsyncDatabase:
             _api_version = api_version
         #
         self.token_provider = coerce_token_provider(token)
+        self.api_endpoint = api_endpoint.strip("/")
         self._astra_db = AsyncAstraDB(
             token=self.token_provider.get_token(),
             api_endpoint=api_endpoint,
@@ -1009,7 +1011,7 @@ class AsyncDatabase:
 
     def __repr__(self) -> str:
         return (
-            f'{self.__class__.__name__}(api_endpoint="{self._astra_db.api_endpoint}", '
+            f'{self.__class__.__name__}(api_endpoint="{self.api_endpoint}", '
             f'token="{str(self.token_provider)[:12]}...", namespace="{self._astra_db.namespace}")'
         )
 
@@ -1047,7 +1049,7 @@ class AsyncDatabase:
         api_version: Optional[str] = None,
     ) -> AsyncDatabase:
         return AsyncDatabase(
-            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
             namespace=namespace or self._astra_db.namespace,
             caller_name=caller_name or self._astra_db.caller_name,
@@ -1139,7 +1141,7 @@ class AsyncDatabase:
         """
 
         return Database(
-            api_endpoint=api_endpoint or self._astra_db.api_endpoint,
+            api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
             namespace=namespace or self._astra_db.namespace,
             caller_name=caller_name or self._astra_db.caller_name,
@@ -1195,7 +1197,7 @@ class AsyncDatabase:
 
         logger.info("getting database info")
         database_info = fetch_database_info(
-            self._astra_db.api_endpoint,
+            self.api_endpoint,
             token=self.token_provider.get_token(),
             namespace=self.namespace,
         )
@@ -1217,7 +1219,7 @@ class AsyncDatabase:
             '01234567-89ab-cdef-0123-456789abcdef'
         """
 
-        parsed_api_endpoint = parse_api_endpoint(self._astra_db.api_endpoint)
+        parsed_api_endpoint = parse_api_endpoint(self.api_endpoint)
         if parsed_api_endpoint is not None:
             return parsed_api_endpoint.database_id
         else:
@@ -1594,7 +1596,7 @@ class AsyncDatabase:
             # we know this is a list of dicts, to marshal into "descriptors"
             logger.info("finished getting collections")
             return AsyncCommandCursor(
-                address=self._astra_db.base_url,
+                address=_client.base_url,
                 items=[
                     CollectionDescriptor.from_dict(col_dict)
                     for col_dict in gc_response["status"]["collections"]
@@ -1744,7 +1746,7 @@ class AsyncDatabase:
 
         if self.environment in Environment.astra_db_values:
             return AstraDBDatabaseAdmin.from_api_endpoint(
-                api_endpoint=self._astra_db.api_endpoint,
+                api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
                 caller_name=self._astra_db.caller_name,
                 caller_version=self._astra_db.caller_version,
@@ -1761,7 +1763,7 @@ class AsyncDatabase:
                     "Parameter `dev_ops_api_version` not supported outside of Astra DB."
                 )
             return DataAPIDatabaseAdmin(
-                api_endpoint=self._astra_db.api_endpoint,
+                api_endpoint=self.api_endpoint,
                 token=coerce_token_provider(token) or self.token_provider,
                 environment=self.environment,
                 api_path=self._astra_db.api_path,

--- a/astrapy/db/__init__.py
+++ b/astrapy/db/__init__.py
@@ -14,6 +14,8 @@
 
 """Core "db" subpackage, exported here to preserve import patterns."""
 
+from __future__ import annotations
+
 from astrapy.core.db import (
     AstraDB,
     AstraDBCollection,

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -747,3 +747,57 @@ class EmbeddingProvider:
             },
             url=raw_dict["url"],
         )
+
+
+@dataclass
+class FindEmbeddingProvidersResult:
+    """
+    A representation of the whole response from the 'findEmbeddingProviders'
+    Data API endpoint.
+
+    Attributes:
+        embedding_providers: a dictionary of provider names to EmbeddingProvider objects.
+        raw_info: a (nested) dictionary containing the original full response from the endpoint.
+    """
+
+    def __repr__(self) -> str:
+        return (
+            "FindEmbeddingProvidersResult(embedding_providers="
+            f"{', '.join(sorted(self.embedding_providers.keys()))})"
+        )
+
+    embedding_providers: Dict[str, EmbeddingProvider]
+    raw_info: Optional[Dict[str, Any]]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Recast this object into a dictionary."""
+
+        return {
+            "embeddingProviders": {
+                ep_name: e_provider.as_dict()
+                for ep_name, e_provider in self.embedding_providers.items()
+            },
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> FindEmbeddingProvidersResult:
+        """
+        Create an instance of FindEmbeddingProvidersResult from a dictionary
+        such as one from the Data API.
+        """
+
+        residual_keys = raw_dict.keys() - {
+            "embeddingProviders",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"a `FindEmbeddingProvidersResult`: '{','.join(sorted(residual_keys))}'"
+            )
+        return FindEmbeddingProvidersResult(
+            raw_info=raw_dict,
+            embedding_providers={
+                ep_name: EmbeddingProvider.from_dict(ep_body)
+                for ep_name, ep_body in raw_dict["embeddingProviders"].items()
+            },
+        )

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -470,6 +472,19 @@ class EmbeddingProviderParameter:
         TODO
         """
 
+        residual_keys = raw_dict.keys() - {
+            "defaultValue",
+            "help",
+            "name",
+            "required",
+            "type",
+            "validation",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"an `EmbeddingProviderParameter`: '{','.join(sorted(residual_keys))}'"
+            )
         return EmbeddingProviderParameter(
             default_value=raw_dict["defaultValue"],
             help=raw_dict["help"],
@@ -507,6 +522,16 @@ class EmbeddingProviderModel:
         TODO
         """
 
+        residual_keys = raw_dict.keys() - {
+            "name",
+            "parameters",
+            "vectorDimension",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"an `EmbeddingProviderModel`: '{','.join(sorted(residual_keys))}'"
+            )
         return EmbeddingProviderModel(
             name=raw_dict["name"],
             parameters=[
@@ -542,6 +567,15 @@ class EmbeddingProviderToken:
         TODO
         """
 
+        residual_keys = raw_dict.keys() - {
+            "accepted",
+            "forwarded",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"an `EmbeddingProviderToken`: '{','.join(sorted(residual_keys))}'"
+            )
         return EmbeddingProviderToken(
             accepted=raw_dict["accepted"],
             forwarded=raw_dict["forwarded"],
@@ -573,6 +607,15 @@ class EmbeddingProviderAuthentication:
         TODO
         """
 
+        residual_keys = raw_dict.keys() - {
+            "enabled",
+            "tokens",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"an `EmbeddingProviderAuthentication`: '{','.join(sorted(residual_keys))}'"
+            )
         return EmbeddingProviderAuthentication(
             enabled=raw_dict["enabled"],
             tokens=[
@@ -617,6 +660,18 @@ class EmbeddingProvider:
         TODO
         """
 
+        residual_keys = raw_dict.keys() - {
+            "displayName",
+            "models",
+            "parameters",
+            "supportedAuthentication",
+            "url",
+        }
+        if residual_keys:
+            warnings.warn(
+                "Unexpected key(s) encountered parsing a dictionary into "
+                f"an `EmbeddingProvider`: '{','.join(sorted(residual_keys))}'"
+            )
         return EmbeddingProvider(
             display_name=raw_dict["displayName"],
             models=[

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -28,7 +28,7 @@ class DatabaseInfo:
     Attributes:
         id: the database ID.
         region: the ID of the region through which the connection to DB is done.
-        namespace: the namespace this DB is set to work with.
+        namespace: the namespace this DB is set to work with. None if not set.
         name: the database name. Not necessarily unique: there can be multiple
             databases with the same name.
         environment: a label, whose value can be `Environment.PROD`,
@@ -51,7 +51,7 @@ class DatabaseInfo:
 
     id: str
     region: str
-    namespace: str
+    namespace: Optional[str]
     name: str
     environment: str
     raw_info: Optional[Dict[str, Any]]

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -441,7 +441,16 @@ class CollectionDescriptor:
 @dataclass
 class EmbeddingProviderParameter:
     """
-    TODO
+    A representation of a parameter as returned by the 'findEmbeddingProviders'
+    Data API endpoint.
+
+    Attributes:
+        default_value: the default value for the parameter.
+        help: a textual description of the parameter.
+        name: the name to use when passing the parameter for vectorize operations.
+        required: whether the parameter is required or not.
+        parameter_type: a textual description of the data type for the parameter.
+        validation: a dictionary describing a parameter-specific validation policy.
     """
 
     default_value: Any
@@ -455,9 +464,7 @@ class EmbeddingProviderParameter:
         return f"EmbeddingProviderParameter(name='{self.name}')"
 
     def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
+        """Recast this object into a dictionary."""
 
         return {
             "defaultValue": self.default_value,
@@ -471,7 +478,8 @@ class EmbeddingProviderParameter:
     @staticmethod
     def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderParameter:
         """
-        TODO
+        Create an instance of EmbeddingProviderParameter from a dictionary
+        such as one from the Data API.
         """
 
         residual_keys = raw_dict.keys() - {
@@ -500,7 +508,16 @@ class EmbeddingProviderParameter:
 @dataclass
 class EmbeddingProviderModel:
     """
-    TODO
+    A representation of an embedding model as returned by the 'findEmbeddingProviders'
+    Data API endpoint.
+
+    Attributes:
+        name: the model name as must be passed when issuing
+            vectorize operations to the API.
+        parameters: a list of the `EmbeddingProviderParameter` objects the model admits.
+        vector_dimension: an integer for the dimensionality of the embedding model.
+            if this is None, the dimension can assume multiple values as specified
+            by a corresponding parameter listed with the model.
     """
 
     name: str
@@ -511,9 +528,7 @@ class EmbeddingProviderModel:
         return f"EmbeddingProviderModel(name='{self.name}')"
 
     def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
+        """Recast this object into a dictionary."""
 
         return {
             "name": self.name,
@@ -524,7 +539,8 @@ class EmbeddingProviderModel:
     @staticmethod
     def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderModel:
         """
-        TODO
+        Create an instance of EmbeddingProviderModel from a dictionary
+        such as one from the Data API.
         """
 
         residual_keys = raw_dict.keys() - {
@@ -550,7 +566,16 @@ class EmbeddingProviderModel:
 @dataclass
 class EmbeddingProviderToken:
     """
-    TODO
+    A representation of a "token", that is a specific secret string, needed by
+    an embedding model; this models a part of the response from the
+    'findEmbeddingProviders' Data API endpoint.
+
+    Attributes:
+        accepted: the name of this "token" as seen by the Data API. This is the
+            name that should be used in the clients when supplying the secret,
+            whether as header or by shared-secret.
+        forwarded: the name used by the API when issuing the embedding request
+            to the embedding provider. This is of no direct interest for the Data API user.
     """
 
     accepted: str
@@ -560,9 +585,7 @@ class EmbeddingProviderToken:
         return f"EmbeddingProviderToken('{self.accepted}')"
 
     def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
+        """Recast this object into a dictionary."""
 
         return {
             "accepted": self.accepted,
@@ -572,7 +595,8 @@ class EmbeddingProviderToken:
     @staticmethod
     def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderToken:
         """
-        TODO
+        Create an instance of EmbeddingProviderToken from a dictionary
+        such as one from the Data API.
         """
 
         residual_keys = raw_dict.keys() - {
@@ -593,19 +617,27 @@ class EmbeddingProviderToken:
 @dataclass
 class EmbeddingProviderAuthentication:
     """
-    TODO
+    A representation of an authentication mode for using an embedding model,
+    modeling the corresponding part of the response returned by the
+    'findEmbeddingProviders' Data API endpoint (namely "supportedAuthentication").
+
+    Attributes:
+        enabled: whether this authentication mode is available for a given model.
+        tokens: a list of `EmbeddingProviderToken` objects,
+            detailing the secrets required for the authentication mode.
     """
 
     enabled: bool
     tokens: List[EmbeddingProviderToken]
 
     def __repr__(self) -> str:
-        return f"EmbeddingProviderAuthentication(enabled={self.enabled}, tokens={','.join(str(token) for token in self.tokens)})"
+        return (
+            f"EmbeddingProviderAuthentication(enabled={self.enabled}, "
+            f"tokens={','.join(str(token) for token in self.tokens)})"
+        )
 
     def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
+        """Recast this object into a dictionary."""
 
         return {
             "enabled": self.enabled,
@@ -615,7 +647,8 @@ class EmbeddingProviderAuthentication:
     @staticmethod
     def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderAuthentication:
         """
-        TODO
+        Create an instance of EmbeddingProviderAuthentication from a dictionary
+        such as one from the Data API.
         """
 
         residual_keys = raw_dict.keys() - {
@@ -639,13 +672,26 @@ class EmbeddingProviderAuthentication:
 @dataclass
 class EmbeddingProvider:
     """
-    TODO
+    A representation of an embedding provider, as returned by the 'findEmbeddingProviders'
+    Data API endpoint.
+
+    Attributes:
+        display_name: a version of the provider name for display and pretty printing.
+            Not to be used when issuing vectorize API requests (for the latter, it is
+            the key in the providers dictionary that is required).
+        models: a list of `EmbeddingProviderModel` objects pertaining to the provider.
+        parameters: a list of `EmbeddingProviderParameter` objects common to all models
+            for this provider.
+        supported_authentication: a dictionary of the authentication modes for
+            this provider. Note that disabled modes may still appear in this map,
+            albeit with the `enabled` property set to False.
+        url: a string template for the URL used by the Data API when issuing the request
+            toward the embedding provider. This is of no direct concern to the Data API user.
     """
 
     def __repr__(self) -> str:
         return f"EmbeddingProvider(display_name='{self.display_name}', models='{self.models}')"
 
-    # name: str  # TODO: add this one?
     display_name: Optional[str]
     models: List[EmbeddingProviderModel]
     parameters: List[EmbeddingProviderParameter]
@@ -653,9 +699,7 @@ class EmbeddingProvider:
     url: Optional[str]
 
     def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
+        """Recast this object into a dictionary."""
 
         return {
             "displayName": self.display_name,
@@ -671,7 +715,8 @@ class EmbeddingProvider:
     @staticmethod
     def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProvider:
         """
-        TODO
+        Create an instance of EmbeddingProvider from a dictionary
+        such as one from the Data API.
         """
 
         residual_keys = raw_dict.keys() - {

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -435,3 +435,234 @@ class CollectionDescriptor:
             options=CollectionOptions.from_dict(raw_dict.get("options") or {}),
             raw_descriptor=raw_dict,
         )
+
+
+@dataclass
+class EmbeddingProviderParameter:
+    """
+    TODO
+    """
+
+    default_value: Any
+    help: Optional[str]
+    name: str
+    required: bool
+    parameter_type: str
+    validation: Dict[str, Any]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            "defaultValue": self.default_value,
+            "help": self.help,
+            "name": self.name,
+            "required": self.required,
+            "type": self.parameter_type,
+            "validation": self.validation,
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderParameter:
+        """
+        TODO
+        """
+
+        return EmbeddingProviderParameter(
+            default_value=raw_dict["defaultValue"],
+            help=raw_dict["help"],
+            name=raw_dict["name"],
+            required=raw_dict["required"],
+            parameter_type=raw_dict["type"],
+            validation=raw_dict["validation"],
+        )
+
+
+@dataclass
+class EmbeddingProviderModel:
+    """
+    TODO
+    """
+
+    name: str
+    parameters: List[EmbeddingProviderParameter]
+    vector_dimension: Optional[int]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            "name": self.name,
+            "parameters": [parameter.as_dict() for parameter in self.parameters],
+            "vectorDimension": self.vector_dimension,
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderModel:
+        """
+        TODO
+        """
+
+        return EmbeddingProviderModel(
+            name=raw_dict["name"],
+            parameters=[
+                EmbeddingProviderParameter.from_dict(param_dict)
+                for param_dict in raw_dict["parameters"]
+            ],
+            vector_dimension=raw_dict["vectorDimension"],
+        )
+
+
+@dataclass
+class EmbeddingProviderToken:
+    """
+    TODO
+    """
+
+    accepted: str
+    forwarded: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            "accepted": self.accepted,
+            "forwarded": self.forwarded,
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderToken:
+        """
+        TODO
+        """
+
+        return EmbeddingProviderToken(
+            accepted=raw_dict["accepted"],
+            forwarded=raw_dict["forwarded"],
+        )
+
+
+@dataclass
+class EmbeddingProviderAuthentication:
+    """
+    TODO
+    """
+
+    enabled: bool
+    tokens: List[EmbeddingProviderToken]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            "enabled": self.enabled,
+            "tokens": [token.as_dict() for token in self.tokens],
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProviderAuthentication:
+        """
+        TODO
+        """
+
+        return EmbeddingProviderAuthentication(
+            enabled=raw_dict["enabled"],
+            tokens=[
+                EmbeddingProviderToken.from_dict(token_dict)
+                for token_dict in raw_dict["tokens"]
+            ],
+        )
+
+
+@dataclass
+class EmbeddingProvider:
+    """
+    TODO
+    """
+
+    # name: str  # TODO: add this one?
+    display_name: Optional[str]
+    models: List[EmbeddingProviderModel]
+    parameters: List[EmbeddingProviderParameter]
+    supported_authentication: Dict[str, EmbeddingProviderAuthentication]
+    url: Optional[str]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            "displayName": self.display_name,
+            "models": [model.as_dict() for model in self.models],
+            "parameters": [parameter.as_dict() for parameter in self.parameters],
+            "supportedAuthentication": {
+                sa_name: sa_value.as_dict()
+                for sa_name, sa_value in self.supported_authentication.items()
+            },
+            "url": self.url,
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProvider:
+        """
+        TODO
+        """
+
+        return EmbeddingProvider(
+            display_name=raw_dict["displayName"],
+            models=[
+                EmbeddingProviderModel.from_dict(model_dict)
+                for model_dict in raw_dict["models"]
+            ],
+            parameters=[
+                EmbeddingProviderParameter.from_dict(param_dict)
+                for param_dict in raw_dict["parameters"]
+            ],
+            supported_authentication={
+                sa_name: EmbeddingProviderAuthentication.from_dict(sa_dict)
+                for sa_name, sa_dict in raw_dict["supportedAuthentication"].items()
+            },
+            url=raw_dict["url"],
+        )
+
+
+@dataclass
+class EmbeddingProvidersDescriptor:
+    """
+    TODO
+    """
+
+    embedding_providers: Dict[str, EmbeddingProvider]
+    raw_descriptor: Optional[Dict[str, Any]]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        TODO
+        """
+
+        return {
+            ep_name: ep.as_dict() for ep_name, ep in self.embedding_providers.items()
+        }
+
+    @staticmethod
+    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProvidersDescriptor:
+        """
+        TODO
+        """
+
+        return EmbeddingProvidersDescriptor(
+            embedding_providers={
+                ep_name: EmbeddingProvider.from_dict(ep_dict)
+                for ep_name, ep_dict in raw_dict.items()
+            },
+            raw_descriptor=raw_dict,
+        )

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -690,7 +690,7 @@ class EmbeddingProvider:
     """
 
     def __repr__(self) -> str:
-        return f"EmbeddingProvider(display_name='{self.display_name}', models='{self.models}')"
+        return f"EmbeddingProvider(display_name='{self.display_name}', models={self.models})"
 
     display_name: Optional[str]
     models: List[EmbeddingProviderModel]

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import warnings
-
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -452,6 +451,9 @@ class EmbeddingProviderParameter:
     parameter_type: str
     validation: Dict[str, Any]
 
+    def __repr__(self) -> str:
+        return f"EmbeddingProviderParameter(name='{self.name}')"
+
     def as_dict(self) -> Dict[str, Any]:
         """
         TODO
@@ -505,6 +507,9 @@ class EmbeddingProviderModel:
     parameters: List[EmbeddingProviderParameter]
     vector_dimension: Optional[int]
 
+    def __repr__(self) -> str:
+        return f"EmbeddingProviderModel(name='{self.name}')"
+
     def as_dict(self) -> Dict[str, Any]:
         """
         TODO
@@ -551,6 +556,9 @@ class EmbeddingProviderToken:
     accepted: str
     forwarded: str
 
+    def __repr__(self) -> str:
+        return f"EmbeddingProviderToken('{self.accepted}')"
+
     def as_dict(self) -> Dict[str, Any]:
         """
         TODO
@@ -591,6 +599,9 @@ class EmbeddingProviderAuthentication:
     enabled: bool
     tokens: List[EmbeddingProviderToken]
 
+    def __repr__(self) -> str:
+        return f"EmbeddingProviderAuthentication(enabled={self.enabled}, tokens={','.join(str(token) for token in self.tokens)})"
+
     def as_dict(self) -> Dict[str, Any]:
         """
         TODO
@@ -630,6 +641,9 @@ class EmbeddingProvider:
     """
     TODO
     """
+
+    def __repr__(self) -> str:
+        return f"EmbeddingProvider(display_name='{self.display_name}', models='{self.models}')"
 
     # name: str  # TODO: add this one?
     display_name: Optional[str]
@@ -687,37 +701,4 @@ class EmbeddingProvider:
                 for sa_name, sa_dict in raw_dict["supportedAuthentication"].items()
             },
             url=raw_dict["url"],
-        )
-
-
-@dataclass
-class EmbeddingProvidersDescriptor:
-    """
-    TODO
-    """
-
-    embedding_providers: Dict[str, EmbeddingProvider]
-    raw_descriptor: Optional[Dict[str, Any]]
-
-    def as_dict(self) -> Dict[str, Any]:
-        """
-        TODO
-        """
-
-        return {
-            ep_name: ep.as_dict() for ep_name, ep in self.embedding_providers.items()
-        }
-
-    @staticmethod
-    def from_dict(raw_dict: Dict[str, Any]) -> EmbeddingProvidersDescriptor:
-        """
-        TODO
-        """
-
-        return EmbeddingProvidersDescriptor(
-            embedding_providers={
-                ep_name: EmbeddingProvider.from_dict(ep_dict)
-                for ep_name, ep_dict in raw_dict.items()
-            },
-            raw_descriptor=raw_dict,
         )

--- a/astrapy/ops/__init__.py
+++ b/astrapy/ops/__init__.py
@@ -14,6 +14,8 @@
 
 """Core "ops" subpackage, exported here to preserve import patterns."""
 
+from __future__ import annotations
+
 from astrapy.core.ops import AstraDBOps
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astrapy"
-version = "1.3.2"
+version = "1.4.0"
 description = "AstraPy is a Pythonic SDK for DataStax Astra and its Data API"
 authors = [
     "Stefano Lottini <stefano.lottini@datastax.com>",

--- a/scripts/astrapy_latest_interface.py
+++ b/scripts/astrapy_latest_interface.py
@@ -16,8 +16,8 @@ token = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
 api_endpoint = os.environ["ASTRA_DB_API_ENDPOINT"]
 
 # Initialize our vector db
-my_client = astrapy.DataAPIClient(token)
-my_database = my_client.get_database(api_endpoint)
+my_client = astrapy.DataAPIClient()
+my_database = my_client.get_database(api_endpoint, token=token)
 
 # In case we already have the collection, let's clear it out
 my_database.drop_collection("collection_test")
@@ -29,8 +29,8 @@ my_collection = my_database.create_collection("collection_test", dimension=5)
 my_collection.insert_one(
     {
         "_id": "1",
-        "name": "Coded Cleats Copy",
-        "description": "ChatGPT integrated sneakers that talk to you",
+        "name": "Coded Cleats",
+        "description": "GenAI-integrated sneakers that talk to you",
         "$vector": [0.25, 0.25, 0.25, 0.25, 0.25],
     },
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@
 Main conftest for shared fixtures (if any).
 """
 
+from __future__ import annotations
+
 import functools
 import warnings
 from typing import Any, Awaitable, Callable, Optional, Tuple, TypedDict

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -16,6 +16,8 @@
 Test fixtures for 'core' testing
 """
 
+from __future__ import annotations
+
 import math
 from typing import AsyncIterable, Dict, Iterable, List, Optional, Set, TypeVar
 

--- a/tests/core/test_async_db_ddl.py
+++ b/tests/core/test_async_db_ddl.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts related to DML & client creation
 """
 
+from __future__ import annotations
+
 import logging
 
 import pytest

--- a/tests/core/test_async_db_dml.py
+++ b/tests/core/test_async_db_dml.py
@@ -17,6 +17,8 @@ Tests for the `db.py` parts on data manipulation "standard" methods
 (i.e. non `vector_*` methods)
 """
 
+from __future__ import annotations
+
 import datetime
 import logging
 import uuid

--- a/tests/core/test_async_db_dml.py
+++ b/tests/core/test_async_db_dml.py
@@ -602,7 +602,6 @@ async def test_chunked_insert_many_failures(
             chunk_size=2,
             concurrency=1,
         )
-    assert len((await async_empty_v_collection.find({}))["data"]["documents"]) == 2
 
     await async_empty_v_collection.delete_many({})
     with pytest.raises(APIRequestError):
@@ -613,7 +612,24 @@ async def test_chunked_insert_many_failures(
             chunk_size=2,
             concurrency=2,
         )
-    assert len((await async_empty_v_collection.find({}))["data"]["documents"]) >= 2
+
+
+@pytest.mark.describe(
+    "chunked_insert_many, failure modes unordered with concurrency (async)"
+)
+async def test_chunked_insert_many_failures_unordered_concurrent(
+    async_empty_v_collection: AsyncAstraDBCollection,
+) -> None:
+    """
+    Note: this is split from the `test_chunked_insert_many_failures` test
+    because the last command there (insert_many of bad_docs with ordered but concurrency>1)
+    leaves orphan running tasks once the exception is raised. This ultimately
+    traces back to known asyncio.gather behaviour - it is not a bug,
+    just something that makes the premises for the next testing ill-defined.
+
+    More info on the underlying issue: https://stackoverflow.com/a/59074112/16545960
+    """
+    dup_docs = [{"_id": tid} for tid in ["a", "b", "b", "d", "e", "f"]]
 
     await async_empty_v_collection.delete_many({})
     ins_result = await async_empty_v_collection.chunked_insert_many(

--- a/tests/core/test_async_db_dml_pagination.py
+++ b/tests/core/test_async_db_dml_pagination.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Optional
 

--- a/tests/core/test_async_db_dml_vector.py
+++ b/tests/core/test_async_db_dml_vector.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts on data manipulation `vector_*` methods
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Iterable, List, cast
 

--- a/tests/core/test_conversions.py
+++ b/tests/core/test_conversions.py
@@ -16,6 +16,8 @@
 Tests for the User-Agent customization logic
 """
 
+from __future__ import annotations
+
 import logging
 
 import pytest

--- a/tests/core/test_db_ddl.py
+++ b/tests/core/test_db_ddl.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts related to DML & client creation
 """
 
+from __future__ import annotations
+
 import logging
 
 import pytest

--- a/tests/core/test_db_dml.py
+++ b/tests/core/test_db_dml.py
@@ -17,6 +17,8 @@ Tests for the `db.py` parts on data manipulation "standard" methods
 (i.e. non `vector_*` methods)
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging

--- a/tests/core/test_db_dml.py
+++ b/tests/core/test_db_dml.py
@@ -592,7 +592,17 @@ def test_chunked_insert_many_failures(
             chunk_size=2,
             concurrency=2,
         )
-    assert len(empty_v_collection.find({})["data"]["documents"]) >= 2
+
+
+@pytest.mark.describe("chunked_insert_many, failure modes unordered with concurrency")
+def test_chunked_insert_many_failures_unordered_concurrent(
+    empty_v_collection: AstraDBCollection,
+) -> None:
+    """
+    Note: no real reason to split this from `test_chunked_insert_many_failures`,
+    other than to preserve symmetry with the async counterpart.
+    """
+    dup_docs = [{"_id": tid} for tid in ["a", "b", "b", "d", "e", "f"]]
 
     empty_v_collection.delete_many({})
     ins_result = empty_v_collection.chunked_insert_many(

--- a/tests/core/test_db_dml_pagination.py
+++ b/tests/core/test_db_dml_pagination.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts on pagination primitives
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Optional
 

--- a/tests/core/test_db_dml_vector.py
+++ b/tests/core/test_db_dml_vector.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts on data manipulation `vector_*` methods
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Iterable, List, cast
 

--- a/tests/core/test_endpoint_parsing.py
+++ b/tests/core/test_endpoint_parsing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.admin import parse_generic_api_url

--- a/tests/core/test_ids.py
+++ b/tests/core/test_ids.py
@@ -16,6 +16,8 @@
 Unit tests for the ObjectIds and UUIDn conversions
 """
 
+from __future__ import annotations
+
 import json
 import uuid as lib_uuid
 

--- a/tests/core/test_imports.py
+++ b/tests/core/test_imports.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 """
-Tests for the User-Agent customization logic
+Tests for the core-related imports
 """
+
+from __future__ import annotations
 
 import pytest
 

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -16,6 +16,8 @@
 Tests for the "TRACE" custom logging level
 """
 
+from __future__ import annotations
+
 import logging
 
 import pytest

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import logging
 from typing import Any, Dict, List, cast

--- a/tests/core/test_timeouts.py
+++ b/tests/core/test_timeouts.py
@@ -16,6 +16,8 @@
 Tests for the `db.py` parts related to DML & client creation
 """
 
+from __future__ import annotations
+
 import logging
 
 import httpx

--- a/tests/core/test_user_agent.py
+++ b/tests/core/test_user_agent.py
@@ -16,6 +16,8 @@
 Tests for the User-Agent customization logic
 """
 
+from __future__ import annotations
+
 import logging
 
 import pytest

--- a/tests/idiomatic/__init__.py
+++ b/tests/idiomatic/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/idiomatic/conftest.py
+++ b/tests/idiomatic/conftest.py
@@ -14,6 +14,8 @@
 
 """Fixtures specific to the non-core-side testing."""
 
+from __future__ import annotations
+
 from typing import Iterable
 
 import pytest

--- a/tests/idiomatic/integration/__init__.py
+++ b/tests/idiomatic/integration/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/idiomatic/integration/test_admin.py
+++ b/tests/idiomatic/integration/test_admin.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 from typing import Any, Awaitable, Callable, List, Optional, Tuple
 

--- a/tests/idiomatic/integration/test_admin.py
+++ b/tests/idiomatic/integration/test_admin.py
@@ -19,7 +19,7 @@ from typing import Any, Awaitable, Callable, List, Optional, Tuple
 
 import pytest
 
-from astrapy import DataAPIClient
+from astrapy import AsyncDatabase, DataAPIClient, Database
 from astrapy.admin import API_ENDPOINT_TEMPLATE_MAP
 
 from ..conftest import (
@@ -584,3 +584,43 @@ class TestAdmin:
             max_seconds=DATABASE_TIMEOUT,
             acondition=_awaiter4,
         )
+
+    @pytest.mark.describe(
+        "test of the update_db_namespace flag for AstraDBDatabaseAdmin, sync"
+    )
+    def test_astra_updatedbnamespace_sync(self, sync_database: Database) -> None:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        namespace0 = sync_database.namespace
+        database_admin = sync_database.get_database_admin()
+        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        assert sync_database.namespace == namespace0
+
+        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        assert sync_database.namespace == NEW_NS_NAME_UPDATED
+
+        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the update_db_namespace flag for AstraDBDatabaseAdmin, async"
+    )
+    async def test_astra_updatedbnamespace_async(
+        self, async_database: AsyncDatabase
+    ) -> None:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        namespace0 = async_database.namespace
+        database_admin = async_database.get_database_admin()
+        await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        assert async_database.namespace == namespace0
+
+        await database_admin.async_create_namespace(
+            NEW_NS_NAME_UPDATED, update_db_namespace=True
+        )
+        assert async_database.namespace == NEW_NS_NAME_UPDATED
+
+        await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -225,6 +225,28 @@ class TestDDLAsync:
     @pytest.mark.skipif(
         SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
     )
+    @pytest.mark.describe("test of Database use_namespace, async")
+    async def test_database_use_namespace_async(
+        self,
+        async_database: AsyncDatabase,
+        async_collection: AsyncCollection,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        # make a copy to avoid mutating the fixture
+        at_database = async_database._copy()
+        assert at_database == async_database
+        assert at_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert TEST_COLLECTION_NAME in await at_database.list_collection_names()
+
+        at_database.use_namespace(data_api_credentials_info["secondary_namespace"])  # type: ignore[arg-type]
+        assert at_database != async_database
+        assert at_database.namespace == data_api_credentials_info["secondary_namespace"]
+        assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
+
+    @pytest.mark.skipif(
+        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+    )
     @pytest.mark.describe("test of cross-namespace collection lifecycle, async")
     async def test_collection_namespace_async(
         self,

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 
 import pytest

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -334,7 +334,11 @@ class TestDDLAsync:
         api_endpoint = data_api_credentials_kwargs["api_endpoint"]
         token = data_api_credentials_kwargs["token"]
         client = DataAPIClient(environment=data_api_credentials_info["environment"])
-        a_database = client.get_async_database(api_endpoint, token=token)
+        a_database = client.get_async_database(
+            api_endpoint,
+            token=token,
+            namespace=data_api_credentials_kwargs["namespace"],
+        )
         coll_names = await a_database.list_collection_names()
         assert isinstance(coll_names, list)
 

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -315,3 +315,39 @@ class TestDDLAsync:
         a_database = client.get_async_database(api_endpoint, token=token)
         coll_names = await a_database.list_collection_names()
         assert isinstance(coll_names, list)
+
+    @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
+    @pytest.mark.describe(
+        "test database-from-admin default namespace per environment, async"
+    )
+    async def test_database_from_admin_default_namespace_per_environment_async(
+        self,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        client = DataAPIClient(environment=data_api_credentials_info["environment"])
+        admin = client.get_admin(token=data_api_credentials_kwargs["token"])
+        db_m = admin.get_async_database(
+            data_api_credentials_kwargs["api_endpoint"],
+            namespace="M",
+        )
+        assert db_m.namespace == "M"
+        db_n = admin.get_async_database(data_api_credentials_kwargs["api_endpoint"])
+        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+
+    @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
+    @pytest.mark.describe(
+        "test database-from-astradbadmin default namespace per environment, async"
+    )
+    async def test_database_from_astradbadmin_default_namespace_per_environment_async(
+        self,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        client = DataAPIClient(environment=data_api_credentials_info["environment"])
+        admin = client.get_admin(token=data_api_credentials_kwargs["token"])
+        db_admin = admin.get_database_admin(data_api_credentials_kwargs["api_endpoint"])
+        db_m = db_admin.get_async_database(namespace="M")
+        assert db_m.namespace == "M"
+        db_n = db_admin.get_async_database()
+        assert isinstance(db_n.namespace, str)  # i.e. resolution took place

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -324,7 +324,11 @@ class TestDDLSync:
         api_endpoint = data_api_credentials_kwargs["api_endpoint"]
         token = data_api_credentials_kwargs["token"]
         client = DataAPIClient(environment=data_api_credentials_info["environment"])
-        database = client.get_database(api_endpoint, token=token)
+        database = client.get_database(
+            api_endpoint,
+            token=token,
+            namespace=data_api_credentials_kwargs["namespace"],
+        )
         assert isinstance(database.list_collection_names(), list)
 
     @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -346,3 +346,39 @@ class TestDDLSync:
             token=data_api_credentials_kwargs["token"],
             environment=data_api_credentials_info["environment"],
         )
+
+    @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
+    @pytest.mark.describe(
+        "test database-from-admin default namespace per environment, sync"
+    )
+    def test_database_from_admin_default_namespace_per_environment_sync(
+        self,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        client = DataAPIClient(environment=data_api_credentials_info["environment"])
+        admin = client.get_admin(token=data_api_credentials_kwargs["token"])
+        db_m = admin.get_database(
+            data_api_credentials_kwargs["api_endpoint"],
+            namespace="M",
+        )
+        assert db_m.namespace == "M"
+        db_n = admin.get_database(data_api_credentials_kwargs["api_endpoint"])
+        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+
+    @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
+    @pytest.mark.describe(
+        "test database-from-astradbadmin default namespace per environment, sync"
+    )
+    def test_database_from_astradbadmin_default_namespace_per_environment_sync(
+        self,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        client = DataAPIClient(environment=data_api_credentials_info["environment"])
+        admin = client.get_admin(token=data_api_credentials_kwargs["token"])
+        db_admin = admin.get_database_admin(data_api_credentials_kwargs["api_endpoint"])
+        db_m = db_admin.get_database(namespace="M")
+        assert db_m.namespace == "M"
+        db_n = db_admin.get_database()
+        assert isinstance(db_n.namespace, str)  # i.e. resolution took place

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 
 import pytest

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -316,6 +316,10 @@ class TestDDLSync:
         parsed_api_endpoint = parse_api_endpoint(
             data_api_credentials_kwargs["api_endpoint"]
         )
+        if parsed_api_endpoint is None:
+            raise ValueError(
+                f"Unparseable API endpoint: {data_api_credentials_kwargs['api_endpoint']}"
+            )
         adm = client.get_admin(token=data_api_credentials_kwargs["token"])
         # auto-region through the DebvOps "db info" call
         assert adm.get_database_admin(

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -216,6 +216,28 @@ class TestDDLSync:
     @pytest.mark.skipif(
         SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
     )
+    @pytest.mark.describe("test of Database use_namespace, sync")
+    def test_database_use_namespace_sync(
+        self,
+        sync_database: Database,
+        sync_collection: Collection,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        # make a copy to avoid mutating the fixture
+        t_database = sync_database._copy()
+        assert t_database == sync_database
+        assert t_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert TEST_COLLECTION_NAME in t_database.list_collection_names()
+
+        t_database.use_namespace(data_api_credentials_info["secondary_namespace"])  # type: ignore[arg-type]
+        assert t_database != sync_database
+        assert t_database.namespace == data_api_credentials_info["secondary_namespace"]
+        assert TEST_COLLECTION_NAME not in t_database.list_collection_names()
+
+    @pytest.mark.skipif(
+        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+    )
     @pytest.mark.describe("test of cross-namespace collection lifecycle, sync")
     def test_collection_namespace_sync(
         self,

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -17,6 +17,7 @@ import time
 import pytest
 
 from astrapy import Collection, DataAPIClient, Database
+from astrapy.admin import AstraDBDatabaseAdmin, parse_api_endpoint
 from astrapy.constants import DefaultIdType, VectorMetric
 from astrapy.ids import UUID, ObjectId
 from astrapy.info import CollectionDescriptor, DatabaseInfo
@@ -301,3 +302,41 @@ class TestDDLSync:
         client = DataAPIClient(environment=data_api_credentials_info["environment"])
         database = client.get_database(api_endpoint, token=token)
         assert isinstance(database.list_collection_names(), list)
+
+    @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
+    @pytest.mark.describe(
+        "test of autoregion through DevOps API for get_database(_admin), sync"
+    )
+    def test_autoregion_getdatabase_sync(
+        self,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        client = DataAPIClient(environment=data_api_credentials_info["environment"])
+        parsed_api_endpoint = parse_api_endpoint(
+            data_api_credentials_kwargs["api_endpoint"]
+        )
+        adm = client.get_admin(token=data_api_credentials_kwargs["token"])
+        # auto-region through the DebvOps "db info" call
+        assert adm.get_database_admin(
+            parsed_api_endpoint.database_id
+        ) == adm.get_database_admin(data_api_credentials_kwargs["api_endpoint"])
+
+        # auto-region for get_database
+        assert adm.get_database(
+            parsed_api_endpoint.database_id,
+            namespace="the_ns",
+        ) == adm.get_database(
+            data_api_credentials_kwargs["api_endpoint"], namespace="the_ns"
+        )
+
+        # auto-region for the init of AstraDBDatabaseAdmin
+        assert AstraDBDatabaseAdmin(
+            data_api_credentials_kwargs["api_endpoint"],
+            token=data_api_credentials_kwargs["token"],
+            environment=data_api_credentials_info["environment"],
+        ) == AstraDBDatabaseAdmin(
+            parsed_api_endpoint.database_id,
+            token=data_api_credentials_kwargs["token"],
+            environment=data_api_credentials_info["environment"],
+        )

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict, List
 

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict, List
 

--- a/tests/idiomatic/integration/test_exceptions_async.py
+++ b/tests/idiomatic/integration/test_exceptions_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List
 
 import pytest

--- a/tests/idiomatic/integration/test_exceptions_sync.py
+++ b/tests/idiomatic/integration/test_exceptions_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import Collection, Database

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -37,6 +37,7 @@ class TestNonAstraAdmin:
             - database -> create_collection/list_collection_names
             - drop namespace
             - list namespaces, check
+            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
         """
         NEW_NS_NAME = "tnaa_test_ns_s"
         NEW_COLL_NAME = "tnaa_test_coll"
@@ -61,6 +62,23 @@ class TestNonAstraAdmin:
         namespaces3 = set(database_admin.list_namespaces())
         assert namespaces3 == namespaces1
 
+        # update_db_namespace:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        database = sync_database._copy()
+
+        namespace0 = database.namespace
+        database_admin = database.get_database_admin()
+        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        assert database.namespace == namespace0
+
+        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        assert database.namespace == NEW_NS_NAME_UPDATED
+
+        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
+
     @pytest.mark.describe(
         "test of the namespace crud with non-Astra DataAPIDatabaseAdmin, async"
     )
@@ -76,6 +94,7 @@ class TestNonAstraAdmin:
             - database -> create_collection/list_collection_names
             - drop namespace
             - list namespaces, check
+            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
         """
         NEW_NS_NAME = "tnaa_test_ns_a"
         NEW_COLL_NAME = "tnaa_test_coll"
@@ -100,42 +119,21 @@ class TestNonAstraAdmin:
         namespaces3 = set(await database_admin.async_list_namespaces())
         assert namespaces3 == namespaces1
 
-    @pytest.mark.describe(
-        "test of the update_db_namespace flag for DataAPIDatabaseAdmin, sync"
-    )
-    def test_nonastra_updatedbnamespace_sync(self, sync_database: Database) -> None:
+        # update_db_namespace:
         NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
         NEW_NS_NAME_UPDATED = "tnudn_upd"
 
-        namespace0 = sync_database.namespace
-        database_admin = sync_database.get_database_admin()
-        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
-        assert sync_database.namespace == namespace0
+        adatabase = async_database._copy()
 
-        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
-        assert sync_database.namespace == NEW_NS_NAME_UPDATED
-
-        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
-        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
-
-    @pytest.mark.describe(
-        "test of the update_db_namespace flag for DataAPIDatabaseAdmin, async"
-    )
-    async def test_nonastra_updatedbnamespace_async(
-        self, async_database: AsyncDatabase
-    ) -> None:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
-
-        namespace0 = async_database.namespace
-        database_admin = async_database.get_database_admin()
+        namespace0 = adatabase.namespace
+        database_admin = adatabase.get_database_admin()
         await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
-        assert async_database.namespace == namespace0
+        assert adatabase.namespace == namespace0
 
         await database_admin.async_create_namespace(
             NEW_NS_NAME_UPDATED, update_db_namespace=True
         )
-        assert async_database.namespace == NEW_NS_NAME_UPDATED
+        assert adatabase.namespace == NEW_NS_NAME_UPDATED
 
         await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
         await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import AsyncDatabase, Database

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -99,3 +99,43 @@ class TestNonAstraAdmin:
 
         namespaces3 = set(await database_admin.async_list_namespaces())
         assert namespaces3 == namespaces1
+
+    @pytest.mark.describe(
+        "test of the update_db_namespace flag for DataAPIDatabaseAdmin, sync"
+    )
+    def test_nonastra_updatedbnamespace_sync(self, sync_database: Database) -> None:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        namespace0 = sync_database.namespace
+        database_admin = sync_database.get_database_admin()
+        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        assert sync_database.namespace == namespace0
+
+        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        assert sync_database.namespace == NEW_NS_NAME_UPDATED
+
+        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the update_db_namespace flag for DataAPIDatabaseAdmin, async"
+    )
+    async def test_nonastra_updatedbnamespace_async(
+        self, async_database: AsyncDatabase
+    ) -> None:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        namespace0 = async_database.namespace
+        database_admin = async_database.get_database_admin()
+        await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        assert async_database.namespace == namespace0
+
+        await database_admin.async_create_namespace(
+            NEW_NS_NAME_UPDATED, update_db_namespace=True
+        )
+        assert async_database.namespace == NEW_NS_NAME_UPDATED
+
+        await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 
 import pytest

--- a/tests/idiomatic/integration/test_timeout_sync.py
+++ b/tests/idiomatic/integration/test_timeout_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 
 import pytest

--- a/tests/idiomatic/unit/__init__.py
+++ b/tests/idiomatic/unit/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/idiomatic/unit/test_admin_conversions.py
+++ b/tests/idiomatic/unit/test_admin_conversions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import httpx
 import pytest
 

--- a/tests/idiomatic/unit/test_admin_conversions.py
+++ b/tests/idiomatic/unit/test_admin_conversions.py
@@ -402,3 +402,61 @@ class TestAdminConversions:
             )
             # it's ignored anyway
             assert db1 == db_adm.get_database(namespace="the-namespace")
+
+    @pytest.mark.describe(
+        "test of spawner_database for AstraDBDatabaseAdmin if not provided"
+    )
+    def test_spawnerdatabase_astradbdatabaseadmin_notprovided(self) -> None:
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        db_adm = AstraDBDatabaseAdmin(api_ep)
+        assert db_adm.spawner_database.api_endpoint == api_ep
+
+    @pytest.mark.describe(
+        "test of spawner_database for DataAPIDatabaseAdmin if not provided"
+    )
+    def test_spawnerdatabase_dataapidatabaseadmin_notprovided(self) -> None:
+        api_ep = "http://aa"
+        db_adm = DataAPIDatabaseAdmin(api_ep)
+        assert db_adm.spawner_database.api_endpoint == api_ep
+
+    @pytest.mark.describe(
+        "test of spawner_database for AstraDBDatabaseAdmin, sync db provided"
+    )
+    def test_spawnerdatabase_astradbdatabaseadmin_syncprovided(self) -> None:
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        db = Database(api_ep, namespace="M")
+        db_adm = AstraDBDatabaseAdmin(api_ep, spawner_database=db)
+        assert db_adm.spawner_database is db
+
+    @pytest.mark.describe(
+        "test of spawner_database for AstraDBDatabaseAdmin, async db provided"
+    )
+    def test_spawnerdatabase_astradbdatabaseadmin_asyncprovided(self) -> None:
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        adb = AsyncDatabase(api_ep, namespace="M")
+        db_adm = AstraDBDatabaseAdmin(api_ep, spawner_database=adb)
+        assert db_adm.spawner_database is adb
+
+    @pytest.mark.describe(
+        "test of spawner_database for DataAPIDatabaseAdmin, sync db provided"
+    )
+    def test_spawnerdatabase_dataapidatabaseadmin_syncprovided(self) -> None:
+        api_ep = "http://aa"
+        db = Database(api_ep)
+        db_adm = DataAPIDatabaseAdmin(api_ep, spawner_database=db)
+        assert db_adm.spawner_database is db
+
+    @pytest.mark.describe(
+        "test of spawner_database for DataAPIDatabaseAdmin, async db provided"
+    )
+    def test_spawnerdatabase_dataapidatabaseadmin_asyncprovided(self) -> None:
+        api_ep = "http://aa"
+        adb = AsyncDatabase(api_ep)
+        db_adm = DataAPIDatabaseAdmin(api_ep, spawner_database=adb)
+        assert db_adm.spawner_database is adb
+
+    @pytest.mark.describe("test of from_api_endpoint for AstraDBDatabaseAdmin")
+    def test_fromapiendpoint_astradbdatabaseadmin(self) -> None:
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        db_adm = AstraDBDatabaseAdmin.from_api_endpoint(api_ep, token="t")
+        assert db_adm.get_database(namespace="M").api_endpoint == api_ep

--- a/tests/idiomatic/unit/test_admin_conversions.py
+++ b/tests/idiomatic/unit/test_admin_conversions.py
@@ -163,8 +163,9 @@ class TestAdminConversions:
     )
     def test_astradbdatabaseadmin_conversions(self) -> None:
         adda1 = AstraDBDatabaseAdmin(
-            "i1",
+            "01234567-89ab-cdef-0123-456789abcdef",
             token="t1",
+            region="reg",
             environment="dev",
             caller_name="cn",
             caller_version="cv",
@@ -172,8 +173,9 @@ class TestAdminConversions:
             dev_ops_api_version="dvv",
         )
         adda2 = AstraDBDatabaseAdmin(
-            "i1",
+            "01234567-89ab-cdef-0123-456789abcdef",
             token="t1",
+            region="reg",
             environment="dev",
             caller_name="cn",
             caller_version="cv",
@@ -182,16 +184,20 @@ class TestAdminConversions:
         )
         assert adda1 == adda2
 
-        assert adda1 != adda1._copy(id="x")
+        assert adda1 != adda1._copy(id="99999999-89ab-cdef-0123-456789abcdef")
         assert adda1 != adda1._copy(token="x")
+        assert adda1 != adda1._copy(region="x")
         assert adda1 != adda1._copy(environment="test")
         assert adda1 != adda1._copy(caller_name="x")
         assert adda1 != adda1._copy(caller_version="x")
         assert adda1 != adda1._copy(dev_ops_url="x")
         assert adda1 != adda1._copy(dev_ops_api_version="x")
 
-        assert adda1 == adda1._copy(id="x")._copy(id="i1")
+        assert adda1 == adda1._copy(id="99999999-89ab-cdef-0123-456789abcdef")._copy(
+            id="01234567-89ab-cdef-0123-456789abcdef"
+        )
         assert adda1 == adda1._copy(token="x")._copy(token="t1")
+        assert adda1 == adda1._copy(region="x")._copy(region="reg")
         assert adda1 == adda1._copy(environment="test")._copy(environment="dev")
         assert adda1 == adda1._copy(caller_name="x")._copy(caller_name="cn")
         assert adda1 == adda1._copy(caller_version="x")._copy(caller_version="cv")
@@ -200,12 +206,14 @@ class TestAdminConversions:
             dev_ops_api_version="dvv"
         )
 
-        assert adda1 != adda1.with_options(id="x")
+        assert adda1 != adda1.with_options(id="99999999-89ab-cdef-0123-456789abcdef")
         assert adda1 != adda1.with_options(token="x")
         assert adda1 != adda1.with_options(caller_name="x")
         assert adda1 != adda1.with_options(caller_version="x")
 
-        assert adda1 == adda1.with_options(id="x").with_options(id="i1")
+        assert adda1 == adda1.with_options(
+            id="99999999-89ab-cdef-0123-456789abcdef"
+        ).with_options(id="01234567-89ab-cdef-0123-456789abcdef")
         assert adda1 == adda1.with_options(token="x").with_options(token="t1")
         assert adda1 == adda1.with_options(caller_name="x").with_options(
             caller_name="cn"
@@ -269,11 +277,13 @@ class TestAdminConversions:
     def test_astradbdatabaseadmin_token_inheritance(self) -> None:
         db_id_string = "01234567-89ab-cdef-0123-456789abcdef"
         adbadmin_t = AstraDBDatabaseAdmin(
-            db_id_string, token=StaticTokenProvider("static")
+            db_id_string,
+            token=StaticTokenProvider("static"),
+            region="reg",
         )
-        adbadmin_0 = AstraDBDatabaseAdmin(db_id_string)
+        adbadmin_0 = AstraDBDatabaseAdmin(db_id_string, region="reg")
         token_f = UsernamePasswordTokenProvider(username="u", password="p")
-        adbadmin_f = AstraDBDatabaseAdmin(db_id_string, token=token_f)
+        adbadmin_f = AstraDBDatabaseAdmin(db_id_string, region="reg", token=token_f)
 
         assert adbadmin_t.get_database(
             token=token_f, namespace="n", region="r"
@@ -339,3 +349,54 @@ class TestAdminConversions:
             a_database_0.get_database_admin(token=token_f)
             == a_database_f.get_database_admin()
         )
+
+    @pytest.mark.describe(
+        "test of id, endpoint, region normalization in get_database(_admin)"
+    )
+    def test_param_normalize_getdatabase(self) -> None:
+        # the case of ID only is deferred to an integration test (it's impure)
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        db_id = "01234567-89ab-cdef-0123-456789abcdef"
+        db_reg = "the-region"
+
+        adm = AstraDBAdmin("t1")
+
+        db_adm1 = adm.get_database_admin(db_id, region=db_reg)
+        db_adm2 = adm.get_database_admin(api_ep, region=db_reg)
+        db_adm3 = adm.get_database_admin(api_ep)
+        with pytest.raises(ValueError):
+            adm.get_database_admin(api_ep, region="not-that-one")
+
+        assert db_adm1 == db_adm2
+        assert db_adm2 == db_adm3
+
+        db_1 = adm.get_database(db_id, region=db_reg, namespace="the_ns")
+        db_2 = adm.get_database(api_ep, region=db_reg, namespace="the_ns")
+        db_3 = adm.get_database(api_ep, namespace="the_ns")
+        with pytest.raises(ValueError):
+            adm.get_database(api_ep, region="not-that-one", namespace="the_ns")
+
+        assert db_1 == db_2
+        assert db_2 == db_3
+
+        db_adm_m1 = AstraDBDatabaseAdmin(db_id, token="t", region=db_reg)
+        db_adm_m2 = AstraDBDatabaseAdmin(api_ep, token="t", region=db_reg)
+        db_adm_m3 = AstraDBDatabaseAdmin(api_ep, token="t")
+        with pytest.raises(ValueError):
+            AstraDBDatabaseAdmin(api_ep, token="t", region="not-that-one")
+
+        assert db_adm_m1 == db_adm_m2
+        assert db_adm_m1 == db_adm_m3
+
+    @pytest.mark.describe(
+        "test of region being deprecated in AstraDBDatabaseAdmin.get_database"
+    )
+    def test_region_deprecation_astradbdatabaseadmin_getdatabase(self) -> None:
+        api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
+        db_adm = AstraDBDatabaseAdmin(api_ep)
+        with pytest.warns(DeprecationWarning):
+            db1 = db_adm.get_database(
+                region="another-region", namespace="the-namespace"
+            )
+            # it's ignored anyway
+            assert db1 == db_adm.get_database(namespace="the-namespace")

--- a/tests/idiomatic/unit/test_bulk_write_results.py
+++ b/tests/idiomatic/unit/test_bulk_write_results.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.operations import reduce_bulk_write_results

--- a/tests/idiomatic/unit/test_collection_options.py
+++ b/tests/idiomatic/unit/test_collection_options.py
@@ -16,6 +16,8 @@
 Unit tests for the validation/parsing of collection options
 """
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Tuple
 
 import pytest

--- a/tests/idiomatic/unit/test_collections_async.py
+++ b/tests/idiomatic/unit/test_collections_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import AsyncCollection, AsyncDatabase

--- a/tests/idiomatic/unit/test_collections_sync.py
+++ b/tests/idiomatic/unit/test_collections_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import Collection, Database

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import AsyncCollection, AsyncDatabase

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -16,16 +16,12 @@ from __future__ import annotations
 
 import pytest
 
-from astrapy import AsyncCollection, AsyncDatabase
-from astrapy.core.defaults import DEFAULT_KEYSPACE_NAME
+from astrapy import AsyncCollection, AsyncDatabase, DataAPIClient
+from astrapy.constants import Environment
+from astrapy.database import DEFAULT_ASTRA_DB_NAMESPACE
 from astrapy.exceptions import DevOpsAPIException
 
-from ..conftest import (
-    SECONDARY_NAMESPACE,
-    TEST_COLLECTION_INSTANCE_NAME,
-    DataAPICredentials,
-    DataAPICredentialsInfo,
-)
+from ..conftest import TEST_COLLECTION_INSTANCE_NAME, DataAPICredentials
 
 
 class TestDatabasesAsync:
@@ -226,27 +222,6 @@ class TestDatabasesAsync:
         assert db1.to_sync().to_async() == db2
         assert db1._copy() == db2
 
-    @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
-    )
-    @pytest.mark.describe("test database namespace property, async")
-    async def test_database_namespace_async(
-        self,
-        data_api_credentials_kwargs: DataAPICredentials,
-        data_api_credentials_info: DataAPICredentialsInfo,
-    ) -> None:
-        db1 = AsyncDatabase(
-            **data_api_credentials_kwargs,
-        )
-        assert db1.namespace == DEFAULT_KEYSPACE_NAME
-
-        db2 = AsyncDatabase(
-            token=data_api_credentials_kwargs["token"],
-            api_endpoint=data_api_credentials_kwargs["api_endpoint"],
-            namespace=data_api_credentials_info["secondary_namespace"],
-        )
-        assert db2.namespace == data_api_credentials_info["secondary_namespace"]
-
     @pytest.mark.describe("test database id, async")
     async def test_database_id_async(self) -> None:
         db1 = AsyncDatabase(
@@ -261,3 +236,49 @@ class TestDatabasesAsync:
         )
         with pytest.raises(DevOpsAPIException):
             db2.id
+
+    @pytest.mark.describe("test database default namespace per environment, async")
+    async def test_database_default_namespace_per_environment_async(self) -> None:
+        db_a_m = AsyncDatabase(
+            "ep", token="t", namespace="M", environment=Environment.PROD
+        )
+        assert db_a_m.namespace == "M"
+        db_o_m = AsyncDatabase(
+            "ep", token="t", namespace="M", environment=Environment.OTHER
+        )
+        assert db_o_m.namespace == "M"
+        db_a_n = AsyncDatabase("ep", token="t", environment=Environment.PROD)
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+        db_o_n = AsyncDatabase("ep", token="t", environment=Environment.OTHER)
+        assert db_o_n.namespace is None
+
+    @pytest.mark.describe(
+        "test database-from-client default namespace per environment, async"
+    )
+    async def test_database_from_client_default_namespace_per_environment_async(
+        self,
+    ) -> None:
+        client_a = DataAPIClient(environment=Environment.PROD)
+        db_a_m = client_a.get_async_database("ep", region="r", namespace="M")
+        assert db_a_m.namespace == "M"
+        db_a_n = client_a.get_async_database("ep", region="r")
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+
+        client_o = DataAPIClient(environment=Environment.OTHER)
+        db_a_m = client_o.get_async_database("http://a", namespace="M")
+        assert db_a_m.namespace == "M"
+        db_a_n = client_o.get_async_database("http://a")
+        assert db_a_n.namespace is None
+
+    @pytest.mark.describe(
+        "test database-from-dataapidbadmin default namespace per environment, async"
+    )
+    async def test_database_from_dataapidbadmin_default_namespace_per_environment_async(
+        self,
+    ) -> None:
+        client = DataAPIClient(environment=Environment.OTHER)
+        db_admin = client.get_async_database("http://a").get_database_admin()
+        db_m = db_admin.get_async_database(namespace="M")
+        assert db_m.namespace == "M"
+        db_n = db_admin.get_async_database()
+        assert db_n.namespace is None

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy import Collection, Database

--- a/tests/idiomatic/unit/test_document_extractors.py
+++ b/tests/idiomatic/unit/test_document_extractors.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List
 
 import pytest

--- a/tests/idiomatic/unit/test_exceptions.py
+++ b/tests/idiomatic/unit/test_exceptions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.exceptions import (

--- a/tests/idiomatic/unit/test_ids.py
+++ b/tests/idiomatic/unit/test_ids.py
@@ -16,6 +16,8 @@
 Unit tests for the ObjectIds and UUIDn conversions, 'idiomatic' imports
 """
 
+from __future__ import annotations
+
 import json
 
 import pytest

--- a/tests/idiomatic/unit/test_imports.py
+++ b/tests/idiomatic/unit/test_imports.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/idiomatic/unit/test_imports.py
+++ b/tests/idiomatic/unit/test_imports.py
@@ -125,6 +125,11 @@ def test_imports() -> None:
         CollectionVectorOptions,
         CollectionVectorServiceOptions,
         DatabaseInfo,
+        EmbeddingProvider,
+        EmbeddingProviderAuthentication,
+        EmbeddingProviderModel,
+        EmbeddingProviderParameter,
+        EmbeddingProviderToken,
     )
     from astrapy.operations import (  # noqa: F401
         AsyncBaseOperation,

--- a/tests/idiomatic/unit/test_imports.py
+++ b/tests/idiomatic/unit/test_imports.py
@@ -132,6 +132,7 @@ def test_imports() -> None:
         EmbeddingProviderModel,
         EmbeddingProviderParameter,
         EmbeddingProviderToken,
+        FindEmbeddingProvidersResult,
     )
     from astrapy.operations import (  # noqa: F401
         AsyncBaseOperation,

--- a/tests/idiomatic/unit/test_info.py
+++ b/tests/idiomatic/unit/test_info.py
@@ -16,6 +16,8 @@
 Unit tests for the parsing of API endpoints and related
 """
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.admin import ParsedAPIEndpoint, parse_api_endpoint

--- a/tests/idiomatic/unit/test_timeouts.py
+++ b/tests/idiomatic/unit/test_timeouts.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 
 import pytest

--- a/tests/idiomatic/unit/test_token_providers.py
+++ b/tests/idiomatic/unit/test_token_providers.py
@@ -16,6 +16,8 @@
 Unit tests for the token providers
 """
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.authentication import (

--- a/tests/preprocess_env.py
+++ b/tests/preprocess_env.py
@@ -18,6 +18,8 @@ Bottleneck entrypoint for reading os.environ and exposing its contents as
 Except for the vectorize information, which for the time being passes as os.environ.
 """
 
+from __future__ import annotations
+
 import os
 import time
 from typing import Optional

--- a/tests/vectorize_idiomatic/__init__.py
+++ b/tests/vectorize_idiomatic/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/vectorize_idiomatic/conftest.py
+++ b/tests/vectorize_idiomatic/conftest.py
@@ -16,6 +16,8 @@
 Fixtures specific to testing on vectorize-ready Data API.
 """
 
+from __future__ import annotations
+
 import os
 from typing import Any, Dict, Iterable
 

--- a/tests/vectorize_idiomatic/integration/__init__.py
+++ b/tests/vectorize_idiomatic/integration/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/vectorize_idiomatic/integration/test_vectorize_methods_async.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_methods_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List
 
 import pytest

--- a/tests/vectorize_idiomatic/integration/test_vectorize_methods_sync.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_methods_sync.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict
 
 import pytest

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
@@ -1,0 +1,40 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from astrapy import AsyncDatabase
+from astrapy.info import EmbeddingProvider
+
+
+class TestVectorizeOpsAsync:
+    @pytest.mark.describe("test of find_embedding_providers, async")
+    async def test_collection_methods_vectorize_async(
+        self,
+        async_database: AsyncDatabase,
+    ) -> None:
+        database_admin = async_database.get_database_admin()
+        ep_map = await database_admin.async_find_embedding_providers()
+
+        assert all(
+            isinstance(emb_prov, EmbeddingProvider) for emb_prov in ep_map.values()
+        )
+
+        reconstructed = {
+            ep_name: EmbeddingProvider.from_dict(emb_prov.as_dict())
+            for ep_name, emb_prov in ep_map.items()
+        }
+        assert reconstructed == ep_map

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pytest
 
 from astrapy import AsyncDatabase
-from astrapy.info import EmbeddingProvider
+from astrapy.info import EmbeddingProvider, FindEmbeddingProvidersResult
 
 
 class TestVectorizeOpsAsync:
@@ -27,14 +27,22 @@ class TestVectorizeOpsAsync:
         async_database: AsyncDatabase,
     ) -> None:
         database_admin = async_database.get_database_admin()
-        ep_map = await database_admin.async_find_embedding_providers()
+        ep_result = database_admin.find_embedding_providers()
+
+        assert isinstance(ep_result, FindEmbeddingProvidersResult)
 
         assert all(
-            isinstance(emb_prov, EmbeddingProvider) for emb_prov in ep_map.values()
+            isinstance(emb_prov, EmbeddingProvider)
+            for emb_prov in ep_result.embedding_providers.values()
         )
 
         reconstructed = {
             ep_name: EmbeddingProvider.from_dict(emb_prov.as_dict())
-            for ep_name, emb_prov in ep_map.items()
+            for ep_name, emb_prov in ep_result.embedding_providers.items()
         }
-        assert reconstructed == ep_map
+        assert reconstructed == ep_result.embedding_providers
+        dict_mapping = {
+            ep_name: emb_prov.as_dict()
+            for ep_name, emb_prov in ep_result.embedding_providers.items()
+        }
+        assert dict_mapping == ep_result.raw_info["embeddingProviders"]  # type: ignore[index]

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pytest
 
 from astrapy import Database
-from astrapy.info import EmbeddingProvider
+from astrapy.info import EmbeddingProvider, FindEmbeddingProvidersResult
 
 
 class TestVectorizeOpsSync:
@@ -27,14 +27,22 @@ class TestVectorizeOpsSync:
         sync_database: Database,
     ) -> None:
         database_admin = sync_database.get_database_admin()
-        ep_map = database_admin.find_embedding_providers()
+        ep_result = database_admin.find_embedding_providers()
+
+        assert isinstance(ep_result, FindEmbeddingProvidersResult)
 
         assert all(
-            isinstance(emb_prov, EmbeddingProvider) for emb_prov in ep_map.values()
+            isinstance(emb_prov, EmbeddingProvider)
+            for emb_prov in ep_result.embedding_providers.values()
         )
 
         reconstructed = {
             ep_name: EmbeddingProvider.from_dict(emb_prov.as_dict())
-            for ep_name, emb_prov in ep_map.items()
+            for ep_name, emb_prov in ep_result.embedding_providers.items()
         }
-        assert reconstructed == ep_map
+        assert reconstructed == ep_result.embedding_providers
+        dict_mapping = {
+            ep_name: emb_prov.as_dict()
+            for ep_name, emb_prov in ep_result.embedding_providers.items()
+        }
+        assert dict_mapping == ep_result.raw_info["embeddingProviders"]  # type: ignore[index]

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
@@ -1,0 +1,40 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from astrapy import Database
+from astrapy.info import EmbeddingProvider
+
+
+class TestVectorizeOpsSync:
+    @pytest.mark.describe("test of find_embedding_providers, sync")
+    def test_collection_methods_vectorize_sync(
+        self,
+        sync_database: Database,
+    ) -> None:
+        database_admin = sync_database.get_database_admin()
+        ep_map = database_admin.find_embedding_providers()
+
+        assert all(
+            isinstance(emb_prov, EmbeddingProvider) for emb_prov in ep_map.values()
+        )
+
+        reconstructed = {
+            ep_name: EmbeddingProvider.from_dict(emb_prov.as_dict())
+            for ep_name, emb_prov in ep_map.items()
+        }
+        assert reconstructed == ep_map

--- a/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
@@ -95,7 +95,7 @@ class TestVectorizeProviders:
         # For the time being this is necessary on HEADER only
         embedding_api_key: Union[str, EmbeddingHeadersProvider]
         at_tokens = testable_vectorize_model["auth_type_tokens"]
-        at_token_lnames = {tk["accepted"].lower() for tk in at_tokens}
+        at_token_lnames = {tk.accepted.lower() for tk in at_tokens}
         if at_token_lnames == {"x-embedding-api-key"}:
             embedding_api_key = os.environ[
                 f"HEADER_EMBEDDING_API_KEY_{testable_vectorize_model['secret_tag']}"

--- a/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 from typing import Any, Dict, List, Union
 

--- a/tests/vectorize_idiomatic/live_provider_info.py
+++ b/tests/vectorize_idiomatic/live_provider_info.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 
 from preprocess_env import (

--- a/tests/vectorize_idiomatic/live_provider_info.py
+++ b/tests/vectorize_idiomatic/live_provider_info.py
@@ -64,4 +64,4 @@ def live_provider_info() -> Dict[str, EmbeddingProvider]:
 
     database_admin = database.get_database_admin()
     response = database_admin.find_embedding_providers()
-    return response
+    return response.embedding_providers

--- a/tests/vectorize_idiomatic/query_providers.py
+++ b/tests/vectorize_idiomatic/query_providers.py
@@ -20,22 +20,24 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from typing import Any, Dict
+from typing import Dict
 
 from live_provider_info import live_provider_info
 
+from astrapy.info import EmbeddingProvider, EmbeddingProviderParameter
 
-def desc_param(param_data: Dict[str, Any]) -> str:
-    if param_data["type"].lower() == "string":
+
+def desc_param(param_data: EmbeddingProviderParameter) -> str:
+    if param_data.parameter_type.lower() == "string":
         return "str"
-    elif param_data["type"].lower() == "number":
-        validation = param_data.get("validation", {})
+    elif param_data.parameter_type.lower() == "number":
+        validation = param_data.validation
         if "numericRange" in validation:
             validation_nr = validation["numericRange"]
             assert isinstance(validation_nr, list) and len(validation_nr) == 2
             range_desc = f"[{validation_nr[0]} : {validation_nr[1]}]"
-            if "defaultValue" in param_data:
-                range_desc2 = f"{range_desc} (default={param_data['defaultValue']})"
+            if param_data.default_value is not None:
+                range_desc2 = f"{range_desc} (default={param_data.default_value})"
             else:
                 range_desc2 = range_desc
             return f"number, {range_desc2}"
@@ -47,56 +49,50 @@ def desc_param(param_data: Dict[str, Any]) -> str:
             raise ValueError(
                 f"Unknown number validation spec: '{json.dumps(validation)}'"
             )
-    elif param_data["type"].lower() == "boolean":
+    elif param_data.parameter_type.lower() == "boolean":
         return "bool"
     else:
         raise NotImplementedError
 
 
 if __name__ == "__main__":
-    response: Dict[str, Any]
-    if "l" in sys.argv[1:]:
-        response = json.load(open("_providers.json"))
-    else:
-        response = live_provider_info()
-        json.dump(response, open("_providers.json", "w"), indent=2, sort_keys=True)
+    providers: Dict[str, EmbeddingProvider] = live_provider_info()
+    providers_json = {ep_name: ep.as_dict() for ep_name, ep in providers.items()}
+    json.dump(providers_json, open("_providers.json", "w"), indent=2, sort_keys=True)
 
-    provider_map = response["status"]["embeddingProviders"]
-    for provider, provider_data in sorted(provider_map.items()):
-        print(f"{provider} ({len(provider_data['models'])} models)")
+    for provider, provider_data in sorted(providers.items()):
+        print(f"{provider} ({len(provider_data.models)} models)")
         print("    auth:")
         for auth_type, auth_data in sorted(
-            provider_data["supportedAuthentication"].items()
+            provider_data.supported_authentication.items()
         ):
-            if auth_data["enabled"]:
-                tokens = ", ".join(
-                    f"'{tok['accepted']}'" for tok in auth_data["tokens"]
-                )
+            if auth_data.enabled:
+                tokens = ", ".join(f"'{tok.accepted}'" for tok in auth_data.tokens)
                 print(f"      {auth_type} ({tokens})")
-        if provider_data.get("parameters"):
+        if provider_data.parameters:
             print("    parameters")
-            for param_data in provider_data["parameters"]:
-                param_name = param_data["name"]
-                if param_data["required"]:
+            for param_data in provider_data.parameters:
+                param_name = param_data.name
+                if param_data.required:
                     param_display_name = param_name
                 else:
                     param_display_name = f"({param_name})"
                 param_desc = desc_param(param_data)
                 print(f"      - {param_display_name}: {param_desc}")
         print("    models:")
-        for model_data in sorted(provider_data["models"], key=lambda pro: pro["name"]):
-            model_name = model_data["name"]
-            if model_data["vectorDimension"] is not None:
-                assert model_data["vectorDimension"] > 0
-                model_dim_desc = f" (D = {model_data['vectorDimension']})"
+        for model_data in sorted(provider_data.models, key=lambda pro: pro.name):
+            model_name = model_data.name
+            if model_data.vector_dimension is not None:
+                assert model_data.vector_dimension > 0
+                model_dim_desc = f" (D = {model_data.vector_dimension})"
             else:
                 model_dim_desc = ""
             if True:
                 print(f"      {model_name}{model_dim_desc}")
-                if model_data.get("parameters"):
-                    for param_data in model_data["parameters"]:
-                        param_name = param_data["name"]
-                        if param_data["required"]:
+                if model_data.parameters:
+                    for param_data in model_data.parameters:
+                        param_name = param_data.name
+                        if param_data.required:
                             param_display_name = param_name
                         else:
                             param_display_name = f"({param_name})"

--- a/tests/vectorize_idiomatic/query_providers.py
+++ b/tests/vectorize_idiomatic/query_providers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/tests/vectorize_idiomatic/unit/__init__.py
+++ b/tests/vectorize_idiomatic/unit/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations

--- a/tests/vectorize_idiomatic/unit/test_collectionvectorserviceoptions.py
+++ b/tests/vectorize_idiomatic/unit/test_collectionvectorserviceoptions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.info import CollectionVectorServiceOptions

--- a/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
+++ b/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
@@ -21,22 +21,22 @@ from astrapy.authentication import (
     EMBEDDING_HEADER_AWS_ACCESS_ID,
     EMBEDDING_HEADER_AWS_SECRET_ID,
     AWSEmbeddingHeadersProvider,
-    EmbeddingAPIKeyHeadersProvider,
+    EmbeddingAPIKeyHeaderProvider,
     coerce_embedding_headers_provider,
 )
 
 
 class TestEmbeddingHeadersProvider:
-    @pytest.mark.describe("test of headers from EmbeddingAPIKeyHeadersProvider")
+    @pytest.mark.describe("test of headers from EmbeddingAPIKeyHeaderProvider")
     def test_embeddingheadersprovider_static(self) -> None:
-        ehp = EmbeddingAPIKeyHeadersProvider("x")
+        ehp = EmbeddingAPIKeyHeaderProvider("x")
         assert {k.lower(): v for k, v in ehp.get_headers().items()} == {
             EMBEDDING_HEADER_API_KEY.lower(): "x"
         }
 
-    @pytest.mark.describe("test of headers from empty EmbeddingAPIKeyHeadersProvider")
+    @pytest.mark.describe("test of headers from empty EmbeddingAPIKeyHeaderProvider")
     def test_embeddingheadersprovider_null(self) -> None:
-        ehp = EmbeddingAPIKeyHeadersProvider(None)
+        ehp = EmbeddingAPIKeyHeaderProvider(None)
         assert ehp.get_headers() == {}
 
     @pytest.mark.describe("test of headers from AWSEmbeddingHeadersProvider")
@@ -55,8 +55,8 @@ class TestEmbeddingHeadersProvider:
     @pytest.mark.describe("test of embedding headers provider coercion")
     def test_embeddingheadersprovider_coercion(self) -> None:
         """This doubles as equality test."""
-        ehp_s = EmbeddingAPIKeyHeadersProvider("x")
-        ehp_n = EmbeddingAPIKeyHeadersProvider(None)
+        ehp_s = EmbeddingAPIKeyHeaderProvider("x")
+        ehp_n = EmbeddingAPIKeyHeaderProvider(None)
         ehp_a = AWSEmbeddingHeadersProvider(
             embedding_access_id="x",
             embedding_secret_id="y",

--- a/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
+++ b/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
@@ -21,22 +21,22 @@ from astrapy.authentication import (
     EMBEDDING_HEADER_AWS_ACCESS_ID,
     EMBEDDING_HEADER_AWS_SECRET_ID,
     AWSEmbeddingHeadersProvider,
-    StaticEmbeddingHeadersProvider,
+    DefaultEmbeddingHeadersProvider,
     coerce_embedding_headers_provider,
 )
 
 
 class TestEmbeddingHeadersProvider:
-    @pytest.mark.describe("test of headers from StaticEmbeddingHeadersProvider")
+    @pytest.mark.describe("test of headers from DefaultEmbeddingHeadersProvider")
     def test_embeddingheadersprovider_static(self) -> None:
-        ehp = StaticEmbeddingHeadersProvider("x")
+        ehp = DefaultEmbeddingHeadersProvider("x")
         assert {k.lower(): v for k, v in ehp.get_headers().items()} == {
             EMBEDDING_HEADER_API_KEY.lower(): "x"
         }
 
-    @pytest.mark.describe("test of headers from empty StaticEmbeddingHeadersProvider")
+    @pytest.mark.describe("test of headers from empty DefaultEmbeddingHeadersProvider")
     def test_embeddingheadersprovider_null(self) -> None:
-        ehp = StaticEmbeddingHeadersProvider(None)
+        ehp = DefaultEmbeddingHeadersProvider(None)
         assert ehp.get_headers() == {}
 
     @pytest.mark.describe("test of headers from AWSEmbeddingHeadersProvider")
@@ -55,8 +55,8 @@ class TestEmbeddingHeadersProvider:
     @pytest.mark.describe("test of embedding headers provider coercion")
     def test_embeddingheadersprovider_coercion(self) -> None:
         """This doubles as equality test."""
-        ehp_s = StaticEmbeddingHeadersProvider("x")
-        ehp_n = StaticEmbeddingHeadersProvider(None)
+        ehp_s = DefaultEmbeddingHeadersProvider("x")
+        ehp_n = DefaultEmbeddingHeadersProvider(None)
         ehp_a = AWSEmbeddingHeadersProvider(
             embedding_access_id="x",
             embedding_secret_id="y",

--- a/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
+++ b/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
@@ -21,22 +21,22 @@ from astrapy.authentication import (
     EMBEDDING_HEADER_AWS_ACCESS_ID,
     EMBEDDING_HEADER_AWS_SECRET_ID,
     AWSEmbeddingHeadersProvider,
-    DefaultEmbeddingHeadersProvider,
+    EmbeddingAPIKeyHeadersProvider,
     coerce_embedding_headers_provider,
 )
 
 
 class TestEmbeddingHeadersProvider:
-    @pytest.mark.describe("test of headers from DefaultEmbeddingHeadersProvider")
+    @pytest.mark.describe("test of headers from EmbeddingAPIKeyHeadersProvider")
     def test_embeddingheadersprovider_static(self) -> None:
-        ehp = DefaultEmbeddingHeadersProvider("x")
+        ehp = EmbeddingAPIKeyHeadersProvider("x")
         assert {k.lower(): v for k, v in ehp.get_headers().items()} == {
             EMBEDDING_HEADER_API_KEY.lower(): "x"
         }
 
-    @pytest.mark.describe("test of headers from empty DefaultEmbeddingHeadersProvider")
+    @pytest.mark.describe("test of headers from empty EmbeddingAPIKeyHeadersProvider")
     def test_embeddingheadersprovider_null(self) -> None:
-        ehp = DefaultEmbeddingHeadersProvider(None)
+        ehp = EmbeddingAPIKeyHeadersProvider(None)
         assert ehp.get_headers() == {}
 
     @pytest.mark.describe("test of headers from AWSEmbeddingHeadersProvider")
@@ -55,8 +55,8 @@ class TestEmbeddingHeadersProvider:
     @pytest.mark.describe("test of embedding headers provider coercion")
     def test_embeddingheadersprovider_coercion(self) -> None:
         """This doubles as equality test."""
-        ehp_s = DefaultEmbeddingHeadersProvider("x")
-        ehp_n = DefaultEmbeddingHeadersProvider(None)
+        ehp_s = EmbeddingAPIKeyHeadersProvider("x")
+        ehp_n = EmbeddingAPIKeyHeadersProvider(None)
         ehp_a = AWSEmbeddingHeadersProvider(
             embedding_access_id="x",
             embedding_secret_id="y",

--- a/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
+++ b/tests/vectorize_idiomatic/unit/test_embeddingheadersprovider.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from astrapy.authentication import (

--- a/tests/vectorize_idiomatic/vectorize_models.py
+++ b/tests/vectorize_idiomatic/vectorize_models.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import sys
 from typing import Any, Dict, Iterable, List, Tuple


### PR DESCRIPTION
DatabaseAdmin classes retain a reference to the Async/Database instance that spawned it, if any
    - introduced a spawner_database parameter to database admin constructors
    - database admin can retroactively set the db's working namespace upon creation of same
    - Idiom `database = client.get_database(...); database.get_database_admin().create_namespace("the_namespace", update_db_namespace=True)`
Database (and AsyncDatabase) classes admit null namespace:
    - default to "default_namespace" only for Astra, otherwise null
    - as long as null, most operations are unavailable and error out
    - a `use_namespace` method to (mutably) set the working namespace on a database instance
AstraDBDatabaseAdmin class is fully region-aware:
    - can be instantiated with an endpoint (also `id` parameter aliased to `api_endpoint`)
    - requires a region to be specified with an ID, unless auto-guess can be done
VectorizeOps: support for find_embedding_providers Database method
Support for multiple-header embedding api keys:
    - `EmbeddingHeadersProvider` classes for `embedding_api_key` parameter
    - AWS header provider in addition to the regular one-header one
    - adapt CI to cover this setup
Testing:
    - restructure CI to fully support HCD alongside Astra DB
    - add details for testing new embedding providers
