### PR TITLE
Cleanup/improve __repr__  of several classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ master
 ======
 Method 'update_one' of [Async]Collection: now invokes the corresponding API command.
 Better URL-parsing error messages for the API endpoint (with guidance on expected format)
+Improved __repr__ for: token/auth-related items, Database/Client classes, response+info objects
 testing on HCD:
     - DockerCompose tweaked to invoke `docker compose`
     - HCD 1.0.0 and Data API 1.0.15 as test targets

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -29,7 +29,7 @@ from astrapy.admin import (
     parse_api_endpoint,
     parse_generic_api_url,
 )
-from astrapy.authentication import coerce_token_provider
+from astrapy.authentication import coerce_token_provider, redact_secret
 from astrapy.constants import Environment
 
 if TYPE_CHECKING:
@@ -96,14 +96,18 @@ class DataAPIClient:
         self._caller_version = caller_version
 
     def __repr__(self) -> str:
-        env_desc: str
-        if self.environment == Environment.PROD:
-            env_desc = ""
+        token_desc: Optional[str]
+        if self.token_provider:
+            token_desc = f'"{redact_secret(str(self.token_provider), 15)}"'
         else:
-            env_desc = f', environment="{self.environment}"'
-        return (
-            f'{self.__class__.__name__}("{str(self.token_provider)[:12]}..."{env_desc})'
-        )
+            token_desc = None
+        env_desc: Optional[str]
+        if self.environment == Environment.PROD:
+            env_desc = None
+        else:
+            env_desc = f'environment="{self.environment}"'
+        parts = [pt for pt in [token_desc, env_desc] if pt is not None]
+        return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, DataAPIClient):

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -28,6 +28,7 @@ from astrapy.api_options import CollectionAPIOptions
 from astrapy.authentication import (
     coerce_embedding_headers_provider,
     coerce_token_provider,
+    redact_secret,
 )
 from astrapy.constants import Environment
 from astrapy.core.db import AstraDB, AsyncAstraDB
@@ -196,11 +197,19 @@ class Database:
         return self.get_collection(name=collection_name)
 
     def __repr__(self) -> str:
-        namespace_desc = self.namespace if self.namespace is not None else "(not set)"
-        return (
-            f'{self.__class__.__name__}(api_endpoint="{self.api_endpoint}", '
-            f'token="{str(self.token_provider)[:12]}...", namespace="{namespace_desc}")'
-        )
+        ep_desc = f'api_endpoint="{self.api_endpoint}"'
+        token_desc: Optional[str]
+        if self.token_provider:
+            token_desc = f'"{redact_secret(str(self.token_provider), 15)}"'
+        else:
+            token_desc = None
+        namespace_desc: Optional[str]
+        if self.namespace is None:
+            namespace_desc = "namespace not set"
+        else:
+            namespace_desc = f'namespace="{self.namespace}"'
+        parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
+        return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Database):
@@ -1112,11 +1121,19 @@ class AsyncDatabase:
         return self.to_sync().get_collection(name=collection_name).to_async()
 
     def __repr__(self) -> str:
-        namespace_desc = self.namespace if self.namespace is not None else "(not set)"
-        return (
-            f'{self.__class__.__name__}(api_endpoint="{self.api_endpoint}", '
-            f'token="{str(self.token_provider)[:12]}...", namespace="{namespace_desc}")'
-        )
+        ep_desc = f'api_endpoint="{self.api_endpoint}"'
+        token_desc: Optional[str]
+        if self.token_provider:
+            token_desc = f'"{redact_secret(str(self.token_provider), 15)}"'
+        else:
+            token_desc = None
+        namespace_desc: Optional[str]
+        if self.namespace is None:
+            namespace_desc = "namespace not set"
+        else:
+            namespace_desc = f'namespace="{self.namespace}"'
+        parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
+        return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, AsyncDatabase):

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -300,6 +300,7 @@ class CollectionOptions:
                     if self.default_id is None
                     else f"default_id={self.default_id.__repr__()}"
                 ),
+                None if self.raw_options is None else "raw_options=...",
             ]
             if pc is not None
         ]
@@ -392,11 +393,16 @@ class CollectionDescriptor:
     raw_descriptor: Optional[Dict[str, Any]]
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"name={self.name.__repr__()}, "
-            f"options={self.options.__repr__()})"
-        )
+        not_null_pieces = [
+            pc
+            for pc in [
+                f"name={self.name.__repr__()}",
+                f"options={self.options.__repr__()}",
+                None if self.raw_descriptor is None else "raw_descriptor=...",
+            ]
+            if pc is not None
+        ]
+        return f"{self.__class__.__name__}({', '.join(not_null_pieces)})"
 
     def as_dict(self) -> Dict[str, Any]:
         """

--- a/astrapy/results.py
+++ b/astrapy/results.py
@@ -32,6 +32,9 @@ class OperationResult(ABC):
 
     raw_results: List[Dict[str, Any]]
 
+    def _piecewise_repr(self, pieces: List[Optional[str]]) -> str:
+        return f"{self.__class__.__name__}({', '.join(pc for pc in pieces if pc)})"
+
     @abstractmethod
     def to_bulk_write_result(self, index_in_bulk_write: int) -> BulkWriteResult: ...
 
@@ -49,6 +52,14 @@ class DeleteResult(OperationResult):
     """
 
     deleted_count: Optional[int]
+
+    def __repr__(self) -> str:
+        return self._piecewise_repr(
+            [
+                f"deleted_count={self.deleted_count}",
+                "raw_results=..." if self.raw_results is not None else None,
+            ]
+        )
 
     def to_bulk_write_result(self, index_in_bulk_write: int) -> BulkWriteResult:
         return BulkWriteResult(
@@ -74,6 +85,14 @@ class InsertOneResult(OperationResult):
 
     inserted_id: Any
 
+    def __repr__(self) -> str:
+        return self._piecewise_repr(
+            [
+                f"inserted_id={self.inserted_id}",
+                "raw_results=..." if self.raw_results is not None else None,
+            ]
+        )
+
     def to_bulk_write_result(self, index_in_bulk_write: int) -> BulkWriteResult:
         return BulkWriteResult(
             bulk_api_results={index_in_bulk_write: self.raw_results},
@@ -97,6 +116,14 @@ class InsertManyResult(OperationResult):
     """
 
     inserted_ids: List[Any]
+
+    def __repr__(self) -> str:
+        return self._piecewise_repr(
+            [
+                f"inserted_ids={self.inserted_ids}",
+                "raw_results=..." if self.raw_results is not None else None,
+            ]
+        )
 
     def to_bulk_write_result(self, index_in_bulk_write: int) -> BulkWriteResult:
         return BulkWriteResult(
@@ -127,6 +154,14 @@ class UpdateResult(OperationResult):
     """
 
     update_info: Dict[str, Any]
+
+    def __repr__(self) -> str:
+        return self._piecewise_repr(
+            [
+                f"update_info={self.update_info}",
+                "raw_results=..." if self.raw_results is not None else None,
+            ]
+        )
 
     def to_bulk_write_result(self, index_in_bulk_write: int) -> BulkWriteResult:
         inserted_count = 1 if "upserted" in self.update_info else 0
@@ -173,6 +208,18 @@ class BulkWriteResult:
     modified_count: int
     upserted_count: int
     upserted_ids: Dict[int, Any]
+
+    def __repr__(self) -> str:
+        pieces = [
+            f"deleted_count={self.deleted_count}",
+            f"inserted_count={self.inserted_count}",
+            f"matched_count={self.matched_count}",
+            f"modified_count={self.modified_count}",
+            f"upserted_count={self.upserted_count}",
+            f"upserted_ids={self.upserted_ids}",
+            "bulk_api_results=..." if self.bulk_api_results else None,
+        ]
+        return f"{self.__class__.__name__}({', '.join(pc for pc in pieces if pc)})"
 
     @staticmethod
     def zero() -> BulkWriteResult:


### PR DESCRIPTION
A better way to redact (partially/totally) the secrets (tokens, api keys etc) from the string repr of several objects.

A more streamlined way to achieve the above

A better error if environment is not allowed for AstraDBAdmin.

A better, manually-curated representation of most dataclasses (info.py and results.py), that leaves the "raw response" bit just hinted if present instead of printing it in a way that pollutes the visual result.

