### PR TITLE
Collection implementations of update_one rely on API's updateOne command

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,12 @@
 master
 ======
-core, prefetched find iterators: fix second-thread hangups in some cases (by @cbornet)
+Method 'update_one' of [Async]Collection: now invokes the corresponding API command.
 testing on HCD:
     - DockerCompose tweaked to invoke `docker compose`
     - HCD 1.0.0 and Data API 1.0.15 as test targets
+core:
+    - prefetched find iterators: fix second-thread hangups in some cases (by @cbornet)
+    - added 'options' parameter to [Async]AstraDBCollection.update_one
 
 v. 1.4.1
 ========

--- a/README.md
+++ b/README.md
@@ -518,8 +518,10 @@ If your code uses the pre-1.0.0 astrapy (i.e. `from astrapy.db import Database, 
 
 That being said, there are no known breakings of backward compatibility:
 **legacy code would run with a newest astrapy version just as well.**
-Here is a recap of the minor changes that came _to the old API_ with 1.0.0:
+Here is a recap of the minor changes that came _to the old API_ with 1.0.0 (and beyond):
 
+- added 'options' parameter to [Async]AstraDBCollection.update_one (v. 1.4.2+)
+- prefetched find iterators: fix second-thread hangups in some cases (v. 1.4.2+)
 - Added support for null tokens (with the effect of no authentication/token header in requests)
 - Added Content-Type header to all HTTP requests to the API
 - Added methods to `[Async]AstraDBCollection`: `delete_one_filter`, 

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -1892,26 +1892,26 @@ class Collection:
             "upsert": upsert,
         }
         _max_time_ms = max_time_ms or self.api_options.max_time_ms
-        logger.info(f"calling find_one_and_update on '{self.name}'")
-        fo_response = self._astra_db_collection.find_one_and_update(
+        logger.info(f"calling update_one on '{self.name}'")
+        uo_response = self._astra_db_collection.update_one(
             update=update,
             sort=_sort,
             filter=filter,
             options=options,
             timeout_info=base_timeout_info(_max_time_ms),
         )
-        logger.info(f"finished calling find_one_and_update on '{self.name}'")
-        if "document" in fo_response.get("data", {}):
-            fo_status = fo_response.get("status") or {}
-            _update_info = _prepare_update_info([fo_status])
+        logger.info(f"finished calling update_one on '{self.name}'")
+        if "status" in uo_response:
+            uo_status = uo_response["status"]
+            _update_info = _prepare_update_info([uo_status])
             return UpdateResult(
-                raw_results=[fo_response],
+                raw_results=[uo_response],
                 update_info=_update_info,
             )
         else:
             raise DataAPIFaultyResponseException(
-                text="Faulty response from find_one_and_update API command.",
-                raw_response=fo_response,
+                text="Faulty response from update_one API command.",
+                raw_response=uo_response,
             )
 
     @recast_method_sync
@@ -4429,26 +4429,26 @@ class AsyncCollection:
             "upsert": upsert,
         }
         _max_time_ms = max_time_ms or self.api_options.max_time_ms
-        logger.info(f"calling find_one_and_update on '{self.name}'")
-        fo_response = await self._astra_db_collection.find_one_and_update(
+        logger.info(f"calling update_one on '{self.name}'")
+        uo_response = await self._astra_db_collection.update_one(
             update=update,
             sort=_sort,
             filter=filter,
             options=options,
             timeout_info=base_timeout_info(_max_time_ms),
         )
-        logger.info(f"finished calling find_one_and_update on '{self.name}'")
-        if "document" in fo_response.get("data", {}):
-            fo_status = fo_response.get("status") or {}
-            _update_info = _prepare_update_info([fo_status])
+        logger.info(f"finished calling update_one on '{self.name}'")
+        if "status" in uo_response:
+            uo_status = uo_response["status"]
+            _update_info = _prepare_update_info([uo_status])
             return UpdateResult(
-                raw_results=[fo_response],
+                raw_results=[uo_response],
                 update_info=_update_info,
             )
         else:
             raise DataAPIFaultyResponseException(
-                text="Faulty response from find_one_and_update API command.",
-                raw_response=fo_response,
+                text="Faulty response from update_one API command.",
+                raw_response=uo_response,
             )
 
     @recast_method_async

--- a/astrapy/core/db.py
+++ b/astrapy/core/db.py
@@ -1103,6 +1103,7 @@ class AstraDBCollection:
         update: Dict[str, Any],
         sort: Optional[Dict[str, Any]] = None,
         timeout_info: TimeoutInfoWideType = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Update a single document in the collection.
@@ -1113,6 +1114,7 @@ class AstraDBCollection:
             timeout_info: a float, or a TimeoutInfo dict, for the HTTP request.
                 Note that a 'read' timeout event will not block the action taken
                 by the API server if it has received the request already.
+            options (dict, optional): Additional options for the operation.
 
         Returns:
             dict: The response from the database after the update operation.
@@ -1121,6 +1123,7 @@ class AstraDBCollection:
             top_level="updateOne",
             filter=filter,
             update=update,
+            options=options,
             sort=sort,
         )
 
@@ -2478,6 +2481,7 @@ class AsyncAstraDBCollection:
         update: Dict[str, Any],
         sort: Optional[Dict[str, Any]] = None,
         timeout_info: TimeoutInfoWideType = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> API_RESPONSE:
         """
         Update a single document in the collection.
@@ -2488,6 +2492,7 @@ class AsyncAstraDBCollection:
             timeout_info: a float, or a TimeoutInfo dict, for the HTTP request.
                 Note that a 'read' timeout event will not block the action taken
                 by the API server if it has received the request already.
+            options (dict, optional): Additional options for the operation.
 
         Returns:
             dict: The response from the database after the update operation.
@@ -2496,6 +2501,7 @@ class AsyncAstraDBCollection:
             top_level="updateOne",
             filter=filter,
             update=update,
+            options=options,
             sort=sort,
         )
 


### PR DESCRIPTION
For historical reasons, internally the method(s, sync+async) were calling the core's findOneAndUpdate, which incurs a penalty of having to return (and then discard) the doc itself.

This PR fixes that. To do so, a small enhancement to core was necessary.
