### PR TITLE
Restore docker-compose usage + upgrade HCD images

### DIFF
--- a/.github/workflows/hcd.yaml
+++ b/.github/workflows/hcd.yaml
@@ -28,6 +28,10 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Alias docker
+      run: |
+        alias docker-compose="docker compose"
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/hcd.yaml
+++ b/.github/workflows/hcd.yaml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Alias docker
       run: |
-        alias docker-compose="docker compose"
+        echo -e '#!/bin/bash\n\ndocker compose "$@"' > /usr/bin/docker-compose ; chmod +x /usr/bin/docker-compose
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/hcd.yaml
+++ b/.github/workflows/hcd.yaml
@@ -28,15 +28,12 @@ jobs:
       with:
         python-version: 3.11
 
-    - name: Alias docker
-      run: |
-        echo -e '#!/bin/bash\n\ndocker compose "$@"' > docker-compose ; chmod +x docker-compose
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install poetry
         poetry install
+        poetry run pip install "testcontainers>=4.3.0"
 
     - name: Run pytest
       run: |

--- a/.github/workflows/hcd.yaml
+++ b/.github/workflows/hcd.yaml
@@ -33,7 +33,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install poetry
         poetry install
-        poetry run pip install "testcontainers>=4.3.0"
 
     - name: Run pytest
       run: |

--- a/.github/workflows/hcd.yaml
+++ b/.github/workflows/hcd.yaml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Alias docker
       run: |
-        echo -e '#!/bin/bash\n\ndocker compose "$@"' > /usr/bin/docker-compose ; chmod +x /usr/bin/docker-compose
+        echo -e '#!/bin/bash\n\ndocker compose "$@"' > docker-compose ; chmod +x docker-compose
 
     - name: Install dependencies
       run: |

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+master
+======
+testing on HCD:
+    - DockerCompose tweaked to invoke `docker compose`
+    - HCD 1.0.0 and Data API 1.0.15 as test targets
+
 v. 1.4.1
 ========
 FindEmbeddingProvidersResult and descendant dataclasses:

--- a/tests/hcd_compose/docker-compose.yml
+++ b/tests/hcd_compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   hcd:
-    image: datastax/hcd:1.0.0-early-preview
+    image: datastax/hcd:1.0.0
     networks:
       - stargate
     mem_limit: 2G
@@ -22,7 +22,7 @@ services:
       retries: 20
 
   data-api:
-    image: stargateio/data-api:v1.0.12
+    image: stargateio/data-api:v1.0.15
     depends_on:
       hcd:
         condition: service_healthy

--- a/tests/preprocess_env.py
+++ b/tests/preprocess_env.py
@@ -114,7 +114,10 @@ else:
 is_docker_compose_started = False
 if DOCKER_COMPOSE_LOCAL_DATA_API:
     if not is_docker_compose_started:
-        compose = DockerCompose(filepath=docker_compose_filepath)
+        try:
+            compose = DockerCompose(filepath=docker_compose_filepath)
+        except TypeError:
+            compose = DockerCompose(docker_compose_filepath)
         compose.start()
         time.sleep(DOCKER_COMPOSE_SLEEP_TIME_SECONDS)
         is_docker_compose_started = True

--- a/tests/preprocess_env.py
+++ b/tests/preprocess_env.py
@@ -114,10 +114,19 @@ else:
 is_docker_compose_started = False
 if DOCKER_COMPOSE_LOCAL_DATA_API:
     if not is_docker_compose_started:
-        try:
-            compose = DockerCompose(filepath=docker_compose_filepath)
-        except TypeError:
-            compose = DockerCompose(docker_compose_filepath)
+
+        # a dirty trick
+        class MyDockerCompose(DockerCompose):
+
+            def docker_compose_command(self):
+                docker_compose_cmd = ["docker", "compose"]
+                for file in self.compose_file_names:
+                    docker_compose_cmd += ["-f", file]
+                if self.env_file:
+                    docker_compose_cmd += ["--env-file", self.env_file]
+                return docker_compose_cmd
+
+        compose = MyDockerCompose(filepath=docker_compose_filepath)
         compose.start()
         time.sleep(DOCKER_COMPOSE_SLEEP_TIME_SECONDS)
         is_docker_compose_started = True


### PR DESCRIPTION
without committing to python 3.9, as a modern testcontainers would require.