### PR TITLE
Emb.providers dataclasses know about parameters' hint and displayName

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+master
+======
+FindEmbeddingProvidersResult and descendant dataclasses:
+    - knowedge of optional-as-null vs optional-as-possibly-absent ancillary fields
+    - add handling of optional 'hint' and 'displayName' fields for parameters
+
 v. 1.4.0
 ========
 DatabaseAdmin classes retain a reference to the Async/Database instance that spawned it, if any

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -454,7 +454,9 @@ class EmbeddingProviderParameter:
     """
 
     default_value: Any
+    display_name: Optional[str]
     help: Optional[str]
+    hint: Optional[str]
     name: str
     required: bool
     parameter_type: str
@@ -467,12 +469,18 @@ class EmbeddingProviderParameter:
         """Recast this object into a dictionary."""
 
         return {
-            "defaultValue": self.default_value,
-            "help": self.help,
-            "name": self.name,
-            "required": self.required,
-            "type": self.parameter_type,
-            "validation": self.validation,
+            k: v
+            for k, v in {
+                "defaultValue": self.default_value,
+                "displayName": self.display_name,
+                "help": self.help,
+                "hint": self.hint,
+                "name": self.name,
+                "required": self.required,
+                "type": self.parameter_type,
+                "validation": self.validation,
+            }.items()
+            if v is not None
         }
 
     @staticmethod
@@ -484,7 +492,9 @@ class EmbeddingProviderParameter:
 
         residual_keys = raw_dict.keys() - {
             "defaultValue",
+            "displayName",
             "help",
+            "hint",
             "name",
             "required",
             "type",
@@ -497,7 +507,9 @@ class EmbeddingProviderParameter:
             )
         return EmbeddingProviderParameter(
             default_value=raw_dict["defaultValue"],
-            help=raw_dict["help"],
+            display_name=raw_dict.get("displayName"),
+            help=raw_dict.get("help"),
+            hint=raw_dict.get("hint"),
             name=raw_dict["name"],
             required=raw_dict["required"],
             parameter_type=raw_dict["type"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astrapy"
-version = "1.4.0"
+version = "1.4.1"
 description = "AstraPy is a Pythonic SDK for DataStax Astra and its Data API"
 authors = [
     "Stefano Lottini <stefano.lottini@datastax.com>",

--- a/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_providers.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any, Dict, List, Union
 
 import pytest
@@ -23,6 +24,8 @@ from astrapy import Database
 from astrapy.authentication import AWSEmbeddingHeadersProvider, EmbeddingHeadersProvider
 from astrapy.exceptions import DataAPIResponseException, InsertManyException
 from astrapy.info import CollectionVectorServiceOptions
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from ..conftest import IS_ASTRA_DB
 from ..vectorize_models import live_test_models

--- a/tests/vectorize_idiomatic/live_provider_info.py
+++ b/tests/vectorize_idiomatic/live_provider_info.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
 from preprocess_env import (
     ASTRA_DB_API_ENDPOINT,
     ASTRA_DB_KEYSPACE,
@@ -29,10 +27,10 @@ from preprocess_env import (
 from astrapy import DataAPIClient, Database
 from astrapy.admin import parse_api_endpoint
 from astrapy.constants import Environment
-from astrapy.info import EmbeddingProvider
+from astrapy.info import FindEmbeddingProvidersResult
 
 
-def live_provider_info() -> Dict[str, EmbeddingProvider]:
+def live_provider_info() -> FindEmbeddingProvidersResult:
     """
     Query the API endpoint `findEmbeddingProviders` endpoint
     for the latest information.
@@ -64,4 +62,4 @@ def live_provider_info() -> Dict[str, EmbeddingProvider]:
 
     database_admin = database.get_database_admin()
     response = database_admin.find_embedding_providers()
-    return response.embedding_providers
+    return response

--- a/tests/vectorize_idiomatic/vectorize_models.py
+++ b/tests/vectorize_idiomatic/vectorize_models.py
@@ -18,8 +18,6 @@ import os
 import sys
 from typing import Any, Dict, Iterable, List, Tuple
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from astrapy.authentication import (
     EMBEDDING_HEADER_API_KEY,
     EMBEDDING_HEADER_AWS_ACCESS_ID,
@@ -27,7 +25,9 @@ from astrapy.authentication import (
 )
 from astrapy.info import CollectionVectorServiceOptions, EmbeddingProviderParameter
 
-from .live_provider_info import live_provider_info
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from live_provider_info import live_provider_info
 
 alphanum = set("qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890")
 
@@ -196,8 +196,10 @@ def live_test_models() -> Iterable[Dict[str, Any]]:
             return f"{longt[:30]}_{longt[-5:]}"
 
     # generate the full list of models based on the live provider endpoint
-    providers = live_provider_info()
-    for provider_name, provider_desc in sorted(providers.items()):
+    provider_info = live_provider_info()
+    for provider_name, provider_desc in sorted(
+        provider_info.embedding_providers.items()
+    ):
         for model in provider_desc.models:
             for auth_type_name, auth_type_desc in sorted(
                 provider_desc.supported_authentication.items()


### PR DESCRIPTION
Also more care about optional fields (possibly absent vs possibly null) in this class hierarchy, and a little restructuring of test fixtures around vectorize.