### PR TITLE
Improve url-parsing error messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 master
 ======
 Method 'update_one' of [Async]Collection: now invokes the corresponding API command.
+Better URL-parsing error messages for the API endpoint (with guidance on expected format)
 testing on HCD:
     - DockerCompose tweaked to invoke `docker compose`
     - HCD 1.0.0 and Data API 1.0.15 as test targets

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -20,9 +20,11 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from astrapy.admin import (
     api_endpoint_parser,
+    api_endpoint_parsing_error_message,
     build_api_endpoint,
     database_id_matcher,
     fetch_raw_database_info_from_id_token,
+    generic_api_url_parsing_error_message,
     normalize_id_endpoint_parameters,
     parse_api_endpoint,
     parse_generic_api_url,
@@ -439,9 +441,8 @@ class DataAPIClient:
                     api_version=api_version,
                 )
             else:
-                raise ValueError(
-                    f"Cannot parse the provided API endpoint ({api_endpoint})."
-                )
+                msg = api_endpoint_parsing_error_message(api_endpoint)
+                raise ValueError(msg)
         else:
             parsed_generic_api_endpoint = parse_generic_api_url(api_endpoint)
             if parsed_generic_api_endpoint:
@@ -457,9 +458,8 @@ class DataAPIClient:
                     api_version=api_version,
                 )
             else:
-                raise ValueError(
-                    f"Cannot parse the provided API endpoint ({api_endpoint})."
-                )
+                msg = generic_api_url_parsing_error_message(api_endpoint)
+                raise ValueError(msg)
 
     def get_async_database_by_api_endpoint(
         self,


### PR DESCRIPTION
They now provide guidance on the expected format:

```
ValueError: Cannot parse the supplied API endpoint (q). The endpoint must be in the following form: "https://<hexadecimal db uuid>-<db region>.apps.astra.datastax.com".

ValueError: Cannot parse the supplied API endpoint (q). The endpoint must be in the following form: "http[s]://<domain name or IP>[:port]".
```