### PR TITLE
Adapt to "extend errors"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ master
 Method 'update_one' of [Async]Collection: now invokes the corresponding API command.
 Better URL-parsing error messages for the API endpoint (with guidance on expected format)
 Improved __repr__ for: token/auth-related items, Database/Client classes, response+info objects
+DataAPIErrorDescriptor can parse 'extend error' in the responses
 testing on HCD:
     - DockerCompose tweaked to invoke `docker compose`
     - HCD 1.0.0 and Data API 1.0.15 as test targets

--- a/astrapy/exceptions.py
+++ b/astrapy/exceptions.py
@@ -134,16 +134,45 @@ class DataAPIErrorDescriptor:
         attributes: a dict with any further key-value pairs returned by the API.
     """
 
+    title: Optional[str]
     error_code: Optional[str]
     message: Optional[str]
+    family: Optional[str]
+    scope: Optional[str]
+    id: Optional[str]
     attributes: Dict[str, Any]
 
+    _known_dict_fields = {
+        "title",
+        "errorCode",
+        "message",
+        "family",
+        "scope",
+        "id",
+    }
+
     def __init__(self, error_dict: Dict[str, str]) -> None:
+        self.title = error_dict.get("title")
         self.error_code = error_dict.get("errorCode")
         self.message = error_dict.get("message")
+        self.family = error_dict.get("family")
+        self.scope = error_dict.get("scope")
+        self.id = error_dict.get("id")
         self.attributes = {
-            k: v for k, v in error_dict.items() if k not in {"errorCode", "message"}
+            k: v for k, v in error_dict.items() if k not in self._known_dict_fields
         }
+
+    def __repr__(self) -> str:
+        pieces = [
+            f"{self.title.__repr__()}" if self.title else None,
+            f"error_code={self.error_code.__repr__()}" if self.error_code else None,
+            f"message={self.message.__repr__()}" if self.message else None,
+            f"family={self.family.__repr__()}" if self.family else None,
+            f"scope={self.scope.__repr__()}" if self.scope else None,
+            f"id={self.id.__repr__()}" if self.id else None,
+            f"attributes={self.attributes.__repr__()}" if self.attributes else None,
+        ]
+        return f"{self.__class__.__name__}({', '.join(pc for pc in pieces if pc)})"
 
 
 @dataclass


### PR DESCRIPTION
Adapt to the "extend errors" spec in the object representing them in astrapy: with all fields being understood as optional, this would be e.g.:

```
{
  "errors": [
    {
      "message": "UNAUTHENTICATED: Invalid token",
      "errorCode": "UNAUTHENTICATED_REQUEST",
      "id": "72c2c084-ef5b-4fd8-889a-97930776c64c",
      "family": "SERVER",
      "title": "UNAUTHENTICATED: Invalid token",
      "scope": "DATABASE"
    }
  ]
}
```