### PR TITLE
Deprecation of all things "namespace"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 master
 ======
+Deprecation of collection bulk_write method (removed in 2.0)
+APICommander logs warnings received from the Data API
 Full removal of "core library" from the current API:
     - DevOps API accessed through APICommander everywhere
     - Admin objects use APICommander consistently

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 master
 ======
-Deprecation of collection bulk_write method (removed in 2.0)
+Deprecation of all *namespace* method names (removal in 2.0)
+Deprecation of collection bulk_write method (removal in 2.0)
 APICommander logs warnings received from the Data API
 Full removal of "core library" from the current API:
     - DevOps API accessed through APICommander everywhere
@@ -18,6 +19,7 @@ Rearrangement into separate modules for:
     - payload/response transformations
     - (sometimes with temporary duplication to avoid depending on 'core')
 Testing:
+    - testing on HCD targets Data API v 1.0.16
     - added tests for APICommander
     - improved tests for admin classes
 Logging of API requests made more uniform and easier to read

--- a/CHANGES
+++ b/CHANGES
@@ -60,7 +60,7 @@ DatabaseAdmin classes retain a reference to the Async/Database instance that spa
     - database admin can retroactively set the db's working namespace upon creation of same
     - Idiom `database = client.get_database(...); database.get_database_admin().create_namespace("the_namespace", update_db_namespace=True)`
 Database (and AsyncDatabase) classes admit null namespace:
-    - default to "default_namespace" only for Astra, otherwise null
+    - default to "default_keyspace" only for Astra, otherwise null
     - as long as null, most operations are unavailable and error out
     - a `use_namespace` method to (mutably) set the working namespace on a database instance
 AstraDBDatabaseAdmin class is fully region-aware:

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ master
 ======
 Deprecation of "namespace-" terminology, replaced by "keyspace-" (removal in 2.0)
     - deprecation of all *namespace* method names
+    - deprecation of the `namespace=` named argument to all methods
     - deprecation of the `update_db_namespace` parameter to create_*space
 Deprecation of collection bulk_write method (removal in 2.0)
 APICommander logs warnings received from the Data API

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
-master
-======
+v. 1.5.0
+========
 Deprecation of "namespace-" terminology, replaced by "keyspace-" (removal in 2.0)
     - deprecation of all *namespace* method names
     - deprecation of the `namespace=` named argument to all methods

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 master
 ======
-Deprecation of all *namespace* method names (removal in 2.0)
+Deprecation of "namespace-" terminology, replaced by "keyspace-" (removal in 2.0)
+    - deprecation of all *namespace* method names
+    - deprecation of the `update_db_namespace` parameter to create_*space
 Deprecation of collection bulk_write method (removal in 2.0)
 APICommander logs warnings received from the Data API
 Full removal of "core library" from the current API:
@@ -9,6 +11,7 @@ Full removal of "core library" from the current API:
     - [Async]Database and [Async]Collection directly use APICommander
     - Cursor library uses APICommander directly
     - Core library imports triggers a submodule-wide deprecation warning
+    - (simplification of the vector/vectorize deprecator utility)
 Widened exception hierarchy with:
     - DevOpsAPIHttpException
     - DevOpsAPITimeoutException

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ print(db_info.name, db_info.id, db_info.region)
 
 my_database_admin = my_astra_admin.get_database_admin(db_info.id)
 
-my_database_admin.list_namespaces()
-my_database_admin.create_namespace("my_dreamspace")
+my_database_admin.list_keyspaces()
+my_database_admin.create_keyspace("my_dreamspace")
 ```
 
 ### Exceptions

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -3428,7 +3428,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             logger.info("finished creating namespace")
             if update_db_namespace:
                 self.spawner_database.use_namespace(name)
-            return cn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in cn_response["status"].items() if k == "ok"}
 
     def create_keyspace(
         self,
@@ -3497,7 +3497,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             logger.info("finished creating keyspace")
             if update_db_namespace:
                 self.spawner_database.use_keyspace(name)
-            return cn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in cn_response["status"].items() if k == "ok"}
 
     @deprecation.deprecated(  # type: ignore[misc]
         deprecated_in="1.5.0",
@@ -3548,7 +3548,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished dropping namespace")
-            return dn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in dn_response["status"].items() if k == "ok"}
 
     def drop_keyspace(
         self,
@@ -3591,7 +3591,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished dropping keyspace")
-            return dn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in dn_response["status"].items() if k == "ok"}
 
     @deprecation.deprecated(  # type: ignore[misc]
         deprecated_in="1.5.0",
@@ -3741,7 +3741,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             logger.info("finished creating namespace, async")
             if update_db_namespace:
                 self.spawner_database.use_namespace(name)
-            return cn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in cn_response["status"].items() if k == "ok"}
 
     async def async_create_keyspace(
         self,
@@ -3813,7 +3813,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             logger.info("finished creating keyspace, async")
             if update_db_namespace:
                 self.spawner_database.use_keyspace(name)
-            return cn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in cn_response["status"].items() if k == "ok"}
 
     @deprecation.deprecated(  # type: ignore[misc]
         deprecated_in="1.5.0",
@@ -3867,7 +3867,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished dropping namespace, async")
-            return dn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in dn_response["status"].items() if k == "ok"}
 
     async def async_drop_keyspace(
         self,
@@ -3913,7 +3913,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             )
         else:
             logger.info("finished dropping keyspace, async")
-            return dn_response["status"]  # type: ignore[no-any-return]
+            return {k: v for k, v in dn_response["status"].items() if k == "ok"}
 
     def get_database(
         self,

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -1443,7 +1443,7 @@ class AstraDBAdmin:
         return Database(
             api_endpoint=normalized_api_endpoint,
             token=_token,
-            namespace=_keyspace,
+            keyspace=_keyspace,
             caller_name=self.caller_name,
             caller_version=self.caller_version,
             environment=self.environment,
@@ -1471,12 +1471,16 @@ class AstraDBAdmin:
         counterpart `get_database`: please see that one for more details.
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
+
         return self.get_database(
             id=id,
             api_endpoint=api_endpoint,
             token=token,
-            keyspace=keyspace,
-            namespace=namespace,
+            keyspace=keyspace_param,
             region=region,
             api_path=api_path,
             api_version=api_version,
@@ -1762,12 +1766,12 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         if spawner_database is not None:
             self.spawner_database = spawner_database
         else:
-            # leaving the namespace to its per-environment default
+            # leaving the keyspace to its per-environment default
             # (a task for the Database)
             self.spawner_database = Database(
                 api_endpoint=self.api_endpoint,
                 token=self.token_provider,
-                namespace=None,
+                keyspace=None,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
                 environment=self.environment,
@@ -3064,10 +3068,14 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         counterpart `get_database`: please see that one for more details.
         """
 
-        return self.get_database(
-            token=token,
+        keyspace_param = check_optional_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
+        )
+
+        return self.get_database(
+            token=token,
+            keyspace=keyspace_param,
             region=region,
             api_path=api_path,
             api_version=api_version,
@@ -3248,12 +3256,12 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         if spawner_database is not None:
             self.spawner_database = spawner_database
         else:
-            # leaving the namespace to its per-environment default
+            # leaving the keyspace to its per-environment default
             # (a task for the Database)
             self.spawner_database = Database(
                 api_endpoint=self.api_endpoint,
                 token=self.token_provider,
-                namespace=None,
+                keyspace=None,
                 caller_name=self.caller_name,
                 caller_version=self.caller_version,
                 environment=self.environment,
@@ -4115,10 +4123,15 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         This method has identical behavior and signature as the sync
         counterpart `get_database`: please see that one for more details.
         """
-        return self.get_database(
-            token=token,
+
+        keyspace_param = check_optional_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
+        )
+
+        return self.get_database(
+            token=token,
+            keyspace=keyspace_param,
             api_path=api_path,
             api_version=api_version,
         ).to_async()

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -57,10 +57,7 @@ from astrapy.exceptions import (
     base_timeout_info,
 )
 from astrapy.info import AdminDatabaseInfo, DatabaseInfo, FindEmbeddingProvidersResult
-from astrapy.meta import (
-    check_optional_namespace_keyspace,
-    check_update_db_namespace_keyspace,
-)
+from astrapy.meta import check_namespace_keyspace, check_update_db_namespace_keyspace
 from astrapy.request_tools import HttpMethod
 
 if TYPE_CHECKING:
@@ -324,7 +321,7 @@ def fetch_database_info(
         For valid-looking endpoints, if something goes wrong an exception is raised.
     """
 
-    keyspace_param = check_optional_namespace_keyspace(
+    keyspace_param = check_namespace_keyspace(
         keyspace=keyspace,
         namespace=namespace,
     )
@@ -379,7 +376,7 @@ async def async_fetch_database_info(
         For valid-looking endpoints, if something goes wrong an exception is raised.
     """
 
-    keyspace_param = check_optional_namespace_keyspace(
+    keyspace_param = check_namespace_keyspace(
         keyspace=keyspace,
         namespace=namespace,
     )
@@ -941,7 +938,7 @@ class AstraDBAdmin:
             >>> my_coll.insert_one({"title": "The Title", "$vector": [0.1, 0.2]})
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1055,7 +1052,7 @@ class AstraDBAdmin:
             AstraDBDatabaseAdmin(id=...)
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1405,7 +1402,7 @@ class AstraDBAdmin:
             `create_database` method of class AstraDBAdmin.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1471,7 +1468,7 @@ class AstraDBAdmin:
         counterpart `get_database`: please see that one for more details.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -3023,7 +3020,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             see the AstraDBAdmin class.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -3068,7 +3065,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         counterpart `get_database`: please see that one for more details.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -4089,7 +4086,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
             of the database itself, which should exist beforehand.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -4125,7 +4122,7 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         counterpart `get_database`: please see that one for more details.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -555,8 +555,8 @@ class AstraDBAdmin:
         >>> database_list[2].id
         '01234567-...'
         >>> my_db_admin = my_astra_db_admin.get_database_admin("01234567-...")
-        >>> my_db_admin.list_namespaces()
-        ['default_keyspace', 'staging_namespace']
+        >>> my_db_admin.list_keyspaces()
+        ['default_keyspace', 'staging_keyspace']
     """
 
     def __init__(
@@ -1321,11 +1321,11 @@ class AstraDBAdmin:
 
         Example:
             >>> my_db_admin = my_astra_db_admin.get_database_admin("01234567-...")
-            >>> my_db_admin.list_namespaces()
+            >>> my_db_admin.list_keyspaces()
             ['default_keyspace']
-            >>> my_db_admin.create_namespace("that_other_one")
+            >>> my_db_admin.create_keyspace("that_other_one")
             {'ok': 1}
-            >>> my_db_admin.list_namespaces()
+            >>> my_db_admin.list_keyspaces()
             ['default_keyspace', 'that_other_one']
 
         Note:
@@ -1490,7 +1490,7 @@ class AstraDBAdmin:
 class DatabaseAdmin(ABC):
     """
     An abstract class defining the interface for a database admin object.
-    This supports generic namespace crud, as well as spawning databases,
+    This supports generic keyspace crud, as well as spawning databases,
     without committing to a specific database architecture (e.g. Astra DB).
     """
 
@@ -1645,8 +1645,8 @@ class DatabaseAdmin(ABC):
 
 class AstraDBDatabaseAdmin(DatabaseAdmin):
     """
-    An "admin" object, able to perform administrative tasks at the namespaces level
-    (i.e. within a certain database), such as creating/listing/dropping namespaces.
+    An "admin" object, able to perform administrative tasks at the keyspaces level
+    (i.e. within a certain database), such as creating/listing/dropping keyspaces.
 
     This is one layer below the AstraDBAdmin concept, in that it is tied to
     a single database and enables admin work within it. As such, it is generally
@@ -1688,8 +1688,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             Generally to be left to its Astra DB default of "/v1".
         spawner_database: either a Database or an AsyncDatabase instance. This represents
             the database class which spawns this admin object, so that, if required,
-            a namespace creation can retroactively "use" the new namespace in the spawner.
-            Used to enable the Async/Database.get_admin_database().create_namespace() pattern.
+            a keyspace creation can retroactively "use" the new keyspace in the spawner.
+            Used to enable the Async/Database.get_admin_database().create_keyspace() pattern.
         max_time_ms: a timeout, in milliseconds, for the DevOps API
             HTTP request should it be necessary (see the `region` argument).
 
@@ -1697,8 +1697,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         >>> from astrapy import DataAPIClient
         >>> my_client = DataAPIClient("AstraCS:...")
         >>> admin_for_my_db = my_client.get_admin().get_database_admin("01234567-...")
-        >>> admin_for_my_db.list_namespaces()
-        ['default_keyspace', 'staging_namespace']
+        >>> admin_for_my_db.list_keyspaces()
+        ['default_keyspace', 'staging_keyspace']
         >>> admin_for_my_db.info().status
         'ACTIVE'
 
@@ -1785,7 +1785,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         }
         self._api_commander = self._get_api_commander()
 
-        # DevOps-API-commander specific init (namespace CRUD, etc)
+        # DevOps-API-commander specific init (keyspace CRUD, etc)
         self.dev_ops_url = (
             dev_ops_url
             if dev_ops_url is not None
@@ -2029,8 +2029,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             ...     id="01234567-...",
             ...     astra_db_admin=DataAPIClient("AstraCS:...").get_admin(),
             ... )
-            >>> admin_for_my_db.list_namespaces()
-            ['default_keyspace', 'staging_namespace']
+            >>> admin_for_my_db.list_keyspaces()
+            ['default_keyspace', 'staging_keyspace']
             >>> admin_for_my_db.info().status
             'ACTIVE'
 
@@ -2089,8 +2089,8 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             ...     api_endpoint="https://01234567-....apps.astra.datastax.com",
             ...     token="AstraCS:...",
             ... )
-            >>> admin_for_my_db.list_namespaces()
-            ['default_keyspace', 'another_namespace']
+            >>> admin_for_my_db.list_keyspaces()
+            ['default_keyspace', 'another_keyspace']
             >>> admin_for_my_db.info().status
             'ACTIVE'
 
@@ -2908,15 +2908,15 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             Otherwise, an exception is raised.
 
         Example:
-            >>> my_db_admin.list_namespaces()
+            >>> my_db_admin.list_keyspaces()
             ['default_keyspace', 'that_other_one']
             >>> my_db_admin.drop()
             {'ok': 1}
-            >>> my_db_admin.list_namespaces()  # raises a 404 Not Found http error
+            >>> my_db_admin.list_keyspaces()  # raises a 404 Not Found http error
 
         Note:
             Once the method succeeds, methods on this object -- such as `info()`,
-            or `list_namespaces()` -- can still be invoked: however, this hardly
+            or `list_keyspaces()` -- can still be invoked: however, this hardly
             makes sense as the underlying actual database is no more.
             It is responsibility of the developer to design a correct flow
             which avoids using a deceased database any further.
@@ -2965,7 +2965,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
 
         Note:
             Once the method succeeds, methods on this object -- such as `info()`,
-            or `list_namespaces()` -- can still be invoked: however, this hardly
+            or `list_keyspaces()` -- can still be invoked: however, this hardly
             makes sense as the underlying actual database is no more.
             It is responsibility of the developer to design a correct flow
             which avoids using a deceased database any further.
@@ -3173,11 +3173,11 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
 class DataAPIDatabaseAdmin(DatabaseAdmin):
     """
     An "admin" object for non-Astra Data API environments, to perform administrative
-    tasks at the namespaces level such as creating/listing/dropping namespaces.
+    tasks at the keyspaces level such as creating/listing/dropping keyspaces.
 
     Conforming to the architecture of non-Astra deployments of the Data API,
     this object works within the one existing database. It is within that database
-    that the namespace CRUD operations (and possibly other admin operations)
+    that the keyspace CRUD operations (and possibly other admin operations)
     are performed. Since non-Astra environment lack the concept of an overall
     admin (such as the all-databases AstraDBAdmin class), a `DataAPIDatabaseAdmin`
     is generally created by invoking the `get_database_admin` method of the
@@ -3202,10 +3202,11 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         caller_name: name of the application, or framework, on behalf of which
             the admin API calls are performed. This ends up in the request user-agent.
         caller_version: version of the caller.
-        spawner_database: either a Database or an AsyncDatabase instance. This represents
-            the database class which spawns this admin object, so that, if required,
-            a namespace creation can retroactively "use" the new namespace in the spawner.
-            Used to enable the Async/Database.get_admin_database().create_namespace() pattern.
+        spawner_database: either a Database or an AsyncDatabase instance.
+            This represents the database class which spawns this admin object, so that,
+            if required, a keyspace creation can retroactively "use" the new keyspace
+            in the spawner. Used to enable the
+            Async/Database.get_admin_database().create_keyspace() pattern.
 
     Example:
         >>> from astrapy import DataAPIClient
@@ -3222,8 +3223,8 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         >>> database = client.get_database(endpoint)
         >>> admin_for_my_db = database.get_database_admin()
         >>>
-        >>> admin_for_my_db.list_namespaces()
-        ['namespace1', 'namespace2']
+        >>> admin_for_my_db.list_keyspaces()
+        ['keyspace1', 'keyspace2']
     """
 
     def __init__(

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -334,6 +334,7 @@ def fetch_database_info(
             return DatabaseInfo(
                 id=parsed_endpoint.database_id,
                 region=parsed_endpoint.region,
+                keyspace=namespace,
                 namespace=namespace,
                 name=raw_info["name"],
                 environment=parsed_endpoint.environment,
@@ -381,6 +382,7 @@ async def async_fetch_database_info(
             return DatabaseInfo(
                 id=parsed_endpoint.database_id,
                 region=parsed_endpoint.region,
+                keyspace=namespace,
                 namespace=namespace,
                 name=raw_info["name"],
                 environment=parsed_endpoint.environment,
@@ -399,6 +401,7 @@ def _recast_as_admin_database_info(
         info=DatabaseInfo(
             id=admin_database_info_dict["id"],
             region=admin_database_info_dict["info"]["region"],
+            keyspace=admin_database_info_dict["info"]["keyspace"],
             namespace=admin_database_info_dict["info"]["keyspace"],
             name=admin_database_info_dict["info"]["name"],
             environment=environment,

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -43,7 +43,7 @@ from astrapy.defaults import (
     DEV_OPS_DATABASE_STATUS_MAINTENANCE,
     DEV_OPS_DATABASE_STATUS_PENDING,
     DEV_OPS_DATABASE_STATUS_TERMINATING,
-    DEV_OPS_NAMESPACE_POLL_INTERVAL_S,
+    DEV_OPS_KEYSPACE_POLL_INTERVAL_S,
     DEV_OPS_RESPONSE_HTTP_ACCEPTED,
     DEV_OPS_RESPONSE_HTTP_CREATED,
     DEV_OPS_URL_ENV_MAP,
@@ -2385,7 +2385,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             last_status_seen = DEV_OPS_DATABASE_STATUS_MAINTENANCE
             while last_status_seen == DEV_OPS_DATABASE_STATUS_MAINTENANCE:
                 logger.info(f"sleeping to poll for status of '{self._database_id}'")
-                time.sleep(DEV_OPS_NAMESPACE_POLL_INTERVAL_S)
+                time.sleep(DEV_OPS_KEYSPACE_POLL_INTERVAL_S)
                 last_status_seen = self.info(
                     max_time_ms=timeout_manager.remaining_timeout_ms(),
                 ).status
@@ -2546,7 +2546,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
                 logger.info(
                     f"sleeping to poll for status of '{self._database_id}', async"
                 )
-                await asyncio.sleep(DEV_OPS_NAMESPACE_POLL_INTERVAL_S)
+                await asyncio.sleep(DEV_OPS_KEYSPACE_POLL_INTERVAL_S)
                 last_db_info = await self.async_info(
                     max_time_ms=timeout_manager.remaining_timeout_ms(),
                 )
@@ -2681,7 +2681,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
             last_status_seen = DEV_OPS_DATABASE_STATUS_MAINTENANCE
             while last_status_seen == DEV_OPS_DATABASE_STATUS_MAINTENANCE:
                 logger.info(f"sleeping to poll for status of '{self._database_id}'")
-                time.sleep(DEV_OPS_NAMESPACE_POLL_INTERVAL_S)
+                time.sleep(DEV_OPS_KEYSPACE_POLL_INTERVAL_S)
                 last_status_seen = self.info(
                     max_time_ms=timeout_manager.remaining_timeout_ms(),
                 ).status
@@ -2814,7 +2814,7 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
                 logger.info(
                     f"sleeping to poll for status of '{self._database_id}', async"
                 )
-                await asyncio.sleep(DEV_OPS_NAMESPACE_POLL_INTERVAL_S)
+                await asyncio.sleep(DEV_OPS_KEYSPACE_POLL_INTERVAL_S)
                 last_db_info = await self.async_info(
                     max_time_ms=timeout_manager.remaining_timeout_ms(),
                 )

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -1384,9 +1384,9 @@ class AstraDBAdmin:
             max_time_ms=max_time_ms,
         )
 
-        _namespace: Optional[str]
+        _keyspace: Optional[str]
         if namespace:
-            _namespace = namespace
+            _keyspace = namespace
         else:
             parsed_api_endpoint = parse_api_endpoint(normalized_api_endpoint)
             if parsed_api_endpoint is None:
@@ -1397,12 +1397,12 @@ class AstraDBAdmin:
                 parsed_api_endpoint.database_id,
                 max_time_ms=max_time_ms,
             )
-            _namespace = this_db_info.info.namespace
+            _keyspace = this_db_info.info.namespace
 
         return Database(
             api_endpoint=normalized_api_endpoint,
             token=_token,
-            namespace=_namespace,
+            namespace=_keyspace,
             caller_name=self.caller_name,
             caller_version=self.caller_version,
             environment=self.environment,

--- a/astrapy/admin.py
+++ b/astrapy/admin.py
@@ -2358,7 +2358,6 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=False,
         )
 
         timeout_manager = MultiCallTimeoutManager(
@@ -2517,7 +2516,6 @@ class AstraDBDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=True,
         )
 
         timeout_manager = MultiCallTimeoutManager(
@@ -3447,7 +3445,6 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=False,
         )
 
         options = {
@@ -3526,7 +3523,6 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=False,
         )
 
         options = {
@@ -3780,7 +3776,6 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=True,
         )
 
         options = {
@@ -3862,7 +3857,6 @@ class DataAPIDatabaseAdmin(DatabaseAdmin):
         _update_db_keyspace = check_update_db_namespace_keyspace(
             update_db_keyspace=update_db_keyspace,
             update_db_namespace=update_db_namespace,
-            from_async_method=True,
         )
 
         options = {

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -424,7 +424,7 @@ class DataAPIClient:
             ... )
             >>> my_db2 = my_client.get_database_by_api_endpoint(
             ...     "https://01234567-....apps.astra.datastax.com",
-            ...     keyspace="the_other_namespace",
+            ...     keyspace="the_other_keyspace",
             ... )
             >>> my_coll = my_db0.create_collection("movies", dimension=2)
             >>> my_coll.insert_one({"title": "The Title", "$vector": [0.5, 0.6]})
@@ -556,7 +556,7 @@ class DataAPIClient:
             ...     cloud_provider="AWS",
             ...     region="eu-west-1",
             ... )
-            >>> my_db_admin.list_namespaces()
+            >>> my_db_admin.list_keyspaces()
             ['default_keyspace', 'that_other_one']
         """
 

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -31,6 +31,7 @@ from astrapy.admin import (
 )
 from astrapy.authentication import coerce_token_provider, redact_secret
 from astrapy.constants import Environment
+from astrapy.meta import check_optional_namespace_keyspace
 
 if TYPE_CHECKING:
     from astrapy import AsyncDatabase, Database
@@ -216,6 +217,7 @@ class DataAPIClient:
         *,
         api_endpoint: Optional[str] = None,
         token: Optional[Union[str, TokenProvider]] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         region: Optional[str] = None,
         api_path: Optional[str] = None,
@@ -236,8 +238,9 @@ class DataAPIClient:
             token: if supplied, is passed to the Database instead of the client token.
                 This can be either a literal token string or a subclass of
                 `astrapy.authentication.TokenProvider`.
-            namespace: if provided, it is passed to the Database; otherwise
+            keyspace: if provided, it is passed to the Database; otherwise
                 the Database class will apply an environment-specific default.
+            namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
             region: the region to use for connecting to the database. The
                 database must be located in that region.
                 The region cannot be specified when the API endoint is used as `id`.
@@ -270,6 +273,11 @@ class DataAPIClient:
             `create_database` method of class AstraDBAdmin.
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
+
         # lazy importing here to avoid circular dependency
         from astrapy import Database
 
@@ -286,12 +294,12 @@ class DataAPIClient:
                 return self.get_database_by_api_endpoint(
                     api_endpoint=_id_or_endpoint,
                     token=token,
-                    namespace=namespace,
+                    keyspace=keyspace_param,
                     api_path=api_path,
                     api_version=api_version,
                 )
             else:
-                # handle overrides. Only region is needed (namespace can stay empty)
+                # handle overrides. Only region is needed (keyspace can stay empty)
                 if region:
                     _region = region
                 else:
@@ -316,7 +324,7 @@ class DataAPIClient:
                 return Database(
                     api_endpoint=_api_endpoint,
                     token=_token,
-                    namespace=namespace,
+                    keyspace=keyspace_param,
                     caller_name=self._caller_name,
                     caller_version=self._caller_version,
                     environment=self.environment,
@@ -334,7 +342,7 @@ class DataAPIClient:
             return self.get_database_by_api_endpoint(
                 api_endpoint=_id_or_endpoint,
                 token=token,
-                namespace=namespace,
+                keyspace=keyspace_param,
                 api_path=api_path,
                 api_version=api_version,
             )
@@ -345,6 +353,7 @@ class DataAPIClient:
         *,
         api_endpoint: Optional[str] = None,
         token: Optional[Union[str, TokenProvider]] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         region: Optional[str] = None,
         api_path: Optional[str] = None,
@@ -358,11 +367,15 @@ class DataAPIClient:
         counterpart `get_database`: please see that one for more details.
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         return self.get_database(
             id=id,
             api_endpoint=api_endpoint,
             token=token,
-            namespace=namespace,
+            keyspace=keyspace_param,
             region=region,
             api_path=api_path,
             api_version=api_version,
@@ -374,6 +387,7 @@ class DataAPIClient:
         api_endpoint: str,
         *,
         token: Optional[Union[str, TokenProvider]] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
@@ -391,8 +405,9 @@ class DataAPIClient:
             token: if supplied, is passed to the Database instead of the client token.
                 This can be either a literal token string or a subclass of
                 `astrapy.authentication.TokenProvider`.
-            namespace: if provided, it is passed to the Database; otherwise
+            keyspace: if provided, it is passed to the Database; otherwise
                 the Database class will apply an environment-specific default.
+            namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
             api_path: path to append to the API Endpoint. In typical usage, this
                 should be left to its default of "/api/json".
             api_version: version specifier to append to the API path. In typical
@@ -420,6 +435,11 @@ class DataAPIClient:
             `create_database` method of class AstraDBAdmin.
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
+
         # lazy importing here to avoid circular dependency
         from astrapy import Database
 
@@ -437,7 +457,7 @@ class DataAPIClient:
                 return Database(
                     api_endpoint=api_endpoint,
                     token=_token,
-                    namespace=namespace,
+                    keyspace=keyspace_param,
                     caller_name=self._caller_name,
                     caller_version=self._caller_version,
                     environment=self.environment,
@@ -454,7 +474,7 @@ class DataAPIClient:
                 return Database(
                     api_endpoint=parsed_generic_api_endpoint,
                     token=_token,
-                    namespace=namespace,
+                    keyspace=keyspace_param,
                     caller_name=self._caller_name,
                     caller_version=self._caller_version,
                     environment=self.environment,
@@ -470,6 +490,7 @@ class DataAPIClient:
         api_endpoint: str,
         *,
         token: Optional[Union[str, TokenProvider]] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
@@ -486,10 +507,14 @@ class DataAPIClient:
         for more details.
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         return self.get_database_by_api_endpoint(
             api_endpoint=api_endpoint,
             token=token,
-            namespace=namespace,
+            keyspace=keyspace_param,
             api_path=api_path,
             api_version=api_version,
         ).to_async()

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -424,7 +424,7 @@ class DataAPIClient:
             ... )
             >>> my_db2 = my_client.get_database_by_api_endpoint(
             ...     "https://01234567-....apps.astra.datastax.com",
-            ...     namespace="the_other_namespace",
+            ...     keyspace="the_other_namespace",
             ... )
             >>> my_coll = my_db0.create_collection("movies", dimension=2)
             >>> my_coll.insert_one({"title": "The Title", "$vector": [0.5, 0.6]})

--- a/astrapy/client.py
+++ b/astrapy/client.py
@@ -31,7 +31,7 @@ from astrapy.admin import (
 )
 from astrapy.authentication import coerce_token_provider, redact_secret
 from astrapy.constants import Environment
-from astrapy.meta import check_optional_namespace_keyspace
+from astrapy.meta import check_namespace_keyspace
 
 if TYPE_CHECKING:
     from astrapy import AsyncDatabase, Database
@@ -273,7 +273,7 @@ class DataAPIClient:
             `create_database` method of class AstraDBAdmin.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -367,7 +367,7 @@ class DataAPIClient:
         counterpart `get_database`: please see that one for more details.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -435,7 +435,7 @@ class DataAPIClient:
             `create_database` method of class AstraDBAdmin.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -507,7 +507,7 @@ class DataAPIClient:
         for more details.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -3301,7 +3301,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="insert",
-            from_async_method=True,
         )
         _document = _collate_vector_to_document(document, vector, vectorize)
         _max_time_ms = max_time_ms or self.api_options.max_time_ms
@@ -3443,7 +3442,6 @@ class AsyncCollection:
             vectors=vectors,
             vectorize=vectorize,
             kind="insert",
-            from_async_method=True,
         )
         if concurrency is None:
             if ordered:
@@ -3910,7 +3908,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _max_time_ms = max_time_ms or self.api_options.max_time_ms
         fo_cursor = self.find(
@@ -4261,7 +4258,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         options = {
@@ -4385,7 +4381,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         options = {
@@ -4548,7 +4543,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         options = {
@@ -4675,7 +4669,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         options = {
@@ -4944,7 +4937,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         _projection = normalize_optional_projection(projection)
@@ -5047,7 +5039,6 @@ class AsyncCollection:
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
         )
         _sort = _collate_vector_to_sort(sort, vector, vectorize)
         _max_time_ms = max_time_ms or self.api_options.max_time_ms

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -2483,6 +2483,15 @@ class Collection:
                 raw_response=None,
             )
 
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=(
+            "Please switch to managing sequences of DML operations "
+            "in app code instead."
+        ),
+    )
     def bulk_write(
         self,
         requests: Iterable[BaseOperation],
@@ -5174,6 +5183,15 @@ class AsyncCollection:
                 raw_response=None,
             )
 
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=(
+            "Please switch to managing sequences of DML operations "
+            "in app code instead."
+        ),
+    )
     async def bulk_write(
         self,
         requests: Iterable[AsyncBaseOperation],

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -298,7 +298,7 @@ class Collection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.namespace}", database={self.database}, '
+            f'namespace="{self.keyspace}", database={self.database}, '
             f"api_options={self.api_options})"
         )
 
@@ -324,7 +324,7 @@ class Collection:
     def _get_api_commander(self) -> APICommander:
         """Instantiate a new APICommander based on the properties of this class."""
 
-        if self._database.namespace is None:
+        if self._database.keyspace is None:
             raise ValueError(
                 "No namespace specified. Collection requires a namespace to "
                 "be set, e.g. through the `namespace` constructor parameter."
@@ -335,7 +335,7 @@ class Collection:
             for comp in (
                 self._database.api_path.strip("/"),
                 self._database.api_version.strip("/"),
-                self._database.namespace,
+                self._database.keyspace,
                 self._name,
             )
             if comp != ""
@@ -362,7 +362,7 @@ class Collection:
         return Collection(
             database=database or self.database._copy(),
             name=name or self.name,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             api_options=self.api_options.with_override(api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -488,7 +488,7 @@ class Collection:
         return AsyncCollection(
             database=database or self.database.to_async(),
             name=name or self.name,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             api_options=self.api_options.with_override(_api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -550,8 +550,8 @@ class Collection:
             return self_descriptors[0].options
         else:
             raise CollectionNotFoundException(
-                text=f"Collection {self.namespace}.{self.name} not found.",
-                namespace=self.namespace,
+                text=f"Collection {self.keyspace}.{self.name} not found.",
+                namespace=self.keyspace,
                 collection_name=self.name,
             )
 
@@ -579,7 +579,7 @@ class Collection:
 
         return CollectionInfo(
             database_info=self.database.info(),
-            namespace=self.namespace,
+            namespace=self.keyspace,
             name=self.name,
             full_name=self.full_name,
         )
@@ -656,7 +656,7 @@ class Collection:
             'default_keyspace.my_v_collection'
         """
 
-        return f"{self.namespace}.{self.name}"
+        return f"{self.keyspace}.{self.name}"
 
     def insert_one(
         self,
@@ -2857,7 +2857,7 @@ class AsyncCollection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.namespace}", database={self.database}, '
+            f'namespace="{self.keyspace}", database={self.database}, '
             f"api_options={self.api_options})"
         )
 
@@ -2883,7 +2883,7 @@ class AsyncCollection:
     def _get_api_commander(self) -> APICommander:
         """Instantiate a new APICommander based on the properties of this class."""
 
-        if self._database.namespace is None:
+        if self._database.keyspace is None:
             raise ValueError(
                 "No namespace specified. AsyncCollection requires a namespace to "
                 "be set, e.g. through the `namespace` constructor parameter."
@@ -2894,7 +2894,7 @@ class AsyncCollection:
             for comp in (
                 self._database.api_path.strip("/"),
                 self._database.api_version.strip("/"),
-                self._database.namespace,
+                self._database.keyspace,
                 self._name,
             )
             if comp != ""
@@ -2937,7 +2937,7 @@ class AsyncCollection:
         return AsyncCollection(
             database=database or self.database._copy(),
             name=name or self.name,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             api_options=self.api_options.with_override(api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -3063,7 +3063,7 @@ class AsyncCollection:
         return Collection(
             database=database or self.database.to_sync(),
             name=name or self.name,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             api_options=self.api_options.with_override(_api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -3127,8 +3127,8 @@ class AsyncCollection:
             return self_descriptors[0].options
         else:
             raise CollectionNotFoundException(
-                text=f"Collection {self.namespace}.{self.name} not found.",
-                namespace=self.namespace,
+                text=f"Collection {self.keyspace}.{self.name} not found.",
+                namespace=self.keyspace,
                 collection_name=self.name,
             )
 
@@ -3156,7 +3156,7 @@ class AsyncCollection:
 
         return CollectionInfo(
             database_info=self.database.info(),
-            namespace=self.namespace,
+            namespace=self.keyspace,
             name=self.name,
             full_name=self.full_name,
         )
@@ -3233,7 +3233,7 @@ class AsyncCollection:
             'default_keyspace.my_v_collection'
         """
 
-        return f"{self.namespace}.{self.name}"
+        return f"{self.keyspace}.{self.name}"
 
     async def insert_one(
         self,

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -275,11 +275,11 @@ class Collection:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        _namespace = namespace if namespace is not None else database.namespace
-        if _namespace is None:
+        _keyspace = namespace if namespace is not None else database.keyspace
+        if _keyspace is None:
             raise ValueError("Attempted to create Collection with 'namespace' unset.")
         self._database = database._copy(
-            namespace=_namespace,
+            namespace=_keyspace,
             caller_name=caller_name,
             caller_version=caller_version,
         )
@@ -2832,13 +2832,13 @@ class AsyncCollection:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        _namespace = namespace if namespace is not None else database.namespace
-        if _namespace is None:
+        _keyspace = namespace if namespace is not None else database.keyspace
+        if _keyspace is None:
             raise ValueError(
                 "Attempted to create AsyncCollection with 'namespace' unset."
             )
         self._database = database._copy(
-            namespace=_namespace,
+            namespace=_keyspace,
             caller_name=caller_name,
             caller_version=caller_version,
         )

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -551,7 +551,7 @@ class Collection:
         else:
             raise CollectionNotFoundException(
                 text=f"Collection {self.keyspace}.{self.name} not found.",
-                namespace=self.keyspace,
+                keyspace=self.keyspace,
                 collection_name=self.name,
             )
 
@@ -3128,7 +3128,7 @@ class AsyncCollection:
         else:
             raise CollectionNotFoundException(
                 text=f"Collection {self.keyspace}.{self.name} not found.",
-                namespace=self.keyspace,
+                keyspace=self.keyspace,
                 collection_name=self.name,
             )
 

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -53,6 +53,7 @@ from astrapy.defaults import (
     DEFAULT_DATA_API_AUTH_HEADER,
     DEFAULT_INSERT_MANY_CHUNK_SIZE,
     DEFAULT_INSERT_MANY_CONCURRENCY,
+    NAMESPACE_DEPRECATION_NOTICE_METHOD,
 )
 from astrapy.exceptions import (
     BulkWriteException,
@@ -595,19 +596,39 @@ class Collection:
         return self._database
 
     @property
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def namespace(self) -> str:
         """
         The namespace this collection is in.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "keyspace" property.**
 
         Example:
             >>> my_coll.namespace
             'default_keyspace'
         """
 
-        _namespace = self.database.namespace
-        if _namespace is None:
-            raise ValueError("The collection's DB is set with namespace=None")
-        return _namespace
+        return self.keyspace
+
+    @property
+    def keyspace(self) -> str:
+        """
+        The keyspace this collection is in.
+
+        Example:
+            >>> my_coll.keyspace
+            'default_keyspace'
+        """
+
+        _keyspace = self.database.keyspace
+        if _keyspace is None:
+            raise ValueError("The collection's DB is set with keyspace=None")
+        return _keyspace
 
     @property
     def name(self) -> str:
@@ -3150,19 +3171,39 @@ class AsyncCollection:
         return self._database
 
     @property
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def namespace(self) -> str:
         """
         The namespace this collection is in.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "keyspace" property.**
 
         Example:
             >>> my_async_coll.namespace
             'default_keyspace'
         """
 
-        _namespace = self.database.namespace
-        if _namespace is None:
-            raise ValueError("The collection's DB is set with namespace=None")
-        return _namespace
+        return self.keyspace
+
+    @property
+    def keyspace(self) -> str:
+        """
+        The keyspace this collection is in.
+
+        Example:
+            >>> my_coll.keyspace
+            'default_keyspace'
+        """
+
+        _keyspace = self.database.keyspace
+        if _keyspace is None:
+            raise ValueError("The collection's DB is set with keyspace=None")
+        return _keyspace
 
     @property
     def name(self) -> str:

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -70,7 +70,7 @@ from astrapy.exceptions import (
     base_timeout_info,
 )
 from astrapy.info import CollectionInfo, CollectionOptions
-from astrapy.meta import check_deprecated_vector_ize, check_optional_namespace_keyspace
+from astrapy.meta import check_deprecated_vector_ize, check_namespace_keyspace
 from astrapy.results import (
     BulkWriteResult,
     DeleteResult,
@@ -273,7 +273,7 @@ class Collection:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -367,7 +367,7 @@ class Collection:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> Collection:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -494,7 +494,7 @@ class Collection:
             77
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -2849,7 +2849,7 @@ class AsyncCollection:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -2961,7 +2961,7 @@ class AsyncCollection:
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> AsyncCollection:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -3088,7 +3088,7 @@ class AsyncCollection:
             77
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -70,7 +70,7 @@ from astrapy.exceptions import (
     base_timeout_info,
 )
 from astrapy.info import CollectionInfo, CollectionOptions
-from astrapy.meta import check_deprecated_vector_ize
+from astrapy.meta import check_deprecated_vector_ize, check_optional_namespace_keyspace
 from astrapy.results import (
     BulkWriteResult,
     DeleteResult,
@@ -231,8 +231,9 @@ class Collection:
             the database the collection belongs to.
         name: the collection name. This parameter should match an existing
             collection on the database.
-        namespace: this is the namespace to which the collection belongs.
-            If not specified, the database's working namespace is used.
+        keyspace: this is the keyspace to which the collection belongs.
+            If not specified, the database's working keyspace is used.
+        namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
         api_options: An instance of `astrapy.api_options.CollectionAPIOptions`
             providing the general settings for interacting with the Data API.
         caller_name: name of the application, or framework, on behalf of which
@@ -266,20 +267,26 @@ class Collection:
         database: Database,
         name: str,
         *,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_options: Optional[CollectionAPIOptions] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
+
         if api_options is None:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        _keyspace = namespace if namespace is not None else database.keyspace
+        _keyspace = keyspace_param if keyspace_param is not None else database.keyspace
         if _keyspace is None:
             raise ValueError("Attempted to create Collection with 'namespace' unset.")
         self._database = database._copy(
-            namespace=_keyspace,
+            keyspace=_keyspace,
             caller_name=caller_name,
             caller_version=caller_version,
         )
@@ -354,15 +361,20 @@ class Collection:
         *,
         database: Optional[Database] = None,
         name: Optional[str] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_options: Optional[CollectionAPIOptions] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> Collection:
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         return Collection(
             database=database or self.database._copy(),
             name=name or self.name,
-            namespace=namespace or self.keyspace,
+            keyspace=keyspace_param or self.keyspace,
             api_options=self.api_options.with_override(api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -432,6 +444,7 @@ class Collection:
         *,
         database: Optional[AsyncDatabase] = None,
         name: Optional[str] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
@@ -449,8 +462,9 @@ class Collection:
                 This represents the database the new collection belongs to.
             name: the collection name. This parameter should match an existing
                 collection on the database.
-            namespace: this is the namespace to which the collection belongs.
-                If not specified, the database's working namespace is used.
+            keyspace: this is the keyspace to which the collection belongs.
+                If not specified, the database's working keyspace is used.
+            namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
             embedding_api_key: optional API key(s) for interacting with the collection.
                 If an embedding service is configured, and this parameter is not None,
                 each Data API call will include the necessary embedding-related headers
@@ -480,6 +494,10 @@ class Collection:
             77
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         _api_options = CollectionAPIOptions(
             embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
@@ -488,7 +506,7 @@ class Collection:
         return AsyncCollection(
             database=database or self.database.to_async(),
             name=name or self.name,
-            namespace=namespace or self.keyspace,
+            keyspace=keyspace_param or self.keyspace,
             api_options=self.api_options.with_override(_api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -2787,8 +2805,9 @@ class AsyncCollection:
             the database the collection belongs to.
         name: the collection name. This parameter should match an existing
             collection on the database.
-        namespace: this is the namespace to which the collection belongs.
-            If not specified, the database's working namespace is used.
+        keyspace: this is the keyspace to which the collection belongs.
+            If not specified, the database's working keyspace is used.
+        namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
         api_options: An instance of `astrapy.api_options.CollectionAPIOptions`
             providing the general settings for interacting with the Data API.
         caller_name: name of the application, or framework, on behalf of which
@@ -2824,22 +2843,28 @@ class AsyncCollection:
         database: AsyncDatabase,
         name: str,
         *,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_options: Optional[CollectionAPIOptions] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> None:
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
+
         if api_options is None:
             self.api_options = CollectionAPIOptions()
         else:
             self.api_options = api_options
-        _keyspace = namespace if namespace is not None else database.keyspace
+        _keyspace = keyspace_param if keyspace_param is not None else database.keyspace
         if _keyspace is None:
             raise ValueError(
                 "Attempted to create AsyncCollection with 'namespace' unset."
             )
         self._database = database._copy(
-            namespace=_keyspace,
+            keyspace=_keyspace,
             caller_name=caller_name,
             caller_version=caller_version,
         )
@@ -2930,15 +2955,20 @@ class AsyncCollection:
         *,
         database: Optional[AsyncDatabase] = None,
         name: Optional[str] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         api_options: Optional[CollectionAPIOptions] = None,
         caller_name: Optional[str] = None,
         caller_version: Optional[str] = None,
     ) -> AsyncCollection:
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         return AsyncCollection(
             database=database or self.database._copy(),
             name=name or self.name,
-            namespace=namespace or self.keyspace,
+            keyspace=keyspace_param or self.keyspace,
             api_options=self.api_options.with_override(api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
@@ -3008,6 +3038,7 @@ class AsyncCollection:
         *,
         database: Optional[Database] = None,
         name: Optional[str] = None,
+        keyspace: Optional[str] = None,
         namespace: Optional[str] = None,
         embedding_api_key: Optional[Union[str, EmbeddingHeadersProvider]] = None,
         collection_max_time_ms: Optional[int] = None,
@@ -3025,8 +3056,9 @@ class AsyncCollection:
                 This represents the database the new collection belongs to.
             name: the collection name. This parameter should match an existing
                 collection on the database.
-            namespace: this is the namespace to which the collection belongs.
-                If not specified, the database's working namespace is used.
+            keyspace: this is the keyspace to which the collection belongs.
+                If not specified, the database's working keyspace is used.
+            namespace: an alias for `keyspace`. *DEPRECATED*, removal in 2.0.
             embedding_api_key: optional API key(s) for interacting with the collection.
                 If an embedding service is configured, and this parameter is not None,
                 each Data API call will include the necessary embedding-related headers
@@ -3056,6 +3088,10 @@ class AsyncCollection:
             77
         """
 
+        keyspace_param = check_optional_namespace_keyspace(
+            keyspace=keyspace,
+            namespace=namespace,
+        )
         _api_options = CollectionAPIOptions(
             embedding_api_key=coerce_embedding_headers_provider(embedding_api_key),
             max_time_ms=collection_max_time_ms,
@@ -3064,7 +3100,7 @@ class AsyncCollection:
         return Collection(
             database=database or self.database.to_sync(),
             name=name or self.name,
-            namespace=namespace or self.keyspace,
+            keyspace=keyspace_param or self.keyspace,
             api_options=self.api_options.with_override(_api_options),
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -305,7 +305,7 @@ class Collection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.keyspace}", database={self.database}, '
+            f'keyspace="{self.keyspace}", database={self.database}, '
             f"api_options={self.api_options})"
         )
 
@@ -2883,7 +2883,7 @@ class AsyncCollection:
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(name="{self.name}", '
-            f'namespace="{self.keyspace}", database={self.database}, '
+            f'keyspace="{self.keyspace}", database={self.database}, '
             f"api_options={self.api_options})"
         )
 

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -579,6 +579,7 @@ class Collection:
 
         return CollectionInfo(
             database_info=self.database.info(),
+            keyspace=self.keyspace,
             namespace=self.keyspace,
             name=self.name,
             full_name=self.full_name,
@@ -3156,6 +3157,7 @@ class AsyncCollection:
 
         return CollectionInfo(
             database_info=self.database.info(),
+            keyspace=self.keyspace,
             namespace=self.keyspace,
             name=self.name,
             full_name=self.full_name,

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -284,7 +284,7 @@ class Collection:
             self.api_options = api_options
         _keyspace = keyspace_param if keyspace_param is not None else database.keyspace
         if _keyspace is None:
-            raise ValueError("Attempted to create Collection with 'namespace' unset.")
+            raise ValueError("Attempted to create Collection with 'keyspace' unset.")
         self._database = database._copy(
             keyspace=_keyspace,
             caller_name=caller_name,
@@ -333,8 +333,8 @@ class Collection:
 
         if self._database.keyspace is None:
             raise ValueError(
-                "No namespace specified. Collection requires a namespace to "
-                "be set, e.g. through the `namespace` constructor parameter."
+                "No keyspace specified. Collection requires a keyspace to "
+                "be set, e.g. through the `keyspace` constructor parameter."
             )
 
         base_path_components = [
@@ -395,7 +395,7 @@ class Collection:
         Args:
             name: the name of the collection. This parameter is useful to
                 quickly spawn Collection instances each pointing to a different
-                collection existing in the same namespace.
+                collection existing in the same keyspace.
             embedding_api_key: optional API key(s) for interacting with the collection.
                 If an embedding service is configured, and this parameter is not None,
                 each Data API call will include the necessary embedding-related headers
@@ -668,7 +668,7 @@ class Collection:
     def full_name(self) -> str:
         """
         The fully-qualified collection name within the database,
-        in the form "namespace.collection_name".
+        in the form "keyspace.collection_name".
 
         Example:
             >>> my_coll.full_name
@@ -2861,7 +2861,7 @@ class AsyncCollection:
         _keyspace = keyspace_param if keyspace_param is not None else database.keyspace
         if _keyspace is None:
             raise ValueError(
-                "Attempted to create AsyncCollection with 'namespace' unset."
+                "Attempted to create AsyncCollection with 'keyspace' unset."
             )
         self._database = database._copy(
             keyspace=_keyspace,
@@ -2911,8 +2911,8 @@ class AsyncCollection:
 
         if self._database.keyspace is None:
             raise ValueError(
-                "No namespace specified. AsyncCollection requires a namespace to "
-                "be set, e.g. through the `namespace` constructor parameter."
+                "No keyspace specified. AsyncCollection requires a keyspace to "
+                "be set, e.g. through the `keyspace` constructor parameter."
             )
 
         base_path_components = [
@@ -2989,7 +2989,7 @@ class AsyncCollection:
         Args:
             name: the name of the collection. This parameter is useful to
                 quickly spawn AsyncCollection instances each pointing to a different
-                collection existing in the same namespace.
+                collection existing in the same keyspace.
             embedding_api_key: optional API key(s) for interacting with the collection.
                 If an embedding service is configured, and this parameter is not None,
                 each Data API call will include the necessary embedding-related headers
@@ -3264,7 +3264,7 @@ class AsyncCollection:
     def full_name(self) -> str:
         """
         The fully-qualified collection name within the database,
-        in the form "namespace.collection_name".
+        in the form "keyspace.collection_name".
 
         Example:
             >>> my_async_coll.full_name

--- a/astrapy/collection.py
+++ b/astrapy/collection.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import (
@@ -596,12 +597,6 @@ class Collection:
         return self._database
 
     @property
-    @deprecation.deprecated(  # type: ignore[misc]
-        deprecated_in="1.5.0",
-        removed_in="2.0.0",
-        current_version=__version__,
-        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
-    )
     def namespace(self) -> str:
         """
         The namespace this collection is in.
@@ -612,6 +607,14 @@ class Collection:
             >>> my_coll.namespace
             'default_keyspace'
         """
+
+        the_warning = deprecation.DeprecatedWarning(
+            "the 'namespace' property",
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+        )
+        warnings.warn(the_warning, stacklevel=2)
 
         return self.keyspace
 
@@ -3171,12 +3174,6 @@ class AsyncCollection:
         return self._database
 
     @property
-    @deprecation.deprecated(  # type: ignore[misc]
-        deprecated_in="1.5.0",
-        removed_in="2.0.0",
-        current_version=__version__,
-        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
-    )
     def namespace(self) -> str:
         """
         The namespace this collection is in.
@@ -3187,6 +3184,14 @@ class AsyncCollection:
             >>> my_async_coll.namespace
             'default_keyspace'
         """
+
+        the_warning = deprecation.DeprecatedWarning(
+            "the 'namespace' property",
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+        )
+        warnings.warn(the_warning, stacklevel=2)
 
         return self.keyspace
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -141,7 +141,7 @@ class Database:
             when creating a Database, on Astra DB the name "default_namespace" is set,
             while on other environments the namespace is left unspecified: in this case,
             most operations are unavailable until a namespace is set (through an explicit
-            `use_namespace` invocation or equivalent).
+            `use_keyspace` invocation or equivalent).
         caller_name: name of the application, or framework, on behalf of which
             the Data API calls are performed. This ends up in the request user-agent.
         caller_version: version of the caller.
@@ -291,7 +291,7 @@ class Database:
         if driver_commander is None:
             raise ValueError(
                 "No namespace specified. This operation requires a namespace to "
-                "be set, e.g. through the `use_namespace` method."
+                "be set, e.g. through the `use_keyspace` method."
             )
         return driver_commander
 
@@ -661,7 +661,7 @@ class Database:
         if _namespace is None:
             raise ValueError(
                 "No namespace specified. This operation requires a namespace to "
-                "be set, e.g. through the `use_namespace` method."
+                "be set, e.g. through the `use_keyspace` method."
             )
         return Collection(
             self,
@@ -1116,7 +1116,7 @@ class AsyncDatabase:
             when creating a Database, on Astra DB the name "default_namespace" is set,
             while on other environments the namespace is left unspecified: in this case,
             most operations are unavailable until a namespace is set (through an explicit
-            `use_namespace` invocation or equivalent).
+            `use_keyspace` invocation or equivalent).
         caller_name: name of the application, or framework, on behalf of which
             the Data API calls are performed. This ends up in the request user-agent.
         caller_version: version of the caller.
@@ -1266,7 +1266,7 @@ class AsyncDatabase:
         if driver_commander is None:
             raise ValueError(
                 "No namespace specified. This operation requires a namespace to "
-                "be set, e.g. through the `use_namespace` method."
+                "be set, e.g. through the `use_keyspace` method."
             )
         return driver_commander
 
@@ -1656,7 +1656,7 @@ class AsyncDatabase:
         if _namespace is None:
             raise ValueError(
                 "No namespace specified. This operation requires a namespace to "
-                "be set, e.g. through the `use_namespace` method."
+                "be set, e.g. through the `use_keyspace` method."
             )
         return AsyncCollection(
             self,

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -18,6 +18,9 @@ import logging
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
+import deprecation
+
+from astrapy import __version__
 from astrapy.admin import fetch_database_info, parse_api_endpoint
 from astrapy.api_commander import APICommander
 from astrapy.api_options import CollectionAPIOptions
@@ -33,6 +36,7 @@ from astrapy.defaults import (
     API_VERSION_ENV_MAP,
     DEFAULT_ASTRA_DB_NAMESPACE,
     DEFAULT_DATA_API_AUTH_HEADER,
+    NAMESPACE_DEPRECATION_NOTICE_METHOD,
 )
 from astrapy.exceptions import (
     CollectionAlreadyExistsException,
@@ -428,10 +432,18 @@ class Database:
         self.caller_version = caller_version
         self._api_commander = self._get_api_commander(namespace=self.namespace)
 
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def use_namespace(self, namespace: str) -> None:
         """
         Switch to a new working namespace for this database.
         This method changes (mutates) the Database instance.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "use_keyspace" method.**
 
         Note that this method does not create the namespace, which should exist
         already (created for instance with a `DatabaseAdmin.create_namespace` call).
@@ -449,9 +461,32 @@ class Database:
             >>> my_db.list_collection_names()
             []
         """
-        logger.info(f"switching to namespace '{namespace}'")
-        self.using_namespace = namespace
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        return self.use_keyspace(keyspace=namespace)
+
+    def use_keyspace(self, keyspace: str) -> None:
+        """
+        Switch to a new working keyspace for this database.
+        This method changes (mutates) the Database instance.
+
+        Note that this method does not create the keyspace, which should exist
+        already (created for instance with a `DatabaseAdmin.create_keyspace` call).
+
+        Args:
+            keyspace: the new keyspace to use as the database working keyspace.
+
+        Returns:
+            None.
+
+        Example:
+            >>> my_db.list_collection_names()
+            ['coll_1', 'coll_2']
+            >>> my_db.use_keyspace("an_empty_keyspace")
+            >>> my_db.list_collection_names()
+            []
+        """
+        logger.info(f"switching to keyspace '{keyspace}'")
+        self.using_namespace = keyspace
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
 
     def info(self) -> DatabaseInfo:
         """
@@ -523,16 +558,40 @@ class Database:
         return self._name
 
     @property
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def namespace(self) -> Optional[str]:
         """
         The namespace this database uses as target for all commands when
         no method-call-specific namespace is specified.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "keyspace" property.**
 
         Returns:
             the working namespace (a string), or None if not set.
 
         Example:
             >>> my_db.namespace
+            'the_keyspace'
+        """
+
+        return self.keyspace
+
+    @property
+    def keyspace(self) -> Optional[str]:
+        """
+        The keyspace this database uses as target for all commands when
+        no method-call-specific keyspace is specified.
+
+        Returns:
+            the working keyspace (a string), or None if not set.
+
+        Example:
+            >>> my_db.keyspace
             'the_keyspace'
         """
 
@@ -1365,10 +1424,18 @@ class AsyncDatabase:
         self.caller_version = caller_version
         self._api_commander = self._get_api_commander(namespace=self.namespace)
 
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def use_namespace(self, namespace: str) -> None:
         """
         Switch to a new working namespace for this database.
         This method changes (mutates) the AsyncDatabase instance.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "use_keyspace" method.**
 
         Note that this method does not create the namespace, which should exist
         already (created for instance with a `DatabaseAdmin.async_create_namespace` call).
@@ -1386,9 +1453,32 @@ class AsyncDatabase:
             >>> asyncio.run(my_async_db.list_collection_names())
             []
         """
-        logger.info(f"switching to namespace '{namespace}'")
-        self.using_namespace = namespace
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        return self.use_keyspace(keyspace=namespace)
+
+    def use_keyspace(self, keyspace: str) -> None:
+        """
+        Switch to a new working keyspace for this database.
+        This method changes (mutates) the AsyncDatabase instance.
+
+        Note that this method does not create the keyspace, which should exist
+        already (created for instance with a `DatabaseAdmin.async_create_keyspace` call).
+
+        Args:
+            keyspace: the new keyspace to use as the database working keyspace.
+
+        Returns:
+            None.
+
+        Example:
+            >>> asyncio.run(my_async_db.list_collection_names())
+            ['coll_1', 'coll_2']
+            >>> my_async_db.use_keyspace("an_empty_keyspace")
+            >>> asyncio.run(my_async_db.list_collection_names())
+            []
+        """
+        logger.info(f"switching to keyspace '{keyspace}'")
+        self.using_namespace = keyspace
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
 
     def info(self) -> DatabaseInfo:
         """
@@ -1460,16 +1550,40 @@ class AsyncDatabase:
         return self._name
 
     @property
+    @deprecation.deprecated(  # type: ignore[misc]
+        deprecated_in="1.5.0",
+        removed_in="2.0.0",
+        current_version=__version__,
+        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+    )
     def namespace(self) -> Optional[str]:
         """
         The namespace this database uses as target for all commands when
         no method-call-specific namespace is specified.
+
+        *DEPRECATED* (removal in 2.0). Switch to the "keyspace" property.**
 
         Returns:
             the working namespace (a string), or None if not set.
 
         Example:
             >>> my_async_db.namespace
+            'the_keyspace'
+        """
+
+        return self.keyspace
+
+    @property
+    def keyspace(self) -> Optional[str]:
+        """
+        The keyspace this database uses as target for all commands when
+        no method-call-specific keyspace is specified.
+
+        Returns:
+            the working keyspace (a string), or None if not set.
+
+        Example:
+            >>> my_async_db.keyspace
             'the_keyspace'
         """
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -226,10 +226,10 @@ class Database:
         else:
             token_desc = None
         namespace_desc: Optional[str]
-        if self.namespace is None:
+        if self.keyspace is None:
             namespace_desc = "namespace not set"
         else:
-            namespace_desc = f'namespace="{self.namespace}"'
+            namespace_desc = f'namespace="{self.keyspace}"'
         parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
@@ -241,7 +241,7 @@ class Database:
                     self.api_endpoint == other.api_endpoint,
                     self.api_path == other.api_path,
                     self.api_version == other.api_version,
-                    self.namespace == other.namespace,
+                    self.keyspace == other.namespace,
                     self.caller_name == other.caller_name,
                     self.caller_version == other.caller_version,
                     self.api_commander == other.api_commander,
@@ -311,7 +311,7 @@ class Database:
         return Database(
             api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
             environment=environment or self.environment,
@@ -402,7 +402,7 @@ class Database:
         return AsyncDatabase(
             api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
             environment=environment or self.environment,
@@ -513,7 +513,7 @@ class Database:
         database_info = fetch_database_info(
             self.api_endpoint,
             token=self.token_provider.get_token(),
-            namespace=self.namespace,
+            namespace=self.keyspace,
         )
         if database_info is not None:
             logger.info("finished getting database info")
@@ -793,7 +793,7 @@ class Database:
             if name in existing_names:
                 raise CollectionAlreadyExistsException(
                     text=f"Collection {name} already exists",
-                    namespace=namespace or self.namespace or "(unspecified)",
+                    namespace=namespace or self.keyspace or "(unspecified)",
                     collection_name=name,
                 )
 
@@ -1203,10 +1203,10 @@ class AsyncDatabase:
         else:
             token_desc = None
         namespace_desc: Optional[str]
-        if self.namespace is None:
+        if self.keyspace is None:
             namespace_desc = "namespace not set"
         else:
-            namespace_desc = f'namespace="{self.namespace}"'
+            namespace_desc = f'namespace="{self.keyspace}"'
         parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
@@ -1218,7 +1218,7 @@ class AsyncDatabase:
                     self.api_endpoint == other.api_endpoint,
                     self.api_path == other.api_path,
                     self.api_version == other.api_version,
-                    self.namespace == other.namespace,
+                    self.keyspace == other.namespace,
                     self.caller_name == other.caller_name,
                     self.caller_version == other.caller_version,
                     self.api_commander == other.api_commander,
@@ -1304,7 +1304,7 @@ class AsyncDatabase:
         return AsyncDatabase(
             api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
             environment=environment or self.environment,
@@ -1396,7 +1396,7 @@ class AsyncDatabase:
         return Database(
             api_endpoint=api_endpoint or self.api_endpoint,
             token=coerce_token_provider(token) or self.token_provider,
-            namespace=namespace or self.namespace,
+            namespace=namespace or self.keyspace,
             caller_name=caller_name or self.caller_name,
             caller_version=caller_version or self.caller_version,
             environment=environment or self.environment,
@@ -1507,7 +1507,7 @@ class AsyncDatabase:
         database_info = fetch_database_info(
             self.api_endpoint,
             token=self.token_provider.get_token(),
-            namespace=self.namespace,
+            namespace=self.keyspace,
         )
         if database_info is not None:
             logger.info("finished getting database info")
@@ -1794,7 +1794,7 @@ class AsyncDatabase:
             if name in existing_names:
                 raise CollectionAlreadyExistsException(
                     text=f"Collection {name} already exists",
-                    namespace=namespace or self.namespace or "(unspecified)",
+                    namespace=namespace or self.keyspace or "(unspecified)",
                     collection_name=name,
                 )
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
@@ -208,7 +209,7 @@ class Database:
 
         self.caller_name = caller_name
         self.caller_version = caller_version
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
         self._name: Optional[str] = None
 
     def __getattr__(self, collection_name: str) -> Collection:
@@ -430,7 +431,7 @@ class Database:
         logger.info(f"setting caller to {caller_name}/{caller_version}")
         self.caller_name = caller_name
         self.caller_version = caller_version
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
 
     @deprecation.deprecated(  # type: ignore[misc]
         deprecated_in="1.5.0",
@@ -558,12 +559,6 @@ class Database:
         return self._name
 
     @property
-    @deprecation.deprecated(  # type: ignore[misc]
-        deprecated_in="1.5.0",
-        removed_in="2.0.0",
-        current_version=__version__,
-        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
-    )
     def namespace(self) -> Optional[str]:
         """
         The namespace this database uses as target for all commands when
@@ -578,6 +573,14 @@ class Database:
             >>> my_db.namespace
             'the_keyspace'
         """
+
+        the_warning = deprecation.DeprecatedWarning(
+            "the 'namespace' property",
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+        )
+        warnings.warn(the_warning, stacklevel=2)
 
         return self.keyspace
 
@@ -1183,7 +1186,7 @@ class AsyncDatabase:
 
         self.caller_name = caller_name
         self.caller_version = caller_version
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
         self._name: Optional[str] = None
 
     def __getattr__(self, collection_name: str) -> AsyncCollection:
@@ -1422,7 +1425,7 @@ class AsyncDatabase:
         logger.info(f"setting caller to {caller_name}/{caller_version}")
         self.caller_name = caller_name
         self.caller_version = caller_version
-        self._api_commander = self._get_api_commander(namespace=self.namespace)
+        self._api_commander = self._get_api_commander(namespace=self.keyspace)
 
     @deprecation.deprecated(  # type: ignore[misc]
         deprecated_in="1.5.0",
@@ -1550,12 +1553,6 @@ class AsyncDatabase:
         return self._name
 
     @property
-    @deprecation.deprecated(  # type: ignore[misc]
-        deprecated_in="1.5.0",
-        removed_in="2.0.0",
-        current_version=__version__,
-        details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
-    )
     def namespace(self) -> Optional[str]:
         """
         The namespace this database uses as target for all commands when
@@ -1570,6 +1567,14 @@ class AsyncDatabase:
             >>> my_async_db.namespace
             'the_keyspace'
         """
+
+        the_warning = deprecation.DeprecatedWarning(
+            "the 'namespace' property",
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_METHOD,
+        )
+        warnings.warn(the_warning, stacklevel=2)
 
         return self.keyspace
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -51,7 +51,7 @@ from astrapy.info import (
     CollectionVectorServiceOptions,
     DatabaseInfo,
 )
-from astrapy.meta import check_optional_namespace_keyspace
+from astrapy.meta import check_namespace_keyspace
 
 if TYPE_CHECKING:
     from astrapy.admin import DatabaseAdmin
@@ -182,7 +182,7 @@ class Database:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> None:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -316,7 +316,7 @@ class Database:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> Database:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -362,7 +362,7 @@ class Database:
             ... )
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -419,7 +419,7 @@ class Database:
             >>> asyncio.run(my_async_db.list_collection_names())
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -683,7 +683,7 @@ class Database:
                 my_db["coll_name"]
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -802,7 +802,7 @@ class Database:
             the dimension must be compatible with the chosen service.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -933,7 +933,7 @@ class Database:
             CollectionDescriptor(name='my_v_col', options=CollectionOptions())
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -985,7 +985,7 @@ class Database:
             ['a_collection', 'another_col']
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1043,7 +1043,7 @@ class Database:
             {'status': {'count': 123}}
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1217,7 +1217,7 @@ class AsyncDatabase:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> None:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1367,7 +1367,7 @@ class AsyncDatabase:
         api_path: Optional[str] = None,
         api_version: Optional[str] = None,
     ) -> AsyncDatabase:
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1413,7 +1413,7 @@ class AsyncDatabase:
             ... )
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1472,7 +1472,7 @@ class AsyncDatabase:
             ['a_collection', 'another_collection']
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1739,7 +1739,7 @@ class AsyncDatabase:
                 my_async_db["coll_name"]
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1862,7 +1862,7 @@ class AsyncDatabase:
             the dimension must be compatible with the chosen service.
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -1994,7 +1994,7 @@ class AsyncDatabase:
             * coll: CollectionDescriptor(name='my_v_col', options=CollectionOptions())
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -2046,7 +2046,7 @@ class AsyncDatabase:
             ['a_collection', 'another_col']
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )
@@ -2107,7 +2107,7 @@ class AsyncDatabase:
             {'status': {'count': 123}}
         """
 
-        keyspace_param = check_optional_namespace_keyspace(
+        keyspace_param = check_namespace_keyspace(
             keyspace=keyspace,
             namespace=namespace,
         )

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -248,7 +248,7 @@ class Database:
                     self.api_endpoint == other.api_endpoint,
                     self.api_path == other.api_path,
                     self.api_version == other.api_version,
-                    self.keyspace == other.namespace,
+                    self.keyspace == other.keyspace,
                     self.caller_name == other.caller_name,
                     self.caller_version == other.caller_version,
                     self.api_commander == other.api_commander,
@@ -356,7 +356,7 @@ class Database:
 
         Example:
             >>> my_db_2 = my_db.with_options(
-            ...     keyspace="the_other_namespace",
+            ...     keyspace="the_other_keyspace",
             ...     caller_name="the_caller",
             ...     caller_version="0.1.0",
             ... )
@@ -1086,7 +1086,7 @@ class Database:
     ) -> DatabaseAdmin:
         """
         Return a DatabaseAdmin object corresponding to this database, for
-        use in admin tasks such as managing namespaces.
+        use in admin tasks such as managing keyspaces.
 
         This method, depending on the environment where the database resides,
         returns an appropriate subclass of DatabaseAdmin.
@@ -1113,10 +1113,10 @@ class Database:
 
         Example:
             >>> my_db_admin = my_db.get_database_admin()
-            >>> if "new_namespace" not in my_db_admin.list_namespaces():
-            ...     my_db_admin.create_namespace("new_namespace")
-            >>> my_db_admin.list_namespaces()
-            ['default_keyspace', 'new_namespace']
+            >>> if "new_keyspace" not in my_db_admin.list_keyspaces():
+            ...     my_db_admin.create_keyspace("new_keyspace")
+            >>> my_db_admin.list_keyspaces()
+            ['default_keyspace', 'new_keyspace']
         """
 
         # lazy importing here to avoid circular dependency
@@ -1283,7 +1283,7 @@ class AsyncDatabase:
                     self.api_endpoint == other.api_endpoint,
                     self.api_path == other.api_path,
                     self.api_version == other.api_version,
-                    self.keyspace == other.namespace,
+                    self.keyspace == other.keyspace,
                     self.caller_name == other.caller_name,
                     self.caller_version == other.caller_version,
                     self.api_commander == other.api_commander,
@@ -1407,7 +1407,7 @@ class AsyncDatabase:
 
         Example:
             >>> my_async_db_2 = my_async_db.with_options(
-            ...     keyspace="the_other_namespace",
+            ...     keyspace="the_other_keyspace",
             ...     caller_name="the_caller",
             ...     caller_version="0.1.0",
             ... )
@@ -2151,7 +2151,7 @@ class AsyncDatabase:
     ) -> DatabaseAdmin:
         """
         Return a DatabaseAdmin object corresponding to this database, for
-        use in admin tasks such as managing namespaces.
+        use in admin tasks such as managing keyspaces.
 
         This method, depending on the environment where the database resides,
         returns an appropriate subclass of DatabaseAdmin.
@@ -2178,10 +2178,10 @@ class AsyncDatabase:
 
         Example:
             >>> my_db_admin = my_async_db.get_database_admin()
-            >>> if "new_namespace" not in my_db_admin.list_namespaces():
-            ...     my_db_admin.create_namespace("new_namespace")
-            >>> my_db_admin.list_namespaces()
-            ['default_keyspace', 'new_namespace']
+            >>> if "new_keyspace" not in my_db_admin.list_keyspaces():
+            ...     my_db_admin.create_keyspace("new_keyspace")
+            >>> my_db_admin.list_keyspaces()
+            ['default_keyspace', 'new_keyspace']
         """
 
         # lazy importing here to avoid circular dependency

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -35,7 +35,7 @@ from astrapy.cursors import AsyncCommandCursor, CommandCursor
 from astrapy.defaults import (
     API_PATH_ENV_MAP,
     API_VERSION_ENV_MAP,
-    DEFAULT_ASTRA_DB_NAMESPACE,
+    DEFAULT_ASTRA_DB_KEYSPACE,
     DEFAULT_DATA_API_AUTH_HEADER,
     NAMESPACE_DEPRECATION_NOTICE_METHOD,
 )
@@ -199,7 +199,7 @@ class Database:
         # enforce defaults if on Astra DB:
         self._using_keyspace: Optional[str]
         if namespace is None and self.environment in Environment.astra_db_values:
-            self._using_keyspace = DEFAULT_ASTRA_DB_NAMESPACE
+            self._using_keyspace = DEFAULT_ASTRA_DB_KEYSPACE
         else:
             self._using_keyspace = namespace
 
@@ -793,7 +793,7 @@ class Database:
             if name in existing_names:
                 raise CollectionAlreadyExistsException(
                     text=f"Collection {name} already exists",
-                    namespace=namespace or self.keyspace or "(unspecified)",
+                    keyspace=namespace or self.keyspace or "(unspecified)",
                     collection_name=name,
                 )
 
@@ -1176,7 +1176,7 @@ class AsyncDatabase:
         # enforce defaults if on Astra DB:
         self._using_keyspace: Optional[str]
         if namespace is None and self.environment in Environment.astra_db_values:
-            self._using_keyspace = DEFAULT_ASTRA_DB_NAMESPACE
+            self._using_keyspace = DEFAULT_ASTRA_DB_KEYSPACE
         else:
             self._using_keyspace = namespace
 
@@ -1794,7 +1794,7 @@ class AsyncDatabase:
             if name in existing_names:
                 raise CollectionAlreadyExistsException(
                     text=f"Collection {name} already exists",
-                    namespace=namespace or self.keyspace or "(unspecified)",
+                    keyspace=namespace or self.keyspace or "(unspecified)",
                     collection_name=name,
                 )
 

--- a/astrapy/database.py
+++ b/astrapy/database.py
@@ -232,12 +232,12 @@ class Database:
             token_desc = f'token="{redact_secret(str(self.token_provider), 15)}"'
         else:
             token_desc = None
-        namespace_desc: Optional[str]
+        keyspace_desc: Optional[str]
         if self.keyspace is None:
-            namespace_desc = "namespace not set"
+            keyspace_desc = "keyspace not set"
         else:
-            namespace_desc = f'namespace="{self.keyspace}"'
-        parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
+            keyspace_desc = f'keyspace="{self.keyspace}"'
+        parts = [pt for pt in [ep_desc, token_desc, keyspace_desc] if pt is not None]
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __eq__(self, other: Any) -> bool:
@@ -537,7 +537,7 @@ class Database:
         database_info = fetch_database_info(
             self.api_endpoint,
             token=self.token_provider.get_token(),
-            namespace=self.keyspace,
+            keyspace=self.keyspace,
         )
         if database_info is not None:
             logger.info("finished getting database info")
@@ -1267,12 +1267,12 @@ class AsyncDatabase:
             token_desc = f'token="{redact_secret(str(self.token_provider), 15)}"'
         else:
             token_desc = None
-        namespace_desc: Optional[str]
+        keyspace_desc: Optional[str]
         if self.keyspace is None:
-            namespace_desc = "namespace not set"
+            keyspace_desc = "keyspace not set"
         else:
-            namespace_desc = f'namespace="{self.keyspace}"'
-        parts = [pt for pt in [ep_desc, token_desc, namespace_desc] if pt is not None]
+            keyspace_desc = f'keyspace="{self.keyspace}"'
+        parts = [pt for pt in [ep_desc, token_desc, keyspace_desc] if pt is not None]
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
     def __eq__(self, other: Any) -> bool:
@@ -1590,7 +1590,7 @@ class AsyncDatabase:
         database_info = fetch_database_info(
             self.api_endpoint,
             token=self.token_provider.get_token(),
-            namespace=self.keyspace,
+            keyspace=self.keyspace,
         )
         if database_info is not None:
             logger.info("finished getting database info")

--- a/astrapy/defaults.py
+++ b/astrapy/defaults.py
@@ -97,3 +97,13 @@ DEFAULT_REDACTED_HEADER_NAMES = {
     EMBEDDING_HEADER_AWS_SECRET_ID,
     EMBEDDING_HEADER_API_KEY,
 }
+
+# Deprecation notices for the phasing out of 'namespace'
+NAMESPACE_DEPRECATION_NOTICE_METHOD = (
+    "The term 'namespace' is being replaced by 'keyspace' throughout the Data API and "
+    "the clients. Please adapt method and parameter names consistently (examples: "
+    "`db_admin.findNamespaces` => `db_admin.findKeyspaces`; `collection.namespace` => "
+    "`collection.keyspace`; `database.list_collections(namespace=...)` => `database."
+    "list_collections(keyspace=...)`). See https://docs.datastax.com/en/astra-db-"
+    "serverless/api-reference/client-versions.html#version-1-5 for more information."
+)

--- a/astrapy/defaults.py
+++ b/astrapy/defaults.py
@@ -24,7 +24,7 @@ DATA_API_ENVIRONMENT_CASSANDRA = "cassandra"
 DATA_API_ENVIRONMENT_OTHER = "other"
 
 # Defaults/settings for Database management
-DEFAULT_ASTRA_DB_NAMESPACE = "default_keyspace"
+DEFAULT_ASTRA_DB_KEYSPACE = "default_keyspace"
 API_ENDPOINT_TEMPLATE_ENV_MAP = {
     DATA_API_ENVIRONMENT_PROD: "https://{database_id}-{region}.apps.astra.datastax.com",
     DATA_API_ENVIRONMENT_DEV: "https://{database_id}-{region}.apps.astra-dev.datastax.com",
@@ -64,7 +64,7 @@ EMBEDDING_HEADER_API_KEY = "X-Embedding-Api-Key"
 # Defaults/settings for DevOps API requests and admin operations
 DEFAULT_DEV_OPS_AUTH_HEADER = "Authorization"
 DEFAULT_DEV_OPS_AUTH_PREFIX = "Bearer "
-DEV_OPS_NAMESPACE_POLL_INTERVAL_S = 2
+DEV_OPS_KEYSPACE_POLL_INTERVAL_S = 2
 DEV_OPS_DATABASE_POLL_INTERVAL_S = 15
 DEV_OPS_DATABASE_STATUS_MAINTENANCE = "MAINTENANCE"
 DEV_OPS_DATABASE_STATUS_ACTIVE = "ACTIVE"

--- a/astrapy/defaults.py
+++ b/astrapy/defaults.py
@@ -113,3 +113,9 @@ NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS = (
     "See https://docs.datastax.com/en/astra-db-serverless/api-reference/client-"
     "versions.html#version-1-5 for more information."
 )
+NAMESPACE_DEPRECATION_NOTICE_NS_SUBJECT = "Parameter `namespace`"
+NAMESPACE_DEPRECATION_NOTICE_NS_DETAILS = (
+    "Please replace the parameter with `keyspace`. "
+    "See https://docs.datastax.com/en/astra-db-serverless/api-reference/client-"
+    "versions.html#version-1-5 for more information."
+)

--- a/astrapy/defaults.py
+++ b/astrapy/defaults.py
@@ -107,3 +107,9 @@ NAMESPACE_DEPRECATION_NOTICE_METHOD = (
     "list_collections(keyspace=...)`). See https://docs.datastax.com/en/astra-db-"
     "serverless/api-reference/client-versions.html#version-1-5 for more information."
 )
+NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_SUBJECT = "Parameter `update_db_namespace`"
+NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS = (
+    "Please replace the parameter with `update_db_keyspace`. "
+    "See https://docs.datastax.com/en/astra-db-serverless/api-reference/client-"
+    "versions.html#version-1-5 for more information."
+)

--- a/astrapy/exceptions.py
+++ b/astrapy/exceptions.py
@@ -483,11 +483,13 @@ class CollectionNotFoundException(DataAPIException):
 
     Attributes:
         text: a text message about the exception.
-        namespace: the namespace where the collection was supposed to be.
+        keyspace: the keyspace where the collection was supposed to be.
+        namespace: an alias for 'keyspace'. *DEPRECATED*, removal in 2.0
         collection_name: the name of the expected collection.
     """
 
     text: str
+    keyspace: str
     namespace: str
     collection_name: str
 
@@ -495,12 +497,13 @@ class CollectionNotFoundException(DataAPIException):
         self,
         text: str,
         *,
-        namespace: str,
+        keyspace: str,
         collection_name: str,
     ) -> None:
         super().__init__(text)
         self.text = text
-        self.namespace = namespace
+        self.keyspace = keyspace
+        self.namespace = keyspace
         self.collection_name = collection_name
 
 
@@ -512,11 +515,13 @@ class CollectionAlreadyExistsException(DataAPIException):
 
     Attributes:
         text: a text message about the exception.
-        namespace: the namespace where the collection was expected not to exist.
+        keyspace: the keyspace where the collection was expected not to exist.
+        namespace: an alias for 'keyspace'. *DEPRECATED*, removal in 2.0
         collection_name: the name of the collection.
     """
 
     text: str
+    keyspace: str
     namespace: str
     collection_name: str
 
@@ -524,12 +529,13 @@ class CollectionAlreadyExistsException(DataAPIException):
         self,
         text: str,
         *,
-        namespace: str,
+        keyspace: str,
         collection_name: str,
     ) -> None:
         super().__init__(text)
         self.text = text
-        self.namespace = namespace
+        self.keyspace = keyspace
+        self.namespace = keyspace
         self.collection_name = collection_name
 
 

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -516,7 +516,7 @@ class EmbeddingProviderParameter:
                 f"an `EmbeddingProviderParameter`: '{','.join(sorted(residual_keys))}'"
             )
         return EmbeddingProviderParameter(
-            default_value=raw_dict["defaultValue"],
+            default_value=raw_dict.get("defaultValue"),
             display_name=raw_dict.get("displayName"),
             help=raw_dict.get("help"),
             hint=raw_dict.get("hint"),

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -121,9 +121,9 @@ class CollectionInfo:
         database_info: a DatabaseInfo instance for the underlying database.
         keyspace: the keyspace where the collection is located.
         namespace: an alias for 'keyspace'. *DEPRECATED*, removal in 2.0
-        name: collection name. Unique within a namespace.
+        name: collection name. Unique within a keyspace.
         full_name: identifier for the collection within the database,
-            in the form "namespace.collection_name".
+            in the form "keyspace.collection_name".
     """
 
     database_info: DatabaseInfo

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -28,7 +28,8 @@ class DatabaseInfo:
     Attributes:
         id: the database ID.
         region: the ID of the region through which the connection to DB is done.
-        namespace: the namespace this DB is set to work with. None if not set.
+        keyspace: the namespace this DB is set to work with. None if not set.
+        namespace: an alias for 'keyspace'. *DEPRECATED*, removal in 2.0
         name: the database name. Not necessarily unique: there can be multiple
             databases with the same name.
         environment: a label, whose value can be `Environment.PROD`,
@@ -45,12 +46,13 @@ class DatabaseInfo:
             database_info.region != database_info.raw_info["region"]
         Conversely, in case of a DatabaseInfo not obtained through a
         connected database, such as when calling `Admin.list_databases()`,
-        all fields except `environment` (e.g. namespace, region, etc)
+        all fields except `environment` (e.g. keyspace, region, etc)
         are set as found on the DevOps API response directly.
     """
 
     id: str
     region: str
+    keyspace: Optional[str]
     namespace: Optional[str]
     name: str
     environment: str
@@ -117,13 +119,15 @@ class CollectionInfo:
 
     Attributes:
         database_info: a DatabaseInfo instance for the underlying database.
-        namespace: the namespace where the collection is located.
+        keyspace: the keyspace where the collection is located.
+        namespace: an alias for 'keyspace'. *DEPRECATED*, removal in 2.0
         name: collection name. Unique within a namespace.
         full_name: identifier for the collection within the database,
             in the form "namespace.collection_name".
     """
 
     database_info: DatabaseInfo
+    keyspace: str
     namespace: str
     name: str
     full_name: str

--- a/astrapy/meta.py
+++ b/astrapy/meta.py
@@ -15,9 +15,14 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Optional
 
 from deprecation import DeprecatedWarning
+
+from astrapy.defaults import (
+    NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS,
+    NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_SUBJECT,
+)
 
 
 def check_deprecated_vector_ize(
@@ -58,7 +63,7 @@ def check_deprecated_vector_ize(
             removed_in="2.0.0",
             details=message,
         )
-        # trying to surface the warning at the rick stack level to best inform user:
+        # trying to surface the warning at the right stack level to best inform user:
         # (considering both the error-recast wrap decorator and the internals)
         if from_async_method:
             if from_operation_class:
@@ -74,3 +79,41 @@ def check_deprecated_vector_ize(
             the_warning,
             stacklevel=s_level,
         )
+
+
+def check_update_db_namespace_keyspace(
+    update_db_keyspace: Optional[bool],
+    update_db_namespace: Optional[bool],
+    from_async_method: bool = False,
+) -> Optional[bool]:
+    # normalize the two aliased parameter names, raising deprecation
+    # when needed and an error if both parameter supplied.
+    # The returned value is the final one for the parameter.
+
+    if update_db_namespace is None:
+        # no need for deprecation nor exceptions
+        return update_db_keyspace
+    else:
+        # issue a deprecation warning
+        the_warning = DeprecatedWarning(
+            NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_SUBJECT,
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS,
+        )
+        # trying to surface the warning at the right stack level to best inform user:
+        # (considering both the error-recast wrap decorator and the internals)
+        s_level = 3
+        warnings.warn(
+            the_warning,
+            stacklevel=s_level,
+        )
+
+        if update_db_keyspace is None:
+            return update_db_namespace
+        else:
+            msg = (
+                "Parameters `update_db_keyspace` and `update_db_namespace` "
+                "(a deprecated alias for the former) cannot be passed at the same time."
+            )
+            raise ValueError(msg)

--- a/astrapy/meta.py
+++ b/astrapy/meta.py
@@ -30,8 +30,6 @@ def check_deprecated_vector_ize(
     vectors: Any,
     vectorize: Any,
     kind: str,
-    from_async_method: bool = False,
-    from_operation_class: bool = False,
 ) -> None:
     # Version check is not done at all - it will be a manual handling once this
     # deprecation becomes a removal.
@@ -56,35 +54,22 @@ def check_deprecated_vector_ize(
             message = "Use $vector or $vectorize fields in the sort clause instead."
         else:
             message = "Replace with $vector or $vectorize appropriately."
-        #
+
         the_warning = DeprecatedWarning(
             passed_desc,
             deprecated_in="1.3.0",
             removed_in="2.0.0",
             details=message,
         )
-        # trying to surface the warning at the right stack level to best inform user:
-        # (considering both the error-recast wrap decorator and the internals)
-        if from_async_method:
-            if from_operation_class:
-                s_level = 3
-            else:
-                s_level = 2
-        else:
-            if from_operation_class:
-                s_level = 3
-            else:
-                s_level = 4
         warnings.warn(
             the_warning,
-            stacklevel=s_level,
+            stacklevel=3,
         )
 
 
 def check_update_db_namespace_keyspace(
     update_db_keyspace: Optional[bool],
     update_db_namespace: Optional[bool],
-    from_async_method: bool = False,
 ) -> Optional[bool]:
     # normalize the two aliased parameter names, raising deprecation
     # when needed and an error if both parameter supplied.
@@ -101,12 +86,9 @@ def check_update_db_namespace_keyspace(
             removed_in="2.0.0",
             details=NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS,
         )
-        # trying to surface the warning at the right stack level to best inform user:
-        # (considering both the error-recast wrap decorator and the internals)
-        s_level = 3
         warnings.warn(
             the_warning,
-            stacklevel=s_level,
+            stacklevel=3,
         )
 
         if update_db_keyspace is None:

--- a/astrapy/meta.py
+++ b/astrapy/meta.py
@@ -69,7 +69,7 @@ def check_deprecated_vector_ize(
         )
 
 
-def check_optional_namespace_keyspace(
+def check_namespace_keyspace(
     keyspace: Optional[str],
     namespace: Optional[str],
 ) -> Optional[str]:

--- a/astrapy/meta.py
+++ b/astrapy/meta.py
@@ -20,6 +20,8 @@ from typing import Any, Optional
 from deprecation import DeprecatedWarning
 
 from astrapy.defaults import (
+    NAMESPACE_DEPRECATION_NOTICE_NS_DETAILS,
+    NAMESPACE_DEPRECATION_NOTICE_NS_SUBJECT,
     NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_DETAILS,
     NAMESPACE_DEPRECATION_NOTICE_UPDATEDBNS_SUBJECT,
 )
@@ -65,6 +67,40 @@ def check_deprecated_vector_ize(
             the_warning,
             stacklevel=3,
         )
+
+
+def check_optional_namespace_keyspace(
+    keyspace: Optional[str],
+    namespace: Optional[str],
+) -> Optional[str]:
+    # normalize the two aliased parameter names, raising deprecation
+    # when needed and an error if both parameter supplied.
+    # The returned value is the final one for the parameter.
+
+    if namespace is None:
+        # no need for deprecation nor exceptions
+        return keyspace
+    else:
+        # issue a deprecation warning
+        the_warning = DeprecatedWarning(
+            NAMESPACE_DEPRECATION_NOTICE_NS_SUBJECT,
+            deprecated_in="1.5.0",
+            removed_in="2.0.0",
+            details=NAMESPACE_DEPRECATION_NOTICE_NS_DETAILS,
+        )
+        warnings.warn(
+            the_warning,
+            stacklevel=3,
+        )
+
+        if keyspace is None:
+            return namespace
+        else:
+            msg = (
+                "Parameters `keyspace` and `namespace` "
+                "(a deprecated alias for the former) cannot be passed at the same time."
+            )
+            raise ValueError(msg)
 
 
 def check_update_db_namespace_keyspace(

--- a/astrapy/operations.py
+++ b/astrapy/operations.py
@@ -116,7 +116,6 @@ class InsertOne(BaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="insert",
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -189,7 +188,6 @@ class InsertMany(BaseOperation):
             vectors=vectors,
             vectorize=vectorize,
             kind="insert",
-            from_operation_class=True,
         )
         self.vectors = vectors
         self.vectorize = vectorize
@@ -267,7 +265,6 @@ class UpdateOne(BaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -395,7 +392,6 @@ class ReplaceOne(BaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -466,7 +462,6 @@ class DeleteOne(BaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -582,8 +577,6 @@ class AsyncInsertOne(AsyncBaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="insert",
-            from_async_method=True,
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -655,8 +648,6 @@ class AsyncInsertMany(AsyncBaseOperation):
             vectors=vectors,
             vectorize=vectorize,
             kind="insert",
-            from_async_method=True,
-            from_operation_class=True,
         )
         self.vectors = vectors
         self.vectorize = vectorize
@@ -735,8 +726,6 @@ class AsyncUpdateOne(AsyncBaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -864,8 +853,6 @@ class AsyncReplaceOne(AsyncBaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize
@@ -936,8 +923,6 @@ class AsyncDeleteOne(AsyncBaseOperation):
             vectors=None,
             vectorize=vectorize,
             kind="find",
-            from_async_method=True,
-            from_operation_class=True,
         )
         self.vector = vector
         self.vectorize = vectorize

--- a/bin/start_stargate.sh
+++ b/bin/start_stargate.sh
@@ -1,8 +1,0 @@
-docker run --name stargate \
-  -p 8080:8080 -p 8081:8081 \
-  -p 8082:8082 -p 127.0.0.1:9042:9042 \
-  -e CLUSTER_NAME=stargate \
-  -e CLUSTER_VERSION=6.8 \
-  -e DEVELOPER_MODE=true \
-  -e DSE=1 \
-  stargateio/stargate-dse-68:v1.0.52

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from astrapy import DataAPIClient
 from astrapy.admin import parse_api_endpoint
 from astrapy.authentication import TokenProvider
 from astrapy.constants import Environment
-from astrapy.defaults import DEFAULT_ASTRA_DB_NAMESPACE
+from astrapy.defaults import DEFAULT_ASTRA_DB_KEYSPACE
 
 from .preprocess_env import (
     ADMIN_ENV_LIST,
@@ -150,7 +150,7 @@ def data_api_credentials_kwargs() -> DataAPICredentials:
         astra_db_creds: DataAPICredentials = {
             "token": ASTRA_DB_TOKEN_PROVIDER or "",
             "api_endpoint": ASTRA_DB_API_ENDPOINT or "",
-            "namespace": ASTRA_DB_KEYSPACE or DEFAULT_ASTRA_DB_NAMESPACE,
+            "namespace": ASTRA_DB_KEYSPACE or DEFAULT_ASTRA_DB_KEYSPACE,
         }
         return astra_db_creds
     else:
@@ -159,7 +159,7 @@ def data_api_credentials_kwargs() -> DataAPICredentials:
         local_db_creds: DataAPICredentials = {
             "token": LOCAL_DATA_API_TOKEN_PROVIDER or "",
             "api_endpoint": LOCAL_DATA_API_ENDPOINT or "",
-            "namespace": LOCAL_DATA_API_KEYSPACE or DEFAULT_ASTRA_DB_NAMESPACE,
+            "namespace": LOCAL_DATA_API_KEYSPACE or DEFAULT_ASTRA_DB_KEYSPACE,
         }
 
         # ensure keyspace(s) exist at this point

--- a/tests/hcd_compose/docker-compose.yml
+++ b/tests/hcd_compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   hcd:
     image: datastax/hcd:1.0.0
@@ -22,7 +20,7 @@ services:
       retries: 20
 
   data-api:
-    image: stargateio/data-api:v1.0.15
+    image: stargateio/data-api:v1.0.16
     depends_on:
       hcd:
         condition: service_healthy

--- a/tests/idiomatic/conftest.py
+++ b/tests/idiomatic/conftest.py
@@ -57,7 +57,7 @@ def sync_database(
     database = client.get_database(
         data_api_credentials_kwargs["api_endpoint"],
         token=data_api_credentials_kwargs["token"],
-        namespace=data_api_credentials_kwargs["namespace"],
+        keyspace=data_api_credentials_kwargs["namespace"],
     )
 
     yield database
@@ -92,7 +92,7 @@ def sync_collection(
     data_api_credentials_kwargs: DataAPICredentials,
     sync_database: Database,
 ) -> Iterable[Collection]:
-    """An actual collection on DB, in the main namespace"""
+    """An actual collection on DB, in the main keyspace"""
     collection = sync_database.create_collection(
         TEST_COLLECTION_NAME,
         dimension=2,

--- a/tests/idiomatic/integration/test_admin.py
+++ b/tests/idiomatic/integration/test_admin.py
@@ -92,13 +92,13 @@ class TestAdmin:
         - create a db (wait)
         - with the AstraDBDatabaseAdmin:
             - info
-            - list namespaces, check
-            - create 2 namespaces (wait, nonwait)
-            - list namespaces, check
+            - list keyspaces, check
+            - create 2 keyspaces (wait, nonwait)
+            - list keyspaces, check
             - get_database -> create_collection/list_collection_names
             - get_async_database, check if == previous
-            - drop namespaces (wait, nonwait)
-            - list namespaces, check
+            - drop keyspaces (wait, nonwait)
+            - list keyspaces, check
             - drop database (wait)
         - check DB not existings
         """
@@ -123,7 +123,7 @@ class TestAdmin:
         # create a db (wait)
         db_admin = admin.create_database(
             name=db_name,
-            namespace="custom_namespace",
+            keyspace="custom_keyspace",
             wait_until_active=True,
             cloud_provider=db_provider,
             region=db_region,
@@ -134,29 +134,29 @@ class TestAdmin:
         assert db_admin.info().id == created_db_id
 
         # list nss
-        namespaces1 = set(db_admin.list_namespaces())
-        assert namespaces1 == {"custom_namespace"}
+        keyspaces1 = set(db_admin.list_keyspaces())
+        assert keyspaces1 == {"custom_keyspace"}
 
-        # create two namespaces
-        w_create_ns_response = db_admin.create_namespace(
-            "waited_ns",
+        # create two keyspaces
+        w_create_ks_response = db_admin.create_keyspace(
+            "waited_ks",
             wait_until_active=True,
         )
-        assert w_create_ns_response == {"ok": 1}
+        assert w_create_ks_response == {"ok": 1}
 
-        nw_create_ns_response = db_admin.create_namespace(
-            "nonwaited_ns",
+        nw_create_ks_response = db_admin.create_keyspace(
+            "nonwaited_ks",
             wait_until_active=False,
         )
-        assert nw_create_ns_response == {"ok": 1}
+        assert nw_create_ks_response == {"ok": 1}
         wait_until_true(
             poll_interval=NAMESPACE_POLL_SLEEP_TIME,
             max_seconds=NAMESPACE_TIMEOUT,
-            condition=lambda: "nonwaited_ns" in db_admin.list_namespaces(),
+            condition=lambda: "nonwaited_ks" in db_admin.list_keyspaces(),
         )
 
-        namespaces3 = set(db_admin.list_namespaces())
-        assert namespaces3 - namespaces1 == {"waited_ns", "nonwaited_ns"}
+        keyspaces3 = set(db_admin.list_keyspaces())
+        assert keyspaces3 - keyspaces1 == {"waited_ks", "nonwaited_ks"}
 
         # get db and use it
         db = db_admin.get_database()
@@ -167,26 +167,26 @@ class TestAdmin:
         assert db_admin.get_async_database().to_sync() == db
 
         # drop nss, wait, nonwait
-        w_drop_ns_response = db_admin.drop_namespace(
-            "waited_ns",
+        w_drop_ks_response = db_admin.drop_keyspace(
+            "waited_ks",
             wait_until_active=True,
         )
-        assert w_drop_ns_response == {"ok": 1}
+        assert w_drop_ks_response == {"ok": 1}
 
-        nw_drop_ns_response = db_admin.drop_namespace(
-            "nonwaited_ns",
+        nw_drop_ks_response = db_admin.drop_keyspace(
+            "nonwaited_ks",
             wait_until_active=False,
         )
-        assert nw_drop_ns_response == {"ok": 1}
+        assert nw_drop_ks_response == {"ok": 1}
         wait_until_true(
             poll_interval=NAMESPACE_POLL_SLEEP_TIME,
             max_seconds=NAMESPACE_TIMEOUT,
-            condition=lambda: "nonwaited_ns" not in db_admin.list_namespaces(),
+            condition=lambda: "nonwaited_ks" not in db_admin.list_keyspaces(),
         )
 
         # check nss after dropping two of them
-        namespaces1b = set(db_admin.list_namespaces())
-        assert namespaces1b == namespaces1
+        keyspaces1b = set(db_admin.list_keyspaces())
+        assert keyspaces1b == keyspaces1
 
         # drop db and check. We wait a little due to "nontransactional cluster md"
         wait_until_true(
@@ -295,7 +295,7 @@ class TestAdmin:
 
         # get db admin from the admin and use it
         db_w_admin = admin.get_database_admin(created_db_id_w)
-        db_w_admin.create_namespace("additional_namespace")
+        db_w_admin.create_keyspace("additional_keyspace")
         db_w_from_admin = db_w_admin.get_database()
         assert isinstance(db_w_from_admin.list_collection_names(), list)
         adb_w_from_admin = db_w_admin.get_async_database()
@@ -344,13 +344,13 @@ class TestAdmin:
         - create a db (wait)
         - with the AstraDBDatabaseAdmin:
             - info
-            - list namespaces, check
-            - create 2 namespaces (wait, nonwait)
-            - list namespaces, check
+            - list keyspaces, check
+            - create 2 keyspaces (wait, nonwait)
+            - list keyspaces, check
             - get_database -> create_collection/list_collection_names
             - get_async_database, check if == previous
-            - drop namespaces (wait, nonwait)
-            - list namespaces, check
+            - drop keyspaces (wait, nonwait)
+            - list keyspaces, check
             - drop database (wait)
         - check DB not existings
         """
@@ -375,7 +375,7 @@ class TestAdmin:
         # create a db (wait)
         db_admin = await admin.async_create_database(
             name=db_name,
-            namespace="custom_namespace",
+            keyspace="custom_keyspace",
             wait_until_active=True,
             cloud_provider=db_provider,
             region=db_region,
@@ -386,24 +386,24 @@ class TestAdmin:
         assert (await db_admin.async_info()).id == created_db_id
 
         # list nss
-        namespaces1 = set(await db_admin.async_list_namespaces())
-        assert namespaces1 == {"custom_namespace"}
+        keyspaces1 = set(await db_admin.async_list_keyspaces())
+        assert keyspaces1 == {"custom_keyspace"}
 
-        # create two namespaces
-        w_create_ns_response = await db_admin.async_create_namespace(
-            "waited_ns",
+        # create two keyspaces
+        w_create_ks_response = await db_admin.async_create_keyspace(
+            "waited_ks",
             wait_until_active=True,
         )
-        assert w_create_ns_response == {"ok": 1}
+        assert w_create_ks_response == {"ok": 1}
 
-        nw_create_ns_response = await db_admin.async_create_namespace(
-            "nonwaited_ns",
+        nw_create_ks_response = await db_admin.async_create_keyspace(
+            "nonwaited_ks",
             wait_until_active=False,
         )
-        assert nw_create_ns_response == {"ok": 1}
+        assert nw_create_ks_response == {"ok": 1}
 
         async def _awaiter1() -> bool:
-            return "nonwaited_ns" in (await db_admin.async_list_namespaces())
+            return "nonwaited_ks" in (await db_admin.async_list_keyspaces())
 
         await await_until_true(
             poll_interval=NAMESPACE_POLL_SLEEP_TIME,
@@ -411,8 +411,8 @@ class TestAdmin:
             acondition=_awaiter1,
         )
 
-        namespaces3 = set(await db_admin.async_list_namespaces())
-        assert namespaces3 - namespaces1 == {"waited_ns", "nonwaited_ns"}
+        keyspaces3 = set(await db_admin.async_list_keyspaces())
+        assert keyspaces3 - keyspaces1 == {"waited_ks", "nonwaited_ks"}
 
         # get db and use it
         adb = db_admin.get_async_database()
@@ -423,21 +423,21 @@ class TestAdmin:
         assert db_admin.get_database().to_async() == adb
 
         # drop nss, wait, nonwait
-        w_drop_ns_response = await db_admin.async_drop_namespace(
-            "waited_ns",
+        w_drop_ks_response = await db_admin.async_drop_keyspace(
+            "waited_ks",
             wait_until_active=True,
         )
-        assert w_drop_ns_response == {"ok": 1}
+        assert w_drop_ks_response == {"ok": 1}
 
-        nw_drop_ns_response = await db_admin.async_drop_namespace(
-            "nonwaited_ns",
+        nw_drop_ks_response = await db_admin.async_drop_keyspace(
+            "nonwaited_ks",
             wait_until_active=False,
         )
-        assert nw_drop_ns_response == {"ok": 1}
+        assert nw_drop_ks_response == {"ok": 1}
 
         async def _awaiter2() -> bool:
-            ns_list = await db_admin.async_list_namespaces()
-            return "nonwaited_ns" not in ns_list
+            ks_list = await db_admin.async_list_keyspaces()
+            return "nonwaited_ks" not in ks_list
 
         await await_until_true(
             poll_interval=NAMESPACE_POLL_SLEEP_TIME,
@@ -446,8 +446,8 @@ class TestAdmin:
         )
 
         # check nss after dropping two of them
-        namespaces1b = set(await db_admin.async_list_namespaces())
-        assert namespaces1b == namespaces1
+        keyspaces1b = set(await db_admin.async_list_keyspaces())
+        assert keyspaces1b == keyspaces1
 
         async def _awaiter3() -> bool:
             a_info = await db_admin.async_info()
@@ -560,7 +560,7 @@ class TestAdmin:
 
         # get db admin from the admin and use it
         db_w_admin = admin.get_database_admin(created_db_id_w)
-        await db_w_admin.async_create_namespace("additional_namespace")
+        await db_w_admin.async_create_keyspace("additional_keyspace")
         adb_w_from_admin = db_w_admin.get_async_database()
         assert isinstance(await adb_w_from_admin.list_collection_names(), list)
         db_w_from_admin = db_w_admin.get_database()
@@ -606,7 +606,7 @@ class TestAdmin:
         )
 
     @pytest.mark.describe(
-        "test of the update_db_namespace flag for AstraDBDatabaseAdmin, sync"
+        "test of the update_db_keyspace flag for AstraDBDatabaseAdmin, sync"
     )
     def test_astra_updatedbnamespace_sync(self, sync_database: Database) -> None:
         NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"

--- a/tests/idiomatic/integration/test_admin.py
+++ b/tests/idiomatic/integration/test_admin.py
@@ -609,19 +609,23 @@ class TestAdmin:
         "test of the update_db_namespace flag for AstraDBDatabaseAdmin, sync"
     )
     def test_astra_updatedbnamespace_sync(self, sync_database: Database) -> None:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
-        namespace0 = sync_database.namespace
+        keyspace0 = sync_database.keyspace
         database_admin = sync_database.get_database_admin()
-        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
-        assert sync_database.namespace == namespace0
+        database_admin.create_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        assert sync_database.keyspace == keyspace0
 
-        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
-        assert sync_database.namespace == NEW_NS_NAME_UPDATED
+        with pytest.warns(DeprecationWarning):
+            database_admin.create_keyspace(
+                NEW_KS_NAME_UPDATED,
+                update_db_namespace=True,
+            )
+        assert sync_database.keyspace == NEW_KS_NAME_UPDATED
 
-        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
-        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
+        database_admin.drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        database_admin.drop_keyspace(NEW_KS_NAME_UPDATED)
 
     @pytest.mark.describe(
         "test of the update_db_namespace flag for AstraDBDatabaseAdmin, async"
@@ -629,18 +633,59 @@ class TestAdmin:
     async def test_astra_updatedbnamespace_async(
         self, async_database: AsyncDatabase
     ) -> None:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
-        namespace0 = async_database.namespace
+        keyspace0 = async_database.keyspace
         database_admin = async_database.get_database_admin()
-        await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
-        assert async_database.namespace == namespace0
+        await database_admin.async_create_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        assert async_database.keyspace == keyspace0
 
-        await database_admin.async_create_namespace(
-            NEW_NS_NAME_UPDATED, update_db_namespace=True
+        with pytest.warns(DeprecationWarning):
+            await database_admin.async_create_keyspace(
+                NEW_KS_NAME_UPDATED, update_db_namespace=True
+            )
+        assert async_database.keyspace == NEW_KS_NAME_UPDATED
+
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the update_db_keyspace flag for AstraDBDatabaseAdmin, sync"
+    )
+    def test_astra_updatedbkeyspace_sync(self, sync_database: Database) -> None:
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
+
+        keyspace0 = sync_database.keyspace
+        database_admin = sync_database.get_database_admin()
+        database_admin.create_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        assert sync_database.keyspace == keyspace0
+
+        database_admin.create_keyspace(NEW_KS_NAME_UPDATED, update_db_keyspace=True)
+        assert sync_database.keyspace == NEW_KS_NAME_UPDATED
+
+        database_admin.drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        database_admin.drop_keyspace(NEW_KS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the update_db_keyspace flag for AstraDBDatabaseAdmin, async"
+    )
+    async def test_astra_updatedbkeyspace_async(
+        self, async_database: AsyncDatabase
+    ) -> None:
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
+
+        keyspace0 = async_database.keyspace
+        database_admin = async_database.get_database_admin()
+        await database_admin.async_create_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        assert async_database.keyspace == keyspace0
+
+        await database_admin.async_create_keyspace(
+            NEW_KS_NAME_UPDATED, update_db_keyspace=True
         )
-        assert async_database.namespace == NEW_NS_NAME_UPDATED
+        assert async_database.keyspace == NEW_KS_NAME_UPDATED
 
-        await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
-        await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -189,7 +189,7 @@ class TestDDLAsync:
     ) -> None:
         assert isinstance(async_database.id, str)
         assert isinstance(async_database.name(), str)
-        assert async_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert async_database.keyspace == data_api_credentials_kwargs["namespace"]
         assert isinstance(async_database.info(), DatabaseInfo)
         assert isinstance(async_database.info().raw_info, dict)
 
@@ -251,12 +251,12 @@ class TestDDLAsync:
         # make a copy to avoid mutating the fixture
         at_database = async_database._copy()
         assert at_database == async_database
-        assert at_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert at_database.keyspace == data_api_credentials_kwargs["namespace"]
         assert TEST_COLLECTION_NAME in await at_database.list_collection_names()
 
         at_database.use_namespace(data_api_credentials_info["secondary_namespace"])
         assert at_database != async_database
-        assert at_database.namespace == data_api_credentials_info["secondary_namespace"]
+        assert at_database.keyspace == data_api_credentials_info["secondary_namespace"]
         assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
 
     @pytest.mark.skipif(

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -199,7 +199,7 @@ class TestDDLAsync:
         async_collection: AsyncCollection,
     ) -> None:
         info = async_collection.info()
-        assert info.namespace == async_collection.namespace
+        assert info.namespace == async_collection.keyspace
         assert info.namespace == async_collection.database.namespace
 
     @pytest.mark.describe("test of Database list_collections, async")
@@ -252,7 +252,7 @@ class TestDDLAsync:
         assert at_database.namespace == data_api_credentials_kwargs["namespace"]
         assert TEST_COLLECTION_NAME in await at_database.list_collection_names()
 
-        at_database.use_namespace(data_api_credentials_info["secondary_namespace"])  # type: ignore[arg-type]
+        at_database.use_namespace(data_api_credentials_info["secondary_namespace"])
         assert at_database != async_database
         assert at_database.namespace == data_api_credentials_info["secondary_namespace"]
         assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
@@ -311,7 +311,7 @@ class TestDDLAsync:
         assert isinstance(cmd1["status"]["count"], int)
         cmd2 = await async_database._copy(namespace="...").command(
             {"countDocuments": {}},
-            namespace=async_collection.namespace,
+            namespace=async_collection.keyspace,
             collection_name=async_collection.name,
         )
         assert cmd2 == cmd1
@@ -325,7 +325,7 @@ class TestDDLAsync:
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["collections"], list)
         cmd2 = await async_database._copy(namespace="...").command(
-            {"findCollections": {}}, namespace=async_database.namespace
+            {"findCollections": {}}, namespace=async_database.keyspace
         )
         assert cmd2 == cmd1
 

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -29,6 +29,7 @@ from ..conftest import (
     TEST_COLLECTION_NAME,
     DataAPICredentials,
     DataAPICredentialsInfo,
+    async_fail_if_not_removed,
 )
 
 
@@ -235,6 +236,7 @@ class TestDDLAsync:
             namespace=data_api_credentials_info["secondary_namespace"]
         )
 
+    @async_fail_if_not_removed
     @pytest.mark.skipif(
         SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
     )
@@ -255,6 +257,28 @@ class TestDDLAsync:
         at_database.use_namespace(data_api_credentials_info["secondary_namespace"])
         assert at_database != async_database
         assert at_database.namespace == data_api_credentials_info["secondary_namespace"]
+        assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
+
+    @pytest.mark.skipif(
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
+    )
+    @pytest.mark.describe("test of Database use_keyspace, async")
+    async def test_database_use_keyspace_async(
+        self,
+        async_database: AsyncDatabase,
+        async_collection: AsyncCollection,
+        data_api_credentials_kwargs: DataAPICredentials,
+        data_api_credentials_info: DataAPICredentialsInfo,
+    ) -> None:
+        # make a copy to avoid mutating the fixture
+        at_database = async_database._copy()
+        assert at_database == async_database
+        assert at_database.keyspace == data_api_credentials_kwargs["namespace"]
+        assert TEST_COLLECTION_NAME in await at_database.list_collection_names()
+
+        at_database.use_keyspace(data_api_credentials_info["secondary_namespace"])  # type: ignore[arg-type]
+        assert at_database != async_database
+        assert at_database.keyspace == data_api_credentials_info["secondary_namespace"]
         assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
 
     @pytest.mark.skipif(

--- a/tests/idiomatic/integration/test_ddl_async.py
+++ b/tests/idiomatic/integration/test_ddl_async.py
@@ -200,8 +200,8 @@ class TestDDLAsync:
         async_collection: AsyncCollection,
     ) -> None:
         info = async_collection.info()
-        assert info.namespace == async_collection.keyspace
-        assert info.namespace == async_collection.database.namespace
+        assert info.keyspace == async_collection.keyspace
+        assert info.keyspace == async_collection.database.keyspace
 
     @pytest.mark.describe("test of Database list_collections, async")
     async def test_database_list_collections_async(
@@ -221,24 +221,22 @@ class TestDDLAsync:
         assert options.vector.dimension == 2
 
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
-    @pytest.mark.describe(
-        "test of Database list_collections on cross-namespaces, async"
-    )
-    async def test_database_list_collections_cross_namespace_async(
+    @pytest.mark.describe("test of Database list_collections on cross-keyspaces, async")
+    async def test_database_list_collections_cross_keyspace_async(
         self,
         async_database: AsyncDatabase,
         async_collection: AsyncCollection,
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
         assert TEST_COLLECTION_NAME not in await async_database.list_collection_names(
-            namespace=data_api_credentials_info["secondary_namespace"]
+            keyspace=data_api_credentials_info["secondary_namespace"]
         )
 
     @async_fail_if_not_removed
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
     @pytest.mark.describe("test of Database use_namespace, async")
     async def test_database_use_namespace_async(
@@ -282,30 +280,30 @@ class TestDDLAsync:
         assert TEST_COLLECTION_NAME not in await at_database.list_collection_names()
 
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
-    @pytest.mark.describe("test of cross-namespace collection lifecycle, async")
-    async def test_collection_namespace_async(
+    @pytest.mark.describe("test of cross-keyspace collection lifecycle, async")
+    async def test_collection_keyspace_async(
         self,
         async_database: AsyncDatabase,
         client: DataAPIClient,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
-        TEST_LOCAL_COLLECTION_NAME1 = "test_crossns_coll1"
-        TEST_LOCAL_COLLECTION_NAME2 = "test_crossns_coll2"
+        TEST_LOCAL_COLLECTION_NAME1 = "test_crossks_coll1"
+        TEST_LOCAL_COLLECTION_NAME2 = "test_crossks_coll2"
         database_on_secondary = client.get_async_database(
             data_api_credentials_kwargs["api_endpoint"],
             token=data_api_credentials_kwargs["token"],
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         await async_database.create_collection(
             TEST_LOCAL_COLLECTION_NAME1,
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         col2_on_secondary = await async_database.create_collection(
             TEST_LOCAL_COLLECTION_NAME2,
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         assert (
             TEST_LOCAL_COLLECTION_NAME1
@@ -333,9 +331,9 @@ class TestDDLAsync:
         )
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["count"], int)
-        cmd2 = await async_database._copy(namespace="...").command(
+        cmd2 = await async_database._copy(keyspace="...").command(
             {"countDocuments": {}},
-            namespace=async_collection.keyspace,
+            keyspace=async_collection.keyspace,
             collection_name=async_collection.name,
         )
         assert cmd2 == cmd1
@@ -348,8 +346,8 @@ class TestDDLAsync:
         cmd1 = await async_database.command({"findCollections": {}})
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["collections"], list)
-        cmd2 = await async_database._copy(namespace="...").command(
-            {"findCollections": {}}, namespace=async_database.keyspace
+        cmd2 = await async_database._copy(keyspace="...").command(
+            {"findCollections": {}}, keyspace=async_database.keyspace
         )
         assert cmd2 == cmd1
 
@@ -374,16 +372,16 @@ class TestDDLAsync:
         a_database = client.get_async_database(
             api_endpoint,
             token=token,
-            namespace=data_api_credentials_kwargs["namespace"],
+            keyspace=data_api_credentials_kwargs["namespace"],
         )
         coll_names = await a_database.list_collection_names()
         assert isinstance(coll_names, list)
 
     @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
     @pytest.mark.describe(
-        "test database-from-admin default namespace per environment, async"
+        "test database-from-admin default keyspace per environment, async"
     )
-    async def test_database_from_admin_default_namespace_per_environment_async(
+    async def test_database_from_admin_default_keyspace_per_environment_async(
         self,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
@@ -392,17 +390,17 @@ class TestDDLAsync:
         admin = client.get_admin(token=data_api_credentials_kwargs["token"])
         db_m = admin.get_async_database(
             data_api_credentials_kwargs["api_endpoint"],
-            namespace="M",
+            keyspace="M",
         )
-        assert db_m.namespace == "M"
+        assert db_m.keyspace == "M"
         db_n = admin.get_async_database(data_api_credentials_kwargs["api_endpoint"])
-        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+        assert isinstance(db_n.keyspace, str)  # i.e. resolution took place
 
     @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
     @pytest.mark.describe(
-        "test database-from-astradbadmin default namespace per environment, async"
+        "test database-from-astradbadmin default keyspace per environment, async"
     )
-    async def test_database_from_astradbadmin_default_namespace_per_environment_async(
+    async def test_database_from_astradbadmin_default_keyspace_per_environment_async(
         self,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
@@ -410,7 +408,7 @@ class TestDDLAsync:
         client = DataAPIClient(environment=data_api_credentials_info["environment"])
         admin = client.get_admin(token=data_api_credentials_kwargs["token"])
         db_admin = admin.get_database_admin(data_api_credentials_kwargs["api_endpoint"])
-        db_m = db_admin.get_async_database(namespace="M")
-        assert db_m.namespace == "M"
+        db_m = db_admin.get_async_database(keyspace="M")
+        assert db_m.keyspace == "M"
         db_n = db_admin.get_async_database()
-        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+        assert isinstance(db_n.keyspace, str)  # i.e. resolution took place

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -198,7 +198,7 @@ class TestDDLSync:
         sync_collection: Collection,
     ) -> None:
         info = sync_collection.info()
-        assert info.namespace == sync_collection.namespace
+        assert info.namespace == sync_collection.keyspace
         assert info.namespace == sync_collection.database.namespace
 
     @pytest.mark.describe("test of Database list_collections, sync")
@@ -249,7 +249,7 @@ class TestDDLSync:
         assert t_database.namespace == data_api_credentials_kwargs["namespace"]
         assert TEST_COLLECTION_NAME in t_database.list_collection_names()
 
-        t_database.use_namespace(data_api_credentials_info["secondary_namespace"])  # type: ignore[arg-type]
+        t_database.use_namespace(data_api_credentials_info["secondary_namespace"])
         assert t_database != sync_database
         assert t_database.namespace == data_api_credentials_info["secondary_namespace"]
         assert TEST_COLLECTION_NAME not in t_database.list_collection_names()
@@ -307,7 +307,7 @@ class TestDDLSync:
         assert isinstance(cmd1["status"]["count"], int)
         cmd2 = sync_database._copy(namespace="...").command(
             {"countDocuments": {}},
-            namespace=sync_collection.namespace,
+            namespace=sync_collection.keyspace,
             collection_name=sync_collection.name,
         )
         assert cmd2 == cmd1
@@ -321,7 +321,7 @@ class TestDDLSync:
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["collections"], list)
         cmd2 = sync_database._copy(namespace="...").command(
-            {"findCollections": {}}, namespace=sync_database.namespace
+            {"findCollections": {}}, namespace=sync_database.keyspace
         )
         assert cmd2 == cmd1
 

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -188,7 +188,7 @@ class TestDDLSync:
     ) -> None:
         assert isinstance(sync_database.id, str)
         assert isinstance(sync_database.name(), str)
-        assert sync_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert sync_database.keyspace == data_api_credentials_kwargs["namespace"]
         assert isinstance(sync_database.info(), DatabaseInfo)
         assert isinstance(sync_database.info().raw_info, dict)
 
@@ -248,12 +248,12 @@ class TestDDLSync:
         # make a copy to avoid mutating the fixture
         t_database = sync_database._copy()
         assert t_database == sync_database
-        assert t_database.namespace == data_api_credentials_kwargs["namespace"]
+        assert t_database.keyspace == data_api_credentials_kwargs["namespace"]
         assert TEST_COLLECTION_NAME in t_database.list_collection_names()
 
         t_database.use_namespace(data_api_credentials_info["secondary_namespace"])
         assert t_database != sync_database
-        assert t_database.namespace == data_api_credentials_info["secondary_namespace"]
+        assert t_database.keyspace == data_api_credentials_info["secondary_namespace"]
         assert TEST_COLLECTION_NAME not in t_database.list_collection_names()
 
     @pytest.mark.skipif(

--- a/tests/idiomatic/integration/test_ddl_sync.py
+++ b/tests/idiomatic/integration/test_ddl_sync.py
@@ -199,8 +199,8 @@ class TestDDLSync:
         sync_collection: Collection,
     ) -> None:
         info = sync_collection.info()
-        assert info.namespace == sync_collection.keyspace
-        assert info.namespace == sync_collection.database.namespace
+        assert info.keyspace == sync_collection.keyspace
+        assert info.keyspace == sync_collection.database.keyspace
 
     @pytest.mark.describe("test of Database list_collections, sync")
     def test_database_list_collections_sync(
@@ -220,22 +220,22 @@ class TestDDLSync:
         assert options.vector.dimension == 2
 
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
-    @pytest.mark.describe("test of Database list_collections on cross-namespaces, sync")
-    def test_database_list_collections_cross_namespace_sync(
+    @pytest.mark.describe("test of Database list_collections on cross-keyspaces, sync")
+    def test_database_list_collections_cross_keyspace_sync(
         self,
         sync_database: Database,
         sync_collection: Collection,
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
         assert TEST_COLLECTION_NAME not in sync_database.list_collection_names(
-            namespace=data_api_credentials_info["secondary_namespace"]
+            keyspace=data_api_credentials_info["secondary_namespace"]
         )
 
     @sync_fail_if_not_removed
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
     @pytest.mark.describe("test of Database use_namespace, sync")
     def test_database_use_namespace_sync(
@@ -279,30 +279,30 @@ class TestDDLSync:
         assert TEST_COLLECTION_NAME not in t_database.list_collection_names()
 
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
-    @pytest.mark.describe("test of cross-namespace collection lifecycle, sync")
-    def test_collection_namespace_sync(
+    @pytest.mark.describe("test of cross-keyspace collection lifecycle, sync")
+    def test_collection_keyspace_sync(
         self,
         sync_database: Database,
         client: DataAPIClient,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
-        TEST_LOCAL_COLLECTION_NAME1 = "test_crossns_coll1"
-        TEST_LOCAL_COLLECTION_NAME2 = "test_crossns_coll2"
+        TEST_LOCAL_COLLECTION_NAME1 = "test_crossks_coll1"
+        TEST_LOCAL_COLLECTION_NAME2 = "test_crossks_coll2"
         database_on_secondary = client.get_database(
             data_api_credentials_kwargs["api_endpoint"],
             token=data_api_credentials_kwargs["token"],
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         sync_database.create_collection(
             TEST_LOCAL_COLLECTION_NAME1,
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         col2_on_secondary = sync_database.create_collection(
             TEST_LOCAL_COLLECTION_NAME2,
-            namespace=data_api_credentials_info["secondary_namespace"],
+            keyspace=data_api_credentials_info["secondary_namespace"],
         )
         assert (
             TEST_LOCAL_COLLECTION_NAME1 in database_on_secondary.list_collection_names()
@@ -329,9 +329,9 @@ class TestDDLSync:
         )
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["count"], int)
-        cmd2 = sync_database._copy(namespace="...").command(
+        cmd2 = sync_database._copy(keyspace="...").command(
             {"countDocuments": {}},
-            namespace=sync_collection.keyspace,
+            keyspace=sync_collection.keyspace,
             collection_name=sync_collection.name,
         )
         assert cmd2 == cmd1
@@ -344,8 +344,8 @@ class TestDDLSync:
         cmd1 = sync_database.command({"findCollections": {}})
         assert isinstance(cmd1, dict)
         assert isinstance(cmd1["status"]["collections"], list)
-        cmd2 = sync_database._copy(namespace="...").command(
-            {"findCollections": {}}, namespace=sync_database.keyspace
+        cmd2 = sync_database._copy(keyspace="...").command(
+            {"findCollections": {}}, keyspace=sync_database.keyspace
         )
         assert cmd2 == cmd1
 
@@ -370,7 +370,7 @@ class TestDDLSync:
         database = client.get_database(
             api_endpoint,
             token=token,
-            namespace=data_api_credentials_kwargs["namespace"],
+            keyspace=data_api_credentials_kwargs["namespace"],
         )
         assert isinstance(database.list_collection_names(), list)
 
@@ -400,9 +400,9 @@ class TestDDLSync:
         # auto-region for get_database
         assert adm.get_database(
             parsed_api_endpoint.database_id,
-            namespace="the_ns",
+            keyspace="the_ks",
         ) == adm.get_database(
-            data_api_credentials_kwargs["api_endpoint"], namespace="the_ns"
+            data_api_credentials_kwargs["api_endpoint"], keyspace="the_ks"
         )
 
         # auto-region for the init of AstraDBDatabaseAdmin
@@ -418,9 +418,9 @@ class TestDDLSync:
 
     @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
     @pytest.mark.describe(
-        "test database-from-admin default namespace per environment, sync"
+        "test database-from-admin default keyspace per environment, sync"
     )
-    def test_database_from_admin_default_namespace_per_environment_sync(
+    def test_database_from_admin_default_keyspace_per_environment_sync(
         self,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
@@ -429,17 +429,17 @@ class TestDDLSync:
         admin = client.get_admin(token=data_api_credentials_kwargs["token"])
         db_m = admin.get_database(
             data_api_credentials_kwargs["api_endpoint"],
-            namespace="M",
+            keyspace="M",
         )
-        assert db_m.namespace == "M"
+        assert db_m.keyspace == "M"
         db_n = admin.get_database(data_api_credentials_kwargs["api_endpoint"])
-        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+        assert isinstance(db_n.keyspace, str)  # i.e. resolution took place
 
     @pytest.mark.skipif(not IS_ASTRA_DB, reason="Not supported outside of Astra DB")
     @pytest.mark.describe(
-        "test database-from-astradbadmin default namespace per environment, sync"
+        "test database-from-astradbadmin default keyspace per environment, sync"
     )
-    def test_database_from_astradbadmin_default_namespace_per_environment_sync(
+    def test_database_from_astradbadmin_default_keyspace_per_environment_sync(
         self,
         data_api_credentials_kwargs: DataAPICredentials,
         data_api_credentials_info: DataAPICredentialsInfo,
@@ -447,7 +447,7 @@ class TestDDLSync:
         client = DataAPIClient(environment=data_api_credentials_info["environment"])
         admin = client.get_admin(token=data_api_credentials_kwargs["token"])
         db_admin = admin.get_database_admin(data_api_credentials_kwargs["api_endpoint"])
-        db_m = db_admin.get_database(namespace="M")
-        assert db_m.namespace == "M"
+        db_m = db_admin.get_database(keyspace="M")
+        assert db_m.keyspace == "M"
         db_n = db_admin.get_database()
-        assert isinstance(db_n.namespace, str)  # i.e. resolution took place
+        assert isinstance(db_n.keyspace, str)  # i.e. resolution took place

--- a/tests/idiomatic/integration/test_dml_async.py
+++ b/tests/idiomatic/integration/test_dml_async.py
@@ -1481,6 +1481,7 @@ class TestDMLAsync:
         assert set(resp_pr2.keys()) == {"f"}
         await acol.delete_many({})
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of ordered bulk_write, async")
     async def test_collection_ordered_bulk_write_async(
         self,
@@ -1521,6 +1522,7 @@ class TestDMLAsync:
         assert len(found_docs[0]) == 3
         assert found_docs[1] == {"_id": "seq4", "from_upsert": True}
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of unordered bulk_write, async")
     async def test_collection_unordered_bulk_write_async(
         self,
@@ -1551,6 +1553,7 @@ class TestDMLAsync:
         assert {"a": 1} in no_id_found_docs
         assert {"b": 1, "newfield": True} in no_id_found_docs
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write with vectors, async")
     async def test_collection_bulk_write_vector_async(
         self,

--- a/tests/idiomatic/integration/test_dml_sync.py
+++ b/tests/idiomatic/integration/test_dml_sync.py
@@ -1372,6 +1372,7 @@ class TestDMLSync:
         assert set(resp_pr2.keys()) == {"f"}
         col.delete_many({})
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of ordered bulk_write, sync")
     def test_collection_ordered_bulk_write_sync(
         self,
@@ -1412,6 +1413,7 @@ class TestDMLSync:
         assert len(found_docs[0]) == 3
         assert found_docs[1] == {"_id": "seq4", "from_upsert": True}
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of unordered bulk_write, sync")
     def test_collection_unordered_bulk_write_sync(
         self,
@@ -1442,6 +1444,7 @@ class TestDMLSync:
         assert {"a": 1} in no_id_found_docs
         assert {"b": 1, "newfield": True} in no_id_found_docs
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write with vectors, sync")
     def test_collection_bulk_write_vector_sync(
         self,

--- a/tests/idiomatic/integration/test_exceptions_async.py
+++ b/tests/idiomatic/integration/test_exceptions_async.py
@@ -151,7 +151,7 @@ class TestExceptionsAsync:
         with pytest.raises(CollectionNotFoundException) as exc:
             await acol.options()
         assert exc.value.collection_name == acol._name
-        assert exc.value.namespace == async_empty_collection.namespace
+        assert exc.value.namespace == async_empty_collection.keyspace
 
     @pytest.mark.describe("test of collection count_documents failure modes, async")
     async def test_collection_count_documents_failures_async(

--- a/tests/idiomatic/integration/test_exceptions_async.py
+++ b/tests/idiomatic/integration/test_exceptions_async.py
@@ -33,7 +33,7 @@ from astrapy.exceptions import (
 )
 from astrapy.operations import AsyncInsertOne
 
-from ..conftest import IS_ASTRA_DB, DataAPICredentials
+from ..conftest import IS_ASTRA_DB, DataAPICredentials, async_fail_if_not_removed
 
 
 class TestExceptionsAsync:
@@ -193,6 +193,7 @@ class TestExceptionsAsync:
         with pytest.raises(DataAPIResponseException):
             await acol.update_one({"a": 1}, {"$set": {"a": -1}})
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of exceptions in ordered bulk_write, async")
     async def test_ordered_bulk_write_failures_async(
         self,
@@ -212,6 +213,7 @@ class TestExceptionsAsync:
         assert exc.value.partial_result.upserted_ids == {}
         assert await async_empty_collection.count_documents({}, upper_bound=10) == 1
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of hard exceptions in ordered bulk_write, async")
     async def test_ordered_bulk_write_error_async(
         self,
@@ -223,6 +225,7 @@ class TestExceptionsAsync:
         with pytest.raises(TypeError):
             await async_empty_collection.bulk_write([i1, i2])
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of exceptions in unordered bulk_write, async")
     async def test_unordered_bulk_write_failures_async(
         self,
@@ -243,6 +246,7 @@ class TestExceptionsAsync:
         assert exc.value.partial_result.upserted_ids == {}
         assert await async_empty_collection.count_documents({}, upper_bound=10) == 2
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of hard exceptions in unordered bulk_write, async")
     async def test_unordered_bulk_write_error_async(
         self,

--- a/tests/idiomatic/integration/test_exceptions_async.py
+++ b/tests/idiomatic/integration/test_exceptions_async.py
@@ -151,7 +151,7 @@ class TestExceptionsAsync:
         with pytest.raises(CollectionNotFoundException) as exc:
             await acol.options()
         assert exc.value.collection_name == acol._name
-        assert exc.value.namespace == async_empty_collection.keyspace
+        assert exc.value.keyspace == async_empty_collection.keyspace
 
     @pytest.mark.describe("test of collection count_documents failure modes, async")
     async def test_collection_count_documents_failures_async(
@@ -298,27 +298,27 @@ class TestExceptionsAsync:
         self,
         async_database: AsyncDatabase,
     ) -> None:
-        f_database = async_database._copy(namespace="nonexisting")
+        f_database = async_database._copy(keyspace="nonexisting")
         if IS_ASTRA_DB:
             with pytest.raises(DataAPIResponseException):
                 await f_database.drop_collection("nonexisting")
         with pytest.raises(DataAPIResponseException):
             await async_database.command(body={"myCommand": {"k": "v"}})
         with pytest.raises(DataAPIResponseException):
-            await async_database.command(body={"myCommand": {"k": "v"}}, namespace="ns")
+            await async_database.command(body={"myCommand": {"k": "v"}}, keyspace="ns")
         with pytest.raises(DataAPIResponseException):
             await async_database.command(
-                body={"myCommand": {"k": "v"}}, namespace="ns", collection_name="coll"
+                body={"myCommand": {"k": "v"}}, keyspace="ns", collection_name="coll"
             )
         with pytest.raises(DataAPIResponseException):
             [
                 coll
                 async for coll in async_database.list_collections(
-                    namespace="nonexisting"
+                    keyspace="nonexisting"
                 )
             ]
         with pytest.raises(DataAPIResponseException):
-            await async_database.list_collection_names(namespace="nonexisting")
+            await async_database.list_collection_names(keyspace="nonexisting")
 
     @pytest.mark.describe("test of database info failures, async")
     async def test_get_database_info_failures_async(
@@ -326,9 +326,9 @@ class TestExceptionsAsync:
         async_database: AsyncDatabase,
         data_api_credentials_kwargs: DataAPICredentials,
     ) -> None:
-        hacked_ns = (data_api_credentials_kwargs["namespace"] or "") + "_hacked"
+        hacked_ks = (data_api_credentials_kwargs["namespace"] or "") + "_hacked"
         with pytest.raises(DevOpsAPIException):
-            async_database._copy(namespace=hacked_ns).info()
+            async_database._copy(keyspace=hacked_ks).info()
 
     @pytest.mark.describe("test of hard exceptions in cursors, async")
     async def test_cursor_hard_exceptions_async(
@@ -372,7 +372,7 @@ class TestExceptionsAsync:
         self,
         async_empty_collection: AsyncCollection,
     ) -> None:
-        awcol = async_empty_collection._copy(namespace="nonexisting")
+        awcol = async_empty_collection._copy(keyspace="nonexisting")
         cur1 = awcol.find({})
         cur2 = awcol.find({})
         cur3 = awcol.find({})
@@ -399,7 +399,7 @@ class TestExceptionsAsync:
         async_database: AsyncDatabase,
     ) -> None:
         with pytest.raises(DataAPIResponseException):
-            async_database.list_collections(namespace="nonexisting")
+            async_database.list_collections(keyspace="nonexisting")
 
         cur1 = async_database.list_collections()
         [doc async for doc in cur1]

--- a/tests/idiomatic/integration/test_exceptions_sync.py
+++ b/tests/idiomatic/integration/test_exceptions_sync.py
@@ -141,7 +141,7 @@ class TestExceptionsSync:
         with pytest.raises(CollectionNotFoundException) as exc:
             col.options()
         assert exc.value.collection_name == col._name
-        assert exc.value.namespace == sync_empty_collection.namespace
+        assert exc.value.namespace == sync_empty_collection.keyspace
 
     @pytest.mark.describe("test of collection count_documents failure modes, sync")
     def test_collection_count_documents_failures_sync(

--- a/tests/idiomatic/integration/test_exceptions_sync.py
+++ b/tests/idiomatic/integration/test_exceptions_sync.py
@@ -29,7 +29,7 @@ from astrapy.exceptions import (
 )
 from astrapy.operations import InsertOne
 
-from ..conftest import IS_ASTRA_DB, DataAPICredentials
+from ..conftest import IS_ASTRA_DB, DataAPICredentials, sync_fail_if_not_removed
 
 
 class TestExceptionsSync:
@@ -183,6 +183,7 @@ class TestExceptionsSync:
         with pytest.raises(DataAPIResponseException):
             col.update_one({"a": 1}, {"$set": {"a": -1}})
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of exceptions in ordered bulk_write, sync")
     def test_ordered_bulk_write_failures_sync(
         self,
@@ -202,6 +203,7 @@ class TestExceptionsSync:
         assert exc.value.partial_result.upserted_ids == {}
         assert sync_empty_collection.count_documents({}, upper_bound=10) == 1
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of hard exceptions in ordered bulk_write, sync")
     def test_ordered_bulk_write_error_sync(
         self,
@@ -213,6 +215,7 @@ class TestExceptionsSync:
         with pytest.raises(TypeError):
             sync_empty_collection.bulk_write([i1, i2])
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of exceptions in unordered bulk_write, sync")
     def test_unordered_bulk_write_failures_sync(
         self,
@@ -233,6 +236,7 @@ class TestExceptionsSync:
         assert exc.value.partial_result.upserted_ids == {}
         assert sync_empty_collection.count_documents({}, upper_bound=10) == 2
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of hard exceptions in unordered bulk_write, sync")
     def test_unordered_bulk_write_error_sync(
         self,

--- a/tests/idiomatic/integration/test_exceptions_sync.py
+++ b/tests/idiomatic/integration/test_exceptions_sync.py
@@ -141,7 +141,7 @@ class TestExceptionsSync:
         with pytest.raises(CollectionNotFoundException) as exc:
             col.options()
         assert exc.value.collection_name == col._name
-        assert exc.value.namespace == sync_empty_collection.keyspace
+        assert exc.value.keyspace == sync_empty_collection.keyspace
 
     @pytest.mark.describe("test of collection count_documents failure modes, sync")
     def test_collection_count_documents_failures_sync(
@@ -288,22 +288,22 @@ class TestExceptionsSync:
         self,
         sync_database: Database,
     ) -> None:
-        f_database = sync_database._copy(namespace="nonexisting")
+        f_database = sync_database._copy(keyspace="nonexisting")
         if IS_ASTRA_DB:
             with pytest.raises(DataAPIResponseException):
                 f_database.drop_collection("nonexisting")
         with pytest.raises(DataAPIResponseException):
             sync_database.command(body={"myCommand": {"k": "v"}})
         with pytest.raises(DataAPIResponseException):
-            sync_database.command(body={"myCommand": {"k": "v"}}, namespace="ns")
+            sync_database.command(body={"myCommand": {"k": "v"}}, keyspace="ns")
         with pytest.raises(DataAPIResponseException):
             sync_database.command(
-                body={"myCommand": {"k": "v"}}, namespace="ns", collection_name="coll"
+                body={"myCommand": {"k": "v"}}, keyspace="ns", collection_name="coll"
             )
         with pytest.raises(DataAPIResponseException):
-            list(sync_database.list_collections(namespace="nonexisting"))
+            list(sync_database.list_collections(keyspace="nonexisting"))
         with pytest.raises(DataAPIResponseException):
-            sync_database.list_collection_names(namespace="nonexisting")
+            sync_database.list_collection_names(keyspace="nonexisting")
 
     @pytest.mark.describe("test of database info failures, sync")
     def test_get_database_info_failures_sync(
@@ -311,9 +311,9 @@ class TestExceptionsSync:
         sync_database: Database,
         data_api_credentials_kwargs: DataAPICredentials,
     ) -> None:
-        hacked_ns = (data_api_credentials_kwargs["namespace"] or "") + "_hacked"
+        hacked_ks = (data_api_credentials_kwargs["namespace"] or "") + "_hacked"
         with pytest.raises(DevOpsAPIException):
-            sync_database._copy(namespace=hacked_ns).info()
+            sync_database._copy(keyspace=hacked_ks).info()
 
     @pytest.mark.describe("test of hard exceptions in cursors, sync")
     def test_cursor_hard_exceptions_sync(
@@ -357,7 +357,7 @@ class TestExceptionsSync:
         self,
         sync_empty_collection: Collection,
     ) -> None:
-        wcol = sync_empty_collection._copy(namespace="nonexisting")
+        wcol = sync_empty_collection._copy(keyspace="nonexisting")
         cur1 = wcol.find({})
         cur2 = wcol.find({})
         cur3 = wcol.find({})
@@ -384,7 +384,7 @@ class TestExceptionsSync:
         sync_database: Database,
     ) -> None:
         with pytest.raises(DataAPIResponseException):
-            sync_database.list_collections(namespace="nonexisting")
+            sync_database.list_collections(keyspace="nonexisting")
 
         cur1 = sync_database.list_collections()
         list(cur1)

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -18,16 +18,24 @@ import pytest
 
 from astrapy import AsyncDatabase, Database
 
-from ..conftest import DO_IDIOMATIC_ADMIN_TESTS, IS_ASTRA_DB
+from ..conftest import (
+    DO_IDIOMATIC_ADMIN_TESTS,
+    IS_ASTRA_DB,
+    async_fail_if_not_removed,
+    sync_fail_if_not_removed,
+)
 
 
 @pytest.mark.skipif(IS_ASTRA_DB, reason="Not supported on Astra DB")
 @pytest.mark.skipif(not DO_IDIOMATIC_ADMIN_TESTS, reason="Admin tests are suppressed")
 class TestNonAstraAdmin:
+    @sync_fail_if_not_removed
     @pytest.mark.describe(
         "test of the namespace crud with non-Astra DataAPIDatabaseAdmin, sync"
     )
-    def test_nonastra_database_admin_sync(self, sync_database: Database) -> None:
+    def test_nonastra_database_admin_namespaces_sync(
+        self, sync_database: Database
+    ) -> None:
         """
         Test plan
         - database -> get_database_admin
@@ -38,6 +46,7 @@ class TestNonAstraAdmin:
             - drop namespace
             - list namespaces, check
             - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+        This version runs the deprecated 'namespace' commands
         """
         NEW_NS_NAME = "tnaa_test_ns_s"
         NEW_COLL_NAME = "tnaa_test_coll"
@@ -79,10 +88,11 @@ class TestNonAstraAdmin:
         database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
         database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
 
+    @async_fail_if_not_removed
     @pytest.mark.describe(
         "test of the namespace crud with non-Astra DataAPIDatabaseAdmin, async"
     )
-    async def test_nonastra_database_admin_async(
+    async def test_nonastra_database_admin_namespaces_async(
         self, async_database: AsyncDatabase
     ) -> None:
         """
@@ -95,6 +105,7 @@ class TestNonAstraAdmin:
             - drop namespace
             - list namespaces, check
             - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+        This version runs the deprecated 'namespace' commands
         """
         NEW_NS_NAME = "tnaa_test_ns_a"
         NEW_COLL_NAME = "tnaa_test_coll"
@@ -137,3 +148,121 @@ class TestNonAstraAdmin:
 
         await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
         await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the keyspace crud with non-Astra DataAPIDatabaseAdmin, sync"
+    )
+    def test_nonastra_database_admin_keyspaces_sync(
+        self, sync_database: Database
+    ) -> None:
+        """
+        Test plan
+        - database -> get_database_admin
+            - list keyspaces, check name not there
+            - create a keyspace
+            - list keyspaces, check
+            - database -> create_collection/list_collection_names
+            - drop keyspace
+            - list keyspaces, check
+            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+        This version uses v2.0-compliant 'keyspace' method names
+        """
+        NEW_NS_NAME = "tnaa_test_ns_s"
+        NEW_COLL_NAME = "tnaa_test_coll"
+        database_admin = sync_database.get_database_admin()
+
+        keyspaces1 = set(database_admin.list_keyspaces())
+        assert NEW_NS_NAME not in keyspaces1
+
+        create_response = database_admin.create_keyspace(NEW_NS_NAME)
+        assert create_response == {"ok": 1}
+
+        keyspaces2 = set(database_admin.list_keyspaces())
+        assert NEW_NS_NAME in keyspaces2
+
+        sync_database_ns = sync_database.with_options(namespace=NEW_NS_NAME)
+        sync_database_ns.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in sync_database_ns.list_collection_names()
+
+        drop_response = database_admin.drop_keyspace(NEW_NS_NAME)
+        assert drop_response == {"ok": 1}
+
+        keyspaces3 = set(database_admin.list_keyspaces())
+        assert keyspaces3 == keyspaces1
+
+        # update_db_namespace:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        database = sync_database._copy()
+
+        keyspace0 = database.keyspace
+        database_admin = database.get_database_admin()
+        database_admin.create_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        assert database.keyspace == keyspace0
+
+        database_admin.create_keyspace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        assert database.keyspace == NEW_NS_NAME_UPDATED
+
+        database_admin.drop_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.drop_keyspace(NEW_NS_NAME_UPDATED)
+
+    @pytest.mark.describe(
+        "test of the keyspace crud with non-Astra DataAPIDatabaseAdmin, async"
+    )
+    async def test_nonastra_database_admin_keyspaces_async(
+        self, async_database: AsyncDatabase
+    ) -> None:
+        """
+        Test plan
+        - database -> get_database_admin
+            - list keyspaces, check name not there
+            - create a keyspace
+            - list keyspaces, check
+            - database -> create_collection/list_collection_names
+            - drop keyspace
+            - list keyspaces, check
+            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+        This version uses v2.0-compliant 'keyspace' method names
+        """
+        NEW_NS_NAME = "tnaa_test_ns_a"
+        NEW_COLL_NAME = "tnaa_test_coll"
+        database_admin = async_database.get_database_admin()
+
+        keyspaces1 = set(await database_admin.async_list_keyspaces())
+        assert NEW_NS_NAME not in keyspaces1
+
+        create_response = await database_admin.async_create_keyspace(NEW_NS_NAME)
+        assert create_response == {"ok": 1}
+
+        keyspaces2 = set(await database_admin.async_list_keyspaces())
+        assert NEW_NS_NAME in keyspaces2
+
+        async_database_ns = async_database.with_options(namespace=NEW_NS_NAME)
+        await async_database_ns.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in (await async_database_ns.list_collection_names())
+
+        drop_response = await database_admin.async_drop_keyspace(NEW_NS_NAME)
+        assert drop_response == {"ok": 1}
+
+        keyspaces3 = set(await database_admin.async_list_keyspaces())
+        assert keyspaces3 == keyspaces1
+
+        # update_db_namespace:
+        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_NS_NAME_UPDATED = "tnudn_upd"
+
+        adatabase = async_database._copy()
+
+        keyspace0 = adatabase.keyspace
+        database_admin = adatabase.get_database_admin()
+        await database_admin.async_create_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        assert adatabase.keyspace == keyspace0
+
+        await database_admin.async_create_keyspace(
+            NEW_NS_NAME_UPDATED, update_db_namespace=True
+        )
+        assert adatabase.keyspace == NEW_NS_NAME_UPDATED
+
+        await database_admin.async_drop_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_NS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -82,7 +82,11 @@ class TestNonAstraAdmin:
         database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
         assert database.namespace == namespace0
 
-        database_admin.create_namespace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        with pytest.warns(DeprecationWarning):
+            database_admin.create_namespace(
+                NEW_NS_NAME_UPDATED,
+                update_db_namespace=True,
+            )
         assert database.namespace == NEW_NS_NAME_UPDATED
 
         database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
@@ -141,9 +145,10 @@ class TestNonAstraAdmin:
         await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
         assert adatabase.namespace == namespace0
 
-        await database_admin.async_create_namespace(
-            NEW_NS_NAME_UPDATED, update_db_namespace=True
-        )
+        with pytest.warns(DeprecationWarning):
+            await database_admin.async_create_namespace(
+                NEW_NS_NAME_UPDATED, update_db_namespace=True
+            )
         assert adatabase.namespace == NEW_NS_NAME_UPDATED
 
         await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
@@ -164,7 +169,7 @@ class TestNonAstraAdmin:
             - database -> create_collection/list_collection_names
             - drop keyspace
             - list keyspaces, check
-            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+            - ALSO: test the update_db_keyspace flag when creating from db->dbadmin
         This version uses v2.0-compliant 'keyspace' method names
         """
         NEW_NS_NAME = "tnaa_test_ns_s"
@@ -190,7 +195,7 @@ class TestNonAstraAdmin:
         keyspaces3 = set(database_admin.list_keyspaces())
         assert keyspaces3 == keyspaces1
 
-        # update_db_namespace:
+        # update_db_keyspace:
         NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
         NEW_NS_NAME_UPDATED = "tnudn_upd"
 
@@ -201,7 +206,7 @@ class TestNonAstraAdmin:
         database_admin.create_keyspace(NEW_NS_NAME_NOT_UPDATED)
         assert database.keyspace == keyspace0
 
-        database_admin.create_keyspace(NEW_NS_NAME_UPDATED, update_db_namespace=True)
+        database_admin.create_keyspace(NEW_NS_NAME_UPDATED, update_db_keyspace=True)
         assert database.keyspace == NEW_NS_NAME_UPDATED
 
         database_admin.drop_keyspace(NEW_NS_NAME_NOT_UPDATED)
@@ -222,7 +227,7 @@ class TestNonAstraAdmin:
             - database -> create_collection/list_collection_names
             - drop keyspace
             - list keyspaces, check
-            - ALSO: test the update_db_namespace flag when creating from db->dbadmin
+            - ALSO: test the update_db_keyspace flag when creating from db->dbadmin
         This version uses v2.0-compliant 'keyspace' method names
         """
         NEW_NS_NAME = "tnaa_test_ns_a"
@@ -248,7 +253,7 @@ class TestNonAstraAdmin:
         keyspaces3 = set(await database_admin.async_list_keyspaces())
         assert keyspaces3 == keyspaces1
 
-        # update_db_namespace:
+        # update_db_keyspace:
         NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
         NEW_NS_NAME_UPDATED = "tnudn_upd"
 
@@ -260,7 +265,7 @@ class TestNonAstraAdmin:
         assert adatabase.keyspace == keyspace0
 
         await database_admin.async_create_keyspace(
-            NEW_NS_NAME_UPDATED, update_db_namespace=True
+            NEW_NS_NAME_UPDATED, update_db_keyspace=True
         )
         assert adatabase.keyspace == NEW_NS_NAME_UPDATED
 

--- a/tests/idiomatic/integration/test_nonastra_admin.py
+++ b/tests/idiomatic/integration/test_nonastra_admin.py
@@ -48,49 +48,49 @@ class TestNonAstraAdmin:
             - ALSO: test the update_db_namespace flag when creating from db->dbadmin
         This version runs the deprecated 'namespace' commands
         """
-        NEW_NS_NAME = "tnaa_test_ns_s"
+        NEW_KS_NAME = "tnaa_test_ks_s"
         NEW_COLL_NAME = "tnaa_test_coll"
         database_admin = sync_database.get_database_admin()
 
         namespaces1 = set(database_admin.list_namespaces())
-        assert NEW_NS_NAME not in namespaces1
+        assert NEW_KS_NAME not in namespaces1
 
-        create_response = database_admin.create_namespace(NEW_NS_NAME)
+        create_response = database_admin.create_namespace(NEW_KS_NAME)
         assert create_response == {"ok": 1}
 
         namespaces2 = set(database_admin.list_namespaces())
-        assert NEW_NS_NAME in namespaces2
+        assert NEW_KS_NAME in namespaces2
 
-        sync_database_ns = sync_database.with_options(namespace=NEW_NS_NAME)
-        sync_database_ns.create_collection(NEW_COLL_NAME)
-        assert NEW_COLL_NAME in sync_database_ns.list_collection_names()
+        sync_database_ks = sync_database.with_options(namespace=NEW_KS_NAME)
+        sync_database_ks.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in sync_database_ks.list_collection_names()
 
-        drop_response = database_admin.drop_namespace(NEW_NS_NAME)
+        drop_response = database_admin.drop_namespace(NEW_KS_NAME)
         assert drop_response == {"ok": 1}
 
         namespaces3 = set(database_admin.list_namespaces())
         assert namespaces3 == namespaces1
 
         # update_db_namespace:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
         database = sync_database._copy()
 
         namespace0 = database.namespace
         database_admin = database.get_database_admin()
-        database_admin.create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.create_namespace(NEW_KS_NAME_NOT_UPDATED)
         assert database.namespace == namespace0
 
         with pytest.warns(DeprecationWarning):
             database_admin.create_namespace(
-                NEW_NS_NAME_UPDATED,
+                NEW_KS_NAME_UPDATED,
                 update_db_namespace=True,
             )
-        assert database.namespace == NEW_NS_NAME_UPDATED
+        assert database.namespace == NEW_KS_NAME_UPDATED
 
-        database_admin.drop_namespace(NEW_NS_NAME_NOT_UPDATED)
-        database_admin.drop_namespace(NEW_NS_NAME_UPDATED)
+        database_admin.drop_namespace(NEW_KS_NAME_NOT_UPDATED)
+        database_admin.drop_namespace(NEW_KS_NAME_UPDATED)
 
     @async_fail_if_not_removed
     @pytest.mark.describe(
@@ -111,48 +111,48 @@ class TestNonAstraAdmin:
             - ALSO: test the update_db_namespace flag when creating from db->dbadmin
         This version runs the deprecated 'namespace' commands
         """
-        NEW_NS_NAME = "tnaa_test_ns_a"
+        NEW_KS_NAME = "tnaa_test_ks_a"
         NEW_COLL_NAME = "tnaa_test_coll"
         database_admin = async_database.get_database_admin()
 
         namespaces1 = set(await database_admin.async_list_namespaces())
-        assert NEW_NS_NAME not in namespaces1
+        assert NEW_KS_NAME not in namespaces1
 
-        create_response = await database_admin.async_create_namespace(NEW_NS_NAME)
+        create_response = await database_admin.async_create_namespace(NEW_KS_NAME)
         assert create_response == {"ok": 1}
 
         namespaces2 = set(await database_admin.async_list_namespaces())
-        assert NEW_NS_NAME in namespaces2
+        assert NEW_KS_NAME in namespaces2
 
-        async_database_ns = async_database.with_options(namespace=NEW_NS_NAME)
-        await async_database_ns.create_collection(NEW_COLL_NAME)
-        assert NEW_COLL_NAME in (await async_database_ns.list_collection_names())
+        async_database_ks = async_database.with_options(namespace=NEW_KS_NAME)
+        await async_database_ks.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in (await async_database_ks.list_collection_names())
 
-        drop_response = await database_admin.async_drop_namespace(NEW_NS_NAME)
+        drop_response = await database_admin.async_drop_namespace(NEW_KS_NAME)
         assert drop_response == {"ok": 1}
 
         namespaces3 = set(await database_admin.async_list_namespaces())
         assert namespaces3 == namespaces1
 
         # update_db_namespace:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
         adatabase = async_database._copy()
 
         namespace0 = adatabase.namespace
         database_admin = adatabase.get_database_admin()
-        await database_admin.async_create_namespace(NEW_NS_NAME_NOT_UPDATED)
+        await database_admin.async_create_namespace(NEW_KS_NAME_NOT_UPDATED)
         assert adatabase.namespace == namespace0
 
         with pytest.warns(DeprecationWarning):
             await database_admin.async_create_namespace(
-                NEW_NS_NAME_UPDATED, update_db_namespace=True
+                NEW_KS_NAME_UPDATED, update_db_namespace=True
             )
-        assert adatabase.namespace == NEW_NS_NAME_UPDATED
+        assert adatabase.namespace == NEW_KS_NAME_UPDATED
 
-        await database_admin.async_drop_namespace(NEW_NS_NAME_NOT_UPDATED)
-        await database_admin.async_drop_namespace(NEW_NS_NAME_UPDATED)
+        await database_admin.async_drop_namespace(NEW_KS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_namespace(NEW_KS_NAME_UPDATED)
 
     @pytest.mark.describe(
         "test of the keyspace crud with non-Astra DataAPIDatabaseAdmin, sync"
@@ -172,45 +172,45 @@ class TestNonAstraAdmin:
             - ALSO: test the update_db_keyspace flag when creating from db->dbadmin
         This version uses v2.0-compliant 'keyspace' method names
         """
-        NEW_NS_NAME = "tnaa_test_ns_s"
+        NEW_KS_NAME = "tnaa_test_ks_s"
         NEW_COLL_NAME = "tnaa_test_coll"
         database_admin = sync_database.get_database_admin()
 
         keyspaces1 = set(database_admin.list_keyspaces())
-        assert NEW_NS_NAME not in keyspaces1
+        assert NEW_KS_NAME not in keyspaces1
 
-        create_response = database_admin.create_keyspace(NEW_NS_NAME)
+        create_response = database_admin.create_keyspace(NEW_KS_NAME)
         assert create_response == {"ok": 1}
 
         keyspaces2 = set(database_admin.list_keyspaces())
-        assert NEW_NS_NAME in keyspaces2
+        assert NEW_KS_NAME in keyspaces2
 
-        sync_database_ns = sync_database.with_options(namespace=NEW_NS_NAME)
-        sync_database_ns.create_collection(NEW_COLL_NAME)
-        assert NEW_COLL_NAME in sync_database_ns.list_collection_names()
+        sync_database_ks = sync_database.with_options(keyspace=NEW_KS_NAME)
+        sync_database_ks.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in sync_database_ks.list_collection_names()
 
-        drop_response = database_admin.drop_keyspace(NEW_NS_NAME)
+        drop_response = database_admin.drop_keyspace(NEW_KS_NAME)
         assert drop_response == {"ok": 1}
 
         keyspaces3 = set(database_admin.list_keyspaces())
         assert keyspaces3 == keyspaces1
 
         # update_db_keyspace:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
         database = sync_database._copy()
 
         keyspace0 = database.keyspace
         database_admin = database.get_database_admin()
-        database_admin.create_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        database_admin.create_keyspace(NEW_KS_NAME_NOT_UPDATED)
         assert database.keyspace == keyspace0
 
-        database_admin.create_keyspace(NEW_NS_NAME_UPDATED, update_db_keyspace=True)
-        assert database.keyspace == NEW_NS_NAME_UPDATED
+        database_admin.create_keyspace(NEW_KS_NAME_UPDATED, update_db_keyspace=True)
+        assert database.keyspace == NEW_KS_NAME_UPDATED
 
-        database_admin.drop_keyspace(NEW_NS_NAME_NOT_UPDATED)
-        database_admin.drop_keyspace(NEW_NS_NAME_UPDATED)
+        database_admin.drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        database_admin.drop_keyspace(NEW_KS_NAME_UPDATED)
 
     @pytest.mark.describe(
         "test of the keyspace crud with non-Astra DataAPIDatabaseAdmin, async"
@@ -230,44 +230,44 @@ class TestNonAstraAdmin:
             - ALSO: test the update_db_keyspace flag when creating from db->dbadmin
         This version uses v2.0-compliant 'keyspace' method names
         """
-        NEW_NS_NAME = "tnaa_test_ns_a"
+        NEW_KS_NAME = "tnaa_test_ks_a"
         NEW_COLL_NAME = "tnaa_test_coll"
         database_admin = async_database.get_database_admin()
 
         keyspaces1 = set(await database_admin.async_list_keyspaces())
-        assert NEW_NS_NAME not in keyspaces1
+        assert NEW_KS_NAME not in keyspaces1
 
-        create_response = await database_admin.async_create_keyspace(NEW_NS_NAME)
+        create_response = await database_admin.async_create_keyspace(NEW_KS_NAME)
         assert create_response == {"ok": 1}
 
         keyspaces2 = set(await database_admin.async_list_keyspaces())
-        assert NEW_NS_NAME in keyspaces2
+        assert NEW_KS_NAME in keyspaces2
 
-        async_database_ns = async_database.with_options(namespace=NEW_NS_NAME)
-        await async_database_ns.create_collection(NEW_COLL_NAME)
-        assert NEW_COLL_NAME in (await async_database_ns.list_collection_names())
+        async_database_ks = async_database.with_options(keyspace=NEW_KS_NAME)
+        await async_database_ks.create_collection(NEW_COLL_NAME)
+        assert NEW_COLL_NAME in (await async_database_ks.list_collection_names())
 
-        drop_response = await database_admin.async_drop_keyspace(NEW_NS_NAME)
+        drop_response = await database_admin.async_drop_keyspace(NEW_KS_NAME)
         assert drop_response == {"ok": 1}
 
         keyspaces3 = set(await database_admin.async_list_keyspaces())
         assert keyspaces3 == keyspaces1
 
         # update_db_keyspace:
-        NEW_NS_NAME_NOT_UPDATED = "tnudn_notupd"
-        NEW_NS_NAME_UPDATED = "tnudn_upd"
+        NEW_KS_NAME_NOT_UPDATED = "tnudn_notupd"
+        NEW_KS_NAME_UPDATED = "tnudn_upd"
 
         adatabase = async_database._copy()
 
         keyspace0 = adatabase.keyspace
         database_admin = adatabase.get_database_admin()
-        await database_admin.async_create_keyspace(NEW_NS_NAME_NOT_UPDATED)
+        await database_admin.async_create_keyspace(NEW_KS_NAME_NOT_UPDATED)
         assert adatabase.keyspace == keyspace0
 
         await database_admin.async_create_keyspace(
-            NEW_NS_NAME_UPDATED, update_db_keyspace=True
+            NEW_KS_NAME_UPDATED, update_db_keyspace=True
         )
-        assert adatabase.keyspace == NEW_NS_NAME_UPDATED
+        assert adatabase.keyspace == NEW_KS_NAME_UPDATED
 
-        await database_admin.async_drop_keyspace(NEW_NS_NAME_NOT_UPDATED)
-        await database_admin.async_drop_keyspace(NEW_NS_NAME_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_NOT_UPDATED)
+        await database_admin.async_drop_keyspace(NEW_KS_NAME_UPDATED)

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -53,7 +53,7 @@ class TestTimeoutAsync:
         info = await async_fetch_database_info(
             async_database.api_endpoint,
             token=async_database.token_provider.get_token(),
-            namespace=async_database.keyspace,
+            keyspace=async_database.keyspace,
         )
         assert info is not None
 
@@ -61,7 +61,7 @@ class TestTimeoutAsync:
             info = await async_fetch_database_info(
                 async_database.api_endpoint,
                 token=async_database.token_provider.get_token(),
-                namespace=async_database.keyspace,
+                keyspace=async_database.keyspace,
                 max_time_ms=1,
             )
             assert info is not None

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -53,7 +53,7 @@ class TestTimeoutAsync:
         info = await async_fetch_database_info(
             async_database.api_endpoint,
             token=async_database.token_provider.get_token(),
-            namespace=async_database.namespace,
+            namespace=async_database.keyspace,
         )
         assert info is not None
 
@@ -61,7 +61,7 @@ class TestTimeoutAsync:
             info = await async_fetch_database_info(
                 async_database.api_endpoint,
                 token=async_database.token_provider.get_token(),
-                namespace=async_database.namespace,
+                namespace=async_database.keyspace,
                 max_time_ms=1,
             )
             assert info is not None

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -23,7 +23,7 @@ from astrapy.admin import async_fetch_database_info
 from astrapy.exceptions import DataAPITimeoutException, DevOpsAPITimeoutException
 from astrapy.operations import AsyncDeleteMany, AsyncInsertMany
 
-from ..conftest import IS_ASTRA_DB
+from ..conftest import IS_ASTRA_DB, async_fail_if_not_removed
 
 
 class TestTimeoutAsync:
@@ -167,6 +167,7 @@ class TestTimeoutAsync:
         with pytest.raises(DataAPITimeoutException):
             await async_collection.delete_many({"f": "delete_many3"}, max_time_ms=2)
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write timeouts, async")
     async def test_bulk_write_ordered_timeout_exceptions_async(
         self,
@@ -185,6 +186,7 @@ class TestTimeoutAsync:
                 [im_a, im_b, dm], ordered=True, max_time_ms=1
             )
 
+    @async_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write timeouts, async")
     async def test_bulk_write_unordered_timeout_exceptions_async(
         self,

--- a/tests/idiomatic/integration/test_timeout_sync.py
+++ b/tests/idiomatic/integration/test_timeout_sync.py
@@ -23,7 +23,7 @@ from astrapy.admin import fetch_database_info
 from astrapy.exceptions import DataAPITimeoutException, DevOpsAPITimeoutException
 from astrapy.operations import DeleteMany, InsertMany
 
-from ..conftest import IS_ASTRA_DB
+from ..conftest import IS_ASTRA_DB, sync_fail_if_not_removed
 
 
 class TestTimeoutSync:
@@ -165,6 +165,7 @@ class TestTimeoutSync:
         with pytest.raises(DataAPITimeoutException):
             sync_collection.delete_many({"f": "delete_many3"}, max_time_ms=2)
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write timeouts, sync")
     def test_bulk_write_ordered_timeout_exceptions_sync(
         self,
@@ -183,6 +184,7 @@ class TestTimeoutSync:
                 [im_a, im_b, dm], ordered=True, max_time_ms=1
             )
 
+    @sync_fail_if_not_removed
     @pytest.mark.describe("test of bulk_write timeouts, sync")
     def test_bulk_write_unordered_timeout_exceptions_sync(
         self,

--- a/tests/idiomatic/integration/test_timeout_sync.py
+++ b/tests/idiomatic/integration/test_timeout_sync.py
@@ -51,7 +51,7 @@ class TestTimeoutSync:
         info = fetch_database_info(
             sync_database.api_endpoint,
             token=sync_database.token_provider.get_token(),
-            namespace=sync_database.namespace,
+            namespace=sync_database.keyspace,
         )
         assert info is not None
 
@@ -59,7 +59,7 @@ class TestTimeoutSync:
             info = fetch_database_info(
                 sync_database.api_endpoint,
                 token=sync_database.token_provider.get_token(),
-                namespace=sync_database.namespace,
+                namespace=sync_database.keyspace,
                 max_time_ms=1,
             )
             assert info is not None

--- a/tests/idiomatic/integration/test_timeout_sync.py
+++ b/tests/idiomatic/integration/test_timeout_sync.py
@@ -51,7 +51,7 @@ class TestTimeoutSync:
         info = fetch_database_info(
             sync_database.api_endpoint,
             token=sync_database.token_provider.get_token(),
-            namespace=sync_database.keyspace,
+            keyspace=sync_database.keyspace,
         )
         assert info is not None
 
@@ -59,7 +59,7 @@ class TestTimeoutSync:
             info = fetch_database_info(
                 sync_database.api_endpoint,
                 token=sync_database.token_provider.get_token(),
-                namespace=sync_database.keyspace,
+                keyspace=sync_database.keyspace,
                 max_time_ms=1,
             )
             assert info is not None

--- a/tests/idiomatic/unit/test_admin_conversions.py
+++ b/tests/idiomatic/unit/test_admin_conversions.py
@@ -339,11 +339,11 @@ class TestAdminConversions:
         db_id_string = "01234567-89ab-cdef-0123-456789abcdef"
 
         assert admin_t.get_database(
-            db_id_string, token=token_f, namespace="n", region="r"
-        ) == admin_f.get_database(db_id_string, namespace="n", region="r")
+            db_id_string, token=token_f, keyspace="n", region="r"
+        ) == admin_f.get_database(db_id_string, keyspace="n", region="r")
         assert admin_0.get_database(
-            db_id_string, token=token_f, namespace="n", region="r"
-        ) == admin_f.get_database(db_id_string, namespace="n", region="r")
+            db_id_string, token=token_f, keyspace="n", region="r"
+        ) == admin_f.get_database(db_id_string, keyspace="n", region="r")
 
     @pytest.mark.describe(
         "test of token inheritance in spawning from AstraDBDatabaseAdmin"
@@ -360,11 +360,11 @@ class TestAdminConversions:
         adbadmin_f = AstraDBDatabaseAdmin(db_id_string, region="reg", token=token_f)
 
         assert adbadmin_t.get_database(
-            token=token_f, namespace="n", region="r"
-        ) == adbadmin_f.get_database(namespace="n", region="r")
+            token=token_f, keyspace="n", region="r"
+        ) == adbadmin_f.get_database(keyspace="n", region="r")
         assert adbadmin_0.get_database(
-            token=token_f, namespace="n", region="r"
-        ) == adbadmin_f.get_database(namespace="n", region="r")
+            token=token_f, keyspace="n", region="r"
+        ) == adbadmin_f.get_database(keyspace="n", region="r")
 
     @pytest.mark.describe(
         "test of token inheritance in spawning from DataAPIDatabaseAdmin"
@@ -379,11 +379,11 @@ class TestAdminConversions:
         dadbadmin_f = DataAPIDatabaseAdmin(a_e_string, token=token_f)
 
         assert dadbadmin_t.get_database(
-            token=token_f, namespace="n"
-        ) == dadbadmin_f.get_database(namespace="n")
+            token=token_f, keyspace="n"
+        ) == dadbadmin_f.get_database(keyspace="n")
         assert dadbadmin_0.get_database(
-            token=token_f, namespace="n"
-        ) == dadbadmin_f.get_database(namespace="n")
+            token=token_f, keyspace="n"
+        ) == dadbadmin_f.get_database(keyspace="n")
 
     @pytest.mark.describe("test of token inheritance in spawning from Database")
     def test_database_token_inheritance(self) -> None:
@@ -444,11 +444,11 @@ class TestAdminConversions:
         assert db_adm1 == db_adm2
         assert db_adm2 == db_adm3
 
-        db_1 = adm.get_database(db_id, region=db_reg, namespace="the_ns")
-        db_2 = adm.get_database(api_ep, region=db_reg, namespace="the_ns")
-        db_3 = adm.get_database(api_ep, namespace="the_ns")
+        db_1 = adm.get_database(db_id, region=db_reg, keyspace="the_ks")
+        db_2 = adm.get_database(api_ep, region=db_reg, keyspace="the_ks")
+        db_3 = adm.get_database(api_ep, keyspace="the_ks")
         with pytest.raises(ValueError):
-            adm.get_database(api_ep, region="not-that-one", namespace="the_ns")
+            adm.get_database(api_ep, region="not-that-one", keyspace="the_ks")
 
         assert db_1 == db_2
         assert db_2 == db_3
@@ -469,11 +469,9 @@ class TestAdminConversions:
         api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
         db_adm = AstraDBDatabaseAdmin(api_ep)
         with pytest.warns(DeprecationWarning):
-            db1 = db_adm.get_database(
-                region="another-region", namespace="the-namespace"
-            )
+            db1 = db_adm.get_database(region="another-region", keyspace="the-keyspace")
             # it's ignored anyway
-            assert db1 == db_adm.get_database(namespace="the-namespace")
+            assert db1 == db_adm.get_database(keyspace="the-keyspace")
 
     @pytest.mark.describe(
         "test of spawner_database for AstraDBDatabaseAdmin if not provided"
@@ -496,7 +494,7 @@ class TestAdminConversions:
     )
     def test_spawnerdatabase_astradbdatabaseadmin_syncprovided(self) -> None:
         api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
-        db = Database(api_ep, namespace="M")
+        db = Database(api_ep, keyspace="M")
         db_adm = AstraDBDatabaseAdmin(api_ep, spawner_database=db)
         assert db_adm.spawner_database is db
 
@@ -505,7 +503,7 @@ class TestAdminConversions:
     )
     def test_spawnerdatabase_astradbdatabaseadmin_asyncprovided(self) -> None:
         api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
-        adb = AsyncDatabase(api_ep, namespace="M")
+        adb = AsyncDatabase(api_ep, keyspace="M")
         db_adm = AstraDBDatabaseAdmin(api_ep, spawner_database=adb)
         assert db_adm.spawner_database is adb
 
@@ -531,4 +529,4 @@ class TestAdminConversions:
     def test_fromapiendpoint_astradbdatabaseadmin(self) -> None:
         api_ep = "https://01234567-89ab-cdef-0123-456789abcdef-the-region.apps.astra.datastax.com"
         db_adm = AstraDBDatabaseAdmin.from_api_endpoint(api_ep, token="t")
-        assert db_adm.get_database(namespace="M").api_endpoint == api_ep
+        assert db_adm.get_database(keyspace="M").api_endpoint == api_ep

--- a/tests/idiomatic/unit/test_collections_async.py
+++ b/tests/idiomatic/unit/test_collections_async.py
@@ -230,6 +230,8 @@ class TestCollectionsAsync:
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
         col1 = await async_database.get_collection("id_test_collection")
+        with pytest.warns(DeprecationWarning):
+            col1.namespace
         assert col1.namespace == async_database.namespace
 
         col2 = await async_database.get_collection(

--- a/tests/idiomatic/unit/test_collections_async.py
+++ b/tests/idiomatic/unit/test_collections_async.py
@@ -73,14 +73,14 @@ class TestCollectionsAsync:
         )
         assert col1 != col1._copy(database=async_database._copy(token="x_t"))
         assert col1 != col1._copy(name="o")
-        assert col1 != col1._copy(namespace="o")
+        assert col1 != col1._copy(keyspace="o")
         assert col1 != col1._copy(caller_name="o")
         assert col1 != col1._copy(caller_version="o")
 
         col2 = col1._copy(
             database=async_database._copy(token="x_t"),
             name="other_name",
-            namespace="other_namespace",
+            keyspace="other_keyspace",
             caller_name="x_n",
             caller_version="x_v",
         )
@@ -93,7 +93,7 @@ class TestCollectionsAsync:
         col3 = col2._copy(
             database=async_database,
             name="id_test_collection",
-            namespace=async_database.keyspace,
+            keyspace=async_database.keyspace,
         )
         assert col3 == col1
 
@@ -129,14 +129,14 @@ class TestCollectionsAsync:
             ).to_async()
         )
         assert col1 != col1.to_sync(name="o").to_async()
-        assert col1 != col1.to_sync(namespace="o").to_async()
+        assert col1 != col1.to_sync(keyspace="o").to_async()
         assert col1 != col1.to_sync(caller_name="o").to_async()
         assert col1 != col1.to_sync(caller_version="o").to_async()
 
         col2s = col1.to_sync(
             database=async_database._copy(token="x_t").to_sync(),
             name="other_name",
-            namespace="other_namespace",
+            keyspace="other_keyspace",
             caller_name="x_n",
             caller_version="x_v",
         )
@@ -149,7 +149,7 @@ class TestCollectionsAsync:
         col3 = col2s.to_async(
             database=async_database,
             name="id_test_collection",
-            namespace=async_database.keyspace,
+            keyspace=async_database.keyspace,
         )
         assert col3 == col1
 
@@ -157,10 +157,10 @@ class TestCollectionsAsync:
     async def test_collection_database_property_async(
         self,
     ) -> None:
-        db1 = AsyncDatabase("a", "t", namespace="ns1")
-        db2 = AsyncDatabase("a", "t", namespace="ns2")
+        db1 = AsyncDatabase("a", "t", keyspace="ns1")
+        db2 = AsyncDatabase("a", "t", keyspace="ns2")
         col1 = AsyncCollection(db1, "coll")
-        col2 = AsyncCollection(db1, "coll", namespace="ns2")
+        col2 = AsyncCollection(db1, "coll", keyspace="ns2")
         assert col1.database == db1
         assert col2.database == db2
 
@@ -168,7 +168,7 @@ class TestCollectionsAsync:
     async def test_collection_name_property_async(
         self,
     ) -> None:
-        db1 = AsyncDatabase("a", "t", namespace="ns1")
+        db1 = AsyncDatabase("a", "t", keyspace="ns1")
         col1 = AsyncCollection(db1, "coll")
         assert col1.name == "coll"
 
@@ -221,7 +221,7 @@ class TestCollectionsAsync:
 
     @async_fail_if_not_removed
     @pytest.mark.skipif(
-        SECONDARY_NAMESPACE is None, reason="No secondary namespace provided"
+        SECONDARY_NAMESPACE is None, reason="No secondary keyspace provided"
     )
     @pytest.mark.describe("test collection namespace property, async")
     async def test_collection_namespace_async(

--- a/tests/idiomatic/unit/test_collections_sync.py
+++ b/tests/idiomatic/unit/test_collections_sync.py
@@ -73,14 +73,14 @@ class TestCollectionsSync:
         )
         assert col1 != col1._copy(database=sync_database._copy(token="x_t"))
         assert col1 != col1._copy(name="o")
-        assert col1 != col1._copy(namespace="o")
+        assert col1 != col1._copy(keyspace="o")
         assert col1 != col1._copy(caller_name="o")
         assert col1 != col1._copy(caller_version="o")
 
         col2 = col1._copy(
             database=sync_database._copy(token="x_t"),
             name="other_name",
-            namespace="other_namespace",
+            keyspace="other_keyspace",
             caller_name="x_n",
             caller_version="x_v",
         )
@@ -93,7 +93,7 @@ class TestCollectionsSync:
         col3 = col2._copy(
             database=sync_database,
             name="id_test_collection",
-            namespace=sync_database.keyspace,
+            keyspace=sync_database.keyspace,
         )
         assert col3 == col1
 
@@ -129,14 +129,14 @@ class TestCollectionsSync:
             ).to_sync()
         )
         assert col1 != col1.to_async(name="o").to_sync()
-        assert col1 != col1.to_async(namespace="o").to_sync()
+        assert col1 != col1.to_async(keyspace="o").to_sync()
         assert col1 != col1.to_async(caller_name="o").to_sync()
         assert col1 != col1.to_async(caller_version="o").to_sync()
 
         col2a = col1.to_async(
             database=sync_database._copy(token="x_t").to_async(),
             name="other_name",
-            namespace="other_namespace",
+            keyspace="other_keyspace",
             caller_name="x_n",
             caller_version="x_v",
         )
@@ -149,7 +149,7 @@ class TestCollectionsSync:
         col3 = col2a.to_sync(
             database=sync_database,
             name="id_test_collection",
-            namespace=sync_database.keyspace,
+            keyspace=sync_database.keyspace,
         )
         assert col3 == col1
 
@@ -157,10 +157,10 @@ class TestCollectionsSync:
     def test_collection_database_property_sync(
         self,
     ) -> None:
-        db1 = Database("a", "t", namespace="ns1")
-        db2 = Database("a", "t", namespace="ns2")
+        db1 = Database("a", "t", keyspace="ns1")
+        db2 = Database("a", "t", keyspace="ns2")
         col1 = Collection(db1, "coll")
-        col2 = Collection(db1, "coll", namespace="ns2")
+        col2 = Collection(db1, "coll", keyspace="ns2")
         assert col1.database == db1
         assert col2.database == db2
 
@@ -168,7 +168,7 @@ class TestCollectionsSync:
     def test_collection_name_property_sync(
         self,
     ) -> None:
-        db1 = Database("a", "t", namespace="ns1")
+        db1 = Database("a", "t", keyspace="ns1")
         col1 = Collection(db1, "coll")
         assert col1.name == "coll"
 

--- a/tests/idiomatic/unit/test_collections_sync.py
+++ b/tests/idiomatic/unit/test_collections_sync.py
@@ -230,6 +230,8 @@ class TestCollectionsSync:
         data_api_credentials_info: DataAPICredentialsInfo,
     ) -> None:
         col1 = sync_database.get_collection("id_test_collection")
+        with pytest.warns(DeprecationWarning):
+            col1.namespace
         assert col1.namespace == sync_database.namespace
 
         col2 = sync_database.get_collection(

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -21,7 +21,11 @@ from astrapy.constants import Environment
 from astrapy.defaults import DEFAULT_ASTRA_DB_NAMESPACE
 from astrapy.exceptions import DevOpsAPIException
 
-from ..conftest import TEST_COLLECTION_INSTANCE_NAME, DataAPICredentials
+from ..conftest import (
+    TEST_COLLECTION_INSTANCE_NAME,
+    DataAPICredentials,
+    sync_fail_if_not_removed,
+)
 
 
 class TestDatabasesAsync:
@@ -282,3 +286,11 @@ class TestDatabasesAsync:
         assert db_m.namespace == "M"
         db_n = db_admin.get_async_database()
         assert db_n.namespace is None
+
+    @sync_fail_if_not_removed
+    @pytest.mark.describe("test of database keyspace property, async")
+    def test_database_keyspace_property_async(
+        self,
+        async_database: AsyncDatabase,
+    ) -> None:
+        assert async_database.namespace == async_database.keyspace

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -18,7 +18,7 @@ import pytest
 
 from astrapy import AsyncCollection, AsyncDatabase, DataAPIClient
 from astrapy.constants import Environment
-from astrapy.defaults import DEFAULT_ASTRA_DB_NAMESPACE
+from astrapy.defaults import DEFAULT_ASTRA_DB_KEYSPACE
 from astrapy.exceptions import DevOpsAPIException
 
 from ..conftest import (
@@ -252,7 +252,7 @@ class TestDatabasesAsync:
         )
         assert db_o_m.namespace == "M"
         db_a_n = AsyncDatabase("ep", token="t", environment=Environment.PROD)
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
         db_o_n = AsyncDatabase("ep", token="t", environment=Environment.OTHER)
         assert db_o_n.namespace is None
 
@@ -266,7 +266,7 @@ class TestDatabasesAsync:
         db_a_m = client_a.get_async_database("ep", region="r", namespace="M")
         assert db_a_m.namespace == "M"
         db_a_n = client_a.get_async_database("ep", region="r")
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
 
         client_o = DataAPIClient(environment=Environment.OTHER)
         db_a_m = client_o.get_async_database("http://a", namespace="M")

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -202,7 +202,7 @@ class TestDatabasesAsync:
         assert collection_ns2 == AsyncCollection(
             async_database, TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
         )
-        assert collection_ns2.database.namespace == NAMESPACE_2
+        assert collection_ns2.database.keyspace == NAMESPACE_2
 
     @pytest.mark.describe("test database conversions with caller mutableness, async")
     async def test_database_conversions_caller_mutableness_async(

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -293,4 +293,6 @@ class TestDatabasesAsync:
         self,
         async_database: AsyncDatabase,
     ) -> None:
+        with pytest.warns(DeprecationWarning):
+            async_database.namespace
         assert async_database.namespace == async_database.keyspace

--- a/tests/idiomatic/unit/test_databases_async.py
+++ b/tests/idiomatic/unit/test_databases_async.py
@@ -67,7 +67,7 @@ class TestDatabasesAsync:
         db1 = AsyncDatabase(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             caller_name="c_n",
             caller_version="c_v",
             api_path="api_path",
@@ -75,7 +75,7 @@ class TestDatabasesAsync:
         )
         assert db1 != db1._copy(api_endpoint="x")
         assert db1 != db1._copy(token="x")
-        assert db1 != db1._copy(namespace="x")
+        assert db1 != db1._copy(keyspace="x")
         assert db1 != db1._copy(caller_name="x")
         assert db1 != db1._copy(caller_version="x")
         assert db1 != db1._copy(api_path="x")
@@ -84,7 +84,7 @@ class TestDatabasesAsync:
         db2 = db1._copy(
             api_endpoint="x",
             token="x",
-            namespace="x",
+            keyspace="x",
             caller_name="x_n",
             caller_version="x_v",
             api_path="x",
@@ -99,16 +99,14 @@ class TestDatabasesAsync:
         db3 = db2._copy(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             api_path="api_path",
             api_version="api_version",
         )
         assert db3 == db1
 
-        assert db1.with_options(namespace="x") != db1
-        assert (
-            db1.with_options(namespace="x").with_options(namespace="namespace") == db1
-        )
+        assert db1.with_options(keyspace="x") != db1
+        assert db1.with_options(keyspace="x").with_options(keyspace="keyspace") == db1
         assert db1.with_options(caller_name="x") != db1
         assert db1.with_options(caller_name="x").with_options(caller_name="c_n") == db1
         assert db1.with_options(caller_version="x") != db1
@@ -124,7 +122,7 @@ class TestDatabasesAsync:
         db1 = AsyncDatabase(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             caller_name="c_n",
             caller_version="c_v",
             api_path="api_path",
@@ -132,7 +130,7 @@ class TestDatabasesAsync:
         )
         assert db1 != db1.to_sync(api_endpoint="o").to_async()
         assert db1 != db1.to_sync(token="o").to_async()
-        assert db1 != db1.to_sync(namespace="o").to_async()
+        assert db1 != db1.to_sync(keyspace="o").to_async()
         assert db1 != db1.to_sync(caller_name="o").to_async()
         assert db1 != db1.to_sync(caller_version="o").to_async()
         assert db1 != db1.to_sync(api_path="o").to_async()
@@ -141,7 +139,7 @@ class TestDatabasesAsync:
         db2s = db1.to_sync(
             api_endpoint="x",
             token="x",
-            namespace="x",
+            keyspace="x",
             caller_name="x_n",
             caller_version="x_v",
             api_path="x",
@@ -156,7 +154,7 @@ class TestDatabasesAsync:
         db3 = db2s.to_async(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             api_path="api_path",
             api_version="api_version",
         )
@@ -195,14 +193,14 @@ class TestDatabasesAsync:
         assert getattr(async_database, TEST_COLLECTION_INSTANCE_NAME) == collection
         assert async_database[TEST_COLLECTION_INSTANCE_NAME] == collection
 
-        NAMESPACE_2 = "other_namespace"
-        collection_ns2 = await async_database.get_collection(
-            TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
+        NAMESPACE_2 = "other_keyspace"
+        collection_ks2 = await async_database.get_collection(
+            TEST_COLLECTION_INSTANCE_NAME, keyspace=NAMESPACE_2
         )
-        assert collection_ns2 == AsyncCollection(
-            async_database, TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
+        assert collection_ks2 == AsyncCollection(
+            async_database, TEST_COLLECTION_INSTANCE_NAME, keyspace=NAMESPACE_2
         )
-        assert collection_ns2.database.keyspace == NAMESPACE_2
+        assert collection_ks2.database.keyspace == NAMESPACE_2
 
     @pytest.mark.describe("test database conversions with caller mutableness, async")
     async def test_database_conversions_caller_mutableness_async(
@@ -241,51 +239,51 @@ class TestDatabasesAsync:
         with pytest.raises(DevOpsAPIException):
             db2.id
 
-    @pytest.mark.describe("test database default namespace per environment, async")
-    async def test_database_default_namespace_per_environment_async(self) -> None:
+    @pytest.mark.describe("test database default keyspace per environment, async")
+    async def test_database_default_keyspace_per_environment_async(self) -> None:
         db_a_m = AsyncDatabase(
-            "ep", token="t", namespace="M", environment=Environment.PROD
+            "ep", token="t", keyspace="M", environment=Environment.PROD
         )
-        assert db_a_m.namespace == "M"
+        assert db_a_m.keyspace == "M"
         db_o_m = AsyncDatabase(
-            "ep", token="t", namespace="M", environment=Environment.OTHER
+            "ep", token="t", keyspace="M", environment=Environment.OTHER
         )
-        assert db_o_m.namespace == "M"
+        assert db_o_m.keyspace == "M"
         db_a_n = AsyncDatabase("ep", token="t", environment=Environment.PROD)
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
+        assert db_a_n.keyspace == DEFAULT_ASTRA_DB_KEYSPACE
         db_o_n = AsyncDatabase("ep", token="t", environment=Environment.OTHER)
-        assert db_o_n.namespace is None
+        assert db_o_n.keyspace is None
 
     @pytest.mark.describe(
-        "test database-from-client default namespace per environment, async"
+        "test database-from-client default keyspace per environment, async"
     )
-    async def test_database_from_client_default_namespace_per_environment_async(
+    async def test_database_from_client_default_keyspace_per_environment_async(
         self,
     ) -> None:
         client_a = DataAPIClient(environment=Environment.PROD)
-        db_a_m = client_a.get_async_database("ep", region="r", namespace="M")
-        assert db_a_m.namespace == "M"
+        db_a_m = client_a.get_async_database("ep", region="r", keyspace="M")
+        assert db_a_m.keyspace == "M"
         db_a_n = client_a.get_async_database("ep", region="r")
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
+        assert db_a_n.keyspace == DEFAULT_ASTRA_DB_KEYSPACE
 
         client_o = DataAPIClient(environment=Environment.OTHER)
-        db_a_m = client_o.get_async_database("http://a", namespace="M")
-        assert db_a_m.namespace == "M"
+        db_a_m = client_o.get_async_database("http://a", keyspace="M")
+        assert db_a_m.keyspace == "M"
         db_a_n = client_o.get_async_database("http://a")
-        assert db_a_n.namespace is None
+        assert db_a_n.keyspace is None
 
     @pytest.mark.describe(
-        "test database-from-dataapidbadmin default namespace per environment, async"
+        "test database-from-dataapidbadmin default keyspace per environment, async"
     )
-    async def test_database_from_dataapidbadmin_default_namespace_per_environment_async(
+    async def test_database_from_dataapidbadmin_default_keyspace_per_environment_async(
         self,
     ) -> None:
         client = DataAPIClient(environment=Environment.OTHER)
         db_admin = client.get_async_database("http://a").get_database_admin()
-        db_m = db_admin.get_async_database(namespace="M")
-        assert db_m.namespace == "M"
+        db_m = db_admin.get_async_database(keyspace="M")
+        assert db_m.keyspace == "M"
         db_n = db_admin.get_async_database()
-        assert db_n.namespace is None
+        assert db_n.keyspace is None
 
     @sync_fail_if_not_removed
     @pytest.mark.describe("test of database keyspace property, async")

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -18,7 +18,7 @@ import pytest
 
 from astrapy import Collection, DataAPIClient, Database
 from astrapy.constants import Environment
-from astrapy.defaults import DEFAULT_ASTRA_DB_NAMESPACE
+from astrapy.defaults import DEFAULT_ASTRA_DB_KEYSPACE
 from astrapy.exceptions import DevOpsAPIException
 
 from ..conftest import (
@@ -249,7 +249,7 @@ class TestDatabasesSync:
         db_o_m = Database("ep", token="t", namespace="M", environment=Environment.OTHER)
         assert db_o_m.namespace == "M"
         db_a_n = Database("ep", token="t", environment=Environment.PROD)
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
         db_o_n = Database("ep", token="t", environment=Environment.OTHER)
         assert db_o_n.namespace is None
 
@@ -261,7 +261,7 @@ class TestDatabasesSync:
         db_a_m = client_a.get_database("id", region="r", namespace="M")
         assert db_a_m.namespace == "M"
         db_a_n = client_a.get_database("id", region="r")
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_NAMESPACE
+        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
 
         client_o = DataAPIClient(environment=Environment.OTHER)
         db_a_m = client_o.get_database("http://a", namespace="M")

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -67,7 +67,7 @@ class TestDatabasesSync:
         db1 = Database(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             caller_name="c_n",
             caller_version="c_v",
             api_path="api_path",
@@ -75,7 +75,7 @@ class TestDatabasesSync:
         )
         assert db1 != db1._copy(api_endpoint="x")
         assert db1 != db1._copy(token="x")
-        assert db1 != db1._copy(namespace="x")
+        assert db1 != db1._copy(keyspace="x")
         assert db1 != db1._copy(caller_name="x")
         assert db1 != db1._copy(caller_version="x")
         assert db1 != db1._copy(api_path="x")
@@ -84,7 +84,7 @@ class TestDatabasesSync:
         db2 = db1._copy(
             api_endpoint="x",
             token="x",
-            namespace="x",
+            keyspace="x",
             caller_name="x_n",
             caller_version="x_v",
             api_path="x",
@@ -99,16 +99,14 @@ class TestDatabasesSync:
         db3 = db2._copy(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             api_path="api_path",
             api_version="api_version",
         )
         assert db3 == db1
 
-        assert db1.with_options(namespace="x") != db1
-        assert (
-            db1.with_options(namespace="x").with_options(namespace="namespace") == db1
-        )
+        assert db1.with_options(keyspace="x") != db1
+        assert db1.with_options(keyspace="x").with_options(keyspace="keyspace") == db1
         assert db1.with_options(caller_name="x") != db1
         assert db1.with_options(caller_name="x").with_options(caller_name="c_n") == db1
         assert db1.with_options(caller_version="x") != db1
@@ -124,7 +122,7 @@ class TestDatabasesSync:
         db1 = Database(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             caller_name="c_n",
             caller_version="c_v",
             api_path="api_path",
@@ -132,7 +130,7 @@ class TestDatabasesSync:
         )
         assert db1 != db1.to_async(api_endpoint="o").to_sync()
         assert db1 != db1.to_async(token="o").to_sync()
-        assert db1 != db1.to_async(namespace="o").to_sync()
+        assert db1 != db1.to_async(keyspace="o").to_sync()
         assert db1 != db1.to_async(caller_name="o").to_sync()
         assert db1 != db1.to_async(caller_version="o").to_sync()
         assert db1 != db1.to_async(api_path="o").to_sync()
@@ -141,7 +139,7 @@ class TestDatabasesSync:
         db2a = db1.to_async(
             api_endpoint="x",
             token="x",
-            namespace="x",
+            keyspace="x",
             caller_name="x_n",
             caller_version="x_v",
             api_path="x",
@@ -156,7 +154,7 @@ class TestDatabasesSync:
         db3 = db2a.to_sync(
             api_endpoint="api_endpoint",
             token="token",
-            namespace="namespace",
+            keyspace="keyspace",
             api_path="api_path",
             api_version="api_version",
         )
@@ -196,14 +194,14 @@ class TestDatabasesSync:
         assert getattr(sync_database, TEST_COLLECTION_INSTANCE_NAME) == collection
         assert sync_database[TEST_COLLECTION_INSTANCE_NAME] == collection
 
-        NAMESPACE_2 = "other_namespace"
-        collection_ns2 = sync_database.get_collection(
-            TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
+        NAMESPACE_2 = "other_keyspace"
+        collection_ks2 = sync_database.get_collection(
+            TEST_COLLECTION_INSTANCE_NAME, keyspace=NAMESPACE_2
         )
-        assert collection_ns2 == Collection(
-            sync_database, TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
+        assert collection_ks2 == Collection(
+            sync_database, TEST_COLLECTION_INSTANCE_NAME, keyspace=NAMESPACE_2
         )
-        assert collection_ns2.database.keyspace == NAMESPACE_2
+        assert collection_ks2.database.keyspace == NAMESPACE_2
 
     @pytest.mark.describe("test database conversions with caller mutableness, sync")
     def test_database_conversions_caller_mutableness_sync(
@@ -242,45 +240,45 @@ class TestDatabasesSync:
         with pytest.raises(DevOpsAPIException):
             db2.id
 
-    @pytest.mark.describe("test database default namespace per environment, sync")
-    def test_database_default_namespace_per_environment_sync(self) -> None:
-        db_a_m = Database("ep", token="t", namespace="M", environment=Environment.PROD)
-        assert db_a_m.namespace == "M"
-        db_o_m = Database("ep", token="t", namespace="M", environment=Environment.OTHER)
-        assert db_o_m.namespace == "M"
+    @pytest.mark.describe("test database default keyspace per environment, sync")
+    def test_database_default_keyspace_per_environment_sync(self) -> None:
+        db_a_m = Database("ep", token="t", keyspace="M", environment=Environment.PROD)
+        assert db_a_m.keyspace == "M"
+        db_o_m = Database("ep", token="t", keyspace="M", environment=Environment.OTHER)
+        assert db_o_m.keyspace == "M"
         db_a_n = Database("ep", token="t", environment=Environment.PROD)
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
+        assert db_a_n.keyspace == DEFAULT_ASTRA_DB_KEYSPACE
         db_o_n = Database("ep", token="t", environment=Environment.OTHER)
-        assert db_o_n.namespace is None
+        assert db_o_n.keyspace is None
 
     @pytest.mark.describe(
-        "test database-from-client default namespace per environment, sync"
+        "test database-from-client default keyspace per environment, sync"
     )
-    def test_database_from_client_default_namespace_per_environment_sync(self) -> None:
+    def test_database_from_client_default_keyspace_per_environment_sync(self) -> None:
         client_a = DataAPIClient(environment=Environment.PROD)
-        db_a_m = client_a.get_database("id", region="r", namespace="M")
-        assert db_a_m.namespace == "M"
+        db_a_m = client_a.get_database("id", region="r", keyspace="M")
+        assert db_a_m.keyspace == "M"
         db_a_n = client_a.get_database("id", region="r")
-        assert db_a_n.namespace == DEFAULT_ASTRA_DB_KEYSPACE
+        assert db_a_n.keyspace == DEFAULT_ASTRA_DB_KEYSPACE
 
         client_o = DataAPIClient(environment=Environment.OTHER)
-        db_a_m = client_o.get_database("http://a", namespace="M")
-        assert db_a_m.namespace == "M"
+        db_a_m = client_o.get_database("http://a", keyspace="M")
+        assert db_a_m.keyspace == "M"
         db_a_n = client_o.get_database("http://a")
-        assert db_a_n.namespace is None
+        assert db_a_n.keyspace is None
 
     @pytest.mark.describe(
-        "test database-from-dataapidbadmin default namespace per environment, sync"
+        "test database-from-dataapidbadmin default keyspace per environment, sync"
     )
-    def test_database_from_dataapidbadmin_default_namespace_per_environment_sync(
+    def test_database_from_dataapidbadmin_default_keyspace_per_environment_sync(
         self,
     ) -> None:
         client = DataAPIClient(environment=Environment.OTHER)
         db_admin = client.get_database("http://a").get_database_admin()
-        db_m = db_admin.get_database(namespace="M")
-        assert db_m.namespace == "M"
+        db_m = db_admin.get_database(keyspace="M")
+        assert db_m.keyspace == "M"
         db_n = db_admin.get_database()
-        assert db_n.namespace is None
+        assert db_n.keyspace is None
 
     @sync_fail_if_not_removed
     @pytest.mark.describe("test of database keyspace property, sync")

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -288,4 +288,6 @@ class TestDatabasesSync:
         self,
         sync_database: Database,
     ) -> None:
+        with pytest.warns(DeprecationWarning):
+            sync_database.namespace
         assert sync_database.namespace == sync_database.keyspace

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -21,7 +21,11 @@ from astrapy.constants import Environment
 from astrapy.defaults import DEFAULT_ASTRA_DB_NAMESPACE
 from astrapy.exceptions import DevOpsAPIException
 
-from ..conftest import TEST_COLLECTION_INSTANCE_NAME, DataAPICredentials
+from ..conftest import (
+    TEST_COLLECTION_INSTANCE_NAME,
+    DataAPICredentials,
+    sync_fail_if_not_removed,
+)
 
 
 class TestDatabasesSync:
@@ -277,3 +281,11 @@ class TestDatabasesSync:
         assert db_m.namespace == "M"
         db_n = db_admin.get_database()
         assert db_n.namespace is None
+
+    @sync_fail_if_not_removed
+    @pytest.mark.describe("test of database keyspace property, sync")
+    def test_database_keyspace_property_sync(
+        self,
+        sync_database: Database,
+    ) -> None:
+        assert sync_database.namespace == sync_database.keyspace

--- a/tests/idiomatic/unit/test_databases_sync.py
+++ b/tests/idiomatic/unit/test_databases_sync.py
@@ -203,7 +203,7 @@ class TestDatabasesSync:
         assert collection_ns2 == Collection(
             sync_database, TEST_COLLECTION_INSTANCE_NAME, namespace=NAMESPACE_2
         )
-        assert collection_ns2.database.namespace == NAMESPACE_2
+        assert collection_ns2.database.keyspace == NAMESPACE_2
 
     @pytest.mark.describe("test database conversions with caller mutableness, sync")
     def test_database_conversions_caller_mutableness_sync(

--- a/tests/idiomatic/unit/test_exceptions.py
+++ b/tests/idiomatic/unit/test_exceptions.py
@@ -102,9 +102,9 @@ def test_dataapihttpexception_raising_500_sync(httpserver: HTTPServer) -> None:
     """
     root_endpoint = httpserver.url_for("/")
     client = DataAPIClient(environment="other")
-    database = client.get_database(root_endpoint, namespace="xnamespace")
+    database = client.get_database(root_endpoint, keyspace="xkeyspace")
     collection = database.get_collection("xcoll")
-    expected_url = "/v1/xnamespace/xcoll"
+    expected_url = "/v1/xkeyspace/xcoll"
     httpserver.expect_oneshot_request(
         expected_url,
         method="POST",
@@ -138,9 +138,9 @@ def test_dataapihttpexception_raising_404_sync(httpserver: HTTPServer) -> None:
     """
     root_endpoint = httpserver.url_for("/")
     client = DataAPIClient(environment="other")
-    database = client.get_database(root_endpoint, namespace="xnamespace")
+    database = client.get_database(root_endpoint, keyspace="xkeyspace")
     collection = database.get_collection("xcoll")
-    expected_url = "/v1/xnamespace/xcoll"
+    expected_url = "/v1/xkeyspace/xcoll"
     httpserver.expect_oneshot_request(
         expected_url,
         method="POST",
@@ -175,9 +175,9 @@ async def test_dataapihttpexception_raising_500_async(httpserver: HTTPServer) ->
     """
     root_endpoint = httpserver.url_for("/")
     client = DataAPIClient(environment="other")
-    adatabase = client.get_async_database(root_endpoint, namespace="xnamespace")
+    adatabase = client.get_async_database(root_endpoint, keyspace="xkeyspace")
     acollection = await adatabase.get_collection("xcoll")
-    expected_url = "/v1/xnamespace/xcoll"
+    expected_url = "/v1/xkeyspace/xcoll"
     httpserver.expect_oneshot_request(
         expected_url,
         method="POST",
@@ -211,9 +211,9 @@ async def test_dataapihttpexception_raising_404_async(httpserver: HTTPServer) ->
     """
     root_endpoint = httpserver.url_for("/")
     client = DataAPIClient(environment="other")
-    adatabase = client.get_async_database(root_endpoint, namespace="xnamespace")
+    adatabase = client.get_async_database(root_endpoint, keyspace="xkeyspace")
     acollection = await adatabase.get_collection("xcoll")
-    expected_url = "/v1/xnamespace/xcoll"
+    expected_url = "/v1/xkeyspace/xcoll"
     httpserver.expect_oneshot_request(
         expected_url,
         method="POST",

--- a/tests/idiomatic/unit/test_timeouts.py
+++ b/tests/idiomatic/unit/test_timeouts.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+import werkzeug
+from pytest_httpserver import HTTPServer
+
+from astrapy.api_commander import APICommander
+from astrapy.exceptions import DataAPITimeoutException, DevOpsAPITimeoutException
+from astrapy.request_tools import HttpMethod
+
+SLEEPER_TIME_S = 0.5
+TIMEOUT_PARAM_S = 0.1
+
+
+def response_sleeper(request: werkzeug.Request) -> werkzeug.Response:
+    time.sleep(SLEEPER_TIME_S)
+    return werkzeug.Response()
+
+
+class TestTimeouts:
+    @pytest.mark.describe("test of APICommander timeout, sync")
+    def test_apicommander_timeout_sync(self, httpserver: HTTPServer) -> None:
+        base_endpoint = httpserver.url_for("/")
+        base_path = "/base"
+        cmd = APICommander(
+            api_endpoint=base_endpoint,
+            path=base_path,
+        )
+
+        httpserver.expect_oneshot_request(
+            base_path,
+            method=HttpMethod.POST,
+        ).respond_with_handler(response_sleeper)
+        with pytest.raises(DataAPITimeoutException):
+            cmd.request(timeout_info=TIMEOUT_PARAM_S)
+
+    @pytest.mark.describe("test of APICommander timeout, async")
+    async def test_apicommander_timeout_async(self, httpserver: HTTPServer) -> None:
+        base_endpoint = httpserver.url_for("/")
+        base_path = "/base"
+        cmd = APICommander(
+            api_endpoint=base_endpoint,
+            path=base_path,
+        )
+
+        httpserver.expect_oneshot_request(
+            base_path,
+            method=HttpMethod.POST,
+        ).respond_with_handler(response_sleeper)
+        with pytest.raises(DataAPITimeoutException):
+            await cmd.async_request(timeout_info=TIMEOUT_PARAM_S)
+
+    @pytest.mark.describe("test of APICommander timeout DevOps, sync")
+    def test_apicommander_timeout_devops_sync(self, httpserver: HTTPServer) -> None:
+        base_endpoint = httpserver.url_for("/")
+        base_path = "/base"
+        cmd = APICommander(
+            api_endpoint=base_endpoint,
+            path=base_path,
+            dev_ops_api=True,
+        )
+
+        httpserver.expect_oneshot_request(
+            base_path,
+            method=HttpMethod.POST,
+        ).respond_with_handler(response_sleeper)
+        with pytest.raises(DevOpsAPITimeoutException):
+            cmd.request(timeout_info=TIMEOUT_PARAM_S)
+
+    @pytest.mark.describe("test of APICommander timeout DevOps, async")
+    async def test_apicommander_timeout_devops_async(
+        self, httpserver: HTTPServer
+    ) -> None:
+        base_endpoint = httpserver.url_for("/")
+        base_path = "/base"
+        cmd = APICommander(
+            api_endpoint=base_endpoint,
+            path=base_path,
+            dev_ops_api=True,
+        )
+
+        httpserver.expect_oneshot_request(
+            base_path,
+            method=HttpMethod.POST,
+        ).respond_with_handler(response_sleeper)
+        with pytest.raises(DevOpsAPITimeoutException):
+            await cmd.async_request(timeout_info=TIMEOUT_PARAM_S)

--- a/tests/vectorize_idiomatic/conftest.py
+++ b/tests/vectorize_idiomatic/conftest.py
@@ -26,7 +26,12 @@ import pytest
 from astrapy import AsyncCollection, AsyncDatabase, Collection, DataAPIClient, Database
 from astrapy.constants import VectorMetric
 
-from ..conftest import IS_ASTRA_DB, DataAPICredentials, DataAPICredentialsInfo
+from ..conftest import (
+    IS_ASTRA_DB,
+    DataAPICredentials,
+    DataAPICredentialsInfo,
+    clean_nulls_from_dict,
+)
 
 TEST_SERVICE_COLLECTION_NAME = "test_indepth_vectorize_collection"
 
@@ -104,5 +109,6 @@ def async_empty_service_collection(
 __all__ = [
     "sync_database",
     "async_database",
+    "clean_nulls_from_dict",
     "IS_ASTRA_DB",
 ]

--- a/tests/vectorize_idiomatic/conftest.py
+++ b/tests/vectorize_idiomatic/conftest.py
@@ -41,7 +41,7 @@ def sync_database(
     database = client.get_database(
         data_api_credentials_kwargs["api_endpoint"],
         token=data_api_credentials_kwargs["token"],
-        namespace=data_api_credentials_kwargs["namespace"],
+        keyspace=data_api_credentials_kwargs["namespace"],
     )
     yield database
 
@@ -70,7 +70,7 @@ def sync_service_collection(
     service_collection_parameters: Dict[str, Any],
 ) -> Iterable[Collection]:
     """
-    An actual collection on DB, in the main namespace.
+    An actual collection on DB, in the main keyspace.
     """
     params = service_collection_parameters
     collection = sync_database.create_collection(

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_async.py
@@ -19,6 +19,8 @@ import pytest
 from astrapy import AsyncDatabase
 from astrapy.info import EmbeddingProvider, FindEmbeddingProvidersResult
 
+from ..conftest import clean_nulls_from_dict
+
 
 class TestVectorizeOpsAsync:
     @pytest.mark.describe("test of find_embedding_providers, async")
@@ -45,4 +47,8 @@ class TestVectorizeOpsAsync:
             ep_name: emb_prov.as_dict()
             for ep_name, emb_prov in ep_result.embedding_providers.items()
         }
-        assert dict_mapping == ep_result.raw_info["embeddingProviders"]  # type: ignore[index]
+        cleaned_dict_mapping = clean_nulls_from_dict(dict_mapping)
+        cleaned_raw_info = clean_nulls_from_dict(
+            ep_result.raw_info["embeddingProviders"]  # type: ignore[index]
+        )
+        assert cleaned_dict_mapping == cleaned_raw_info

--- a/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
+++ b/tests/vectorize_idiomatic/integration/test_vectorize_ops_sync.py
@@ -19,6 +19,8 @@ import pytest
 from astrapy import Database
 from astrapy.info import EmbeddingProvider, FindEmbeddingProvidersResult
 
+from ..conftest import clean_nulls_from_dict
+
 
 class TestVectorizeOpsSync:
     @pytest.mark.describe("test of find_embedding_providers, sync")
@@ -45,4 +47,8 @@ class TestVectorizeOpsSync:
             ep_name: emb_prov.as_dict()
             for ep_name, emb_prov in ep_result.embedding_providers.items()
         }
-        assert dict_mapping == ep_result.raw_info["embeddingProviders"]  # type: ignore[index]
+        cleaned_dict_mapping = clean_nulls_from_dict(dict_mapping)
+        cleaned_raw_info = clean_nulls_from_dict(
+            ep_result.raw_info["embeddingProviders"]  # type: ignore[index]
+        )
+        assert cleaned_dict_mapping == cleaned_raw_info

--- a/tests/vectorize_idiomatic/live_provider_info.py
+++ b/tests/vectorize_idiomatic/live_provider_info.py
@@ -50,14 +50,14 @@ def live_provider_info() -> FindEmbeddingProvidersResult:
         database = client.get_database(
             ASTRA_DB_API_ENDPOINT,
             token=ASTRA_DB_TOKEN_PROVIDER,
-            namespace=ASTRA_DB_KEYSPACE,
+            keyspace=ASTRA_DB_KEYSPACE,
         )
     else:
         client = DataAPIClient(environment=Environment.OTHER)
         database = client.get_database(
             LOCAL_DATA_API_ENDPOINT,
             token=LOCAL_DATA_API_TOKEN_PROVIDER,
-            namespace=LOCAL_DATA_API_KEYSPACE,
+            keyspace=LOCAL_DATA_API_KEYSPACE,
         )
 
     database_admin = database.get_database_admin()

--- a/tests/vectorize_idiomatic/vectorize_models.py
+++ b/tests/vectorize_idiomatic/vectorize_models.py
@@ -251,16 +251,13 @@ def live_test_models() -> Iterable[Dict[str, Any]]:
                     ]
                     if d_params:
                         d_param = d_params[0]
-                        if d_param.default_value is not None:
-                            if (provider_name, model.name) in FORCE_DIMENSION_MAP:
-                                optional_dimension = False
-                                dimension = FORCE_DIMENSION_MAP[
-                                    (provider_name, model.name)
-                                ]
-                            else:
-                                optional_dimension = True
-                                assert model.vector_dimension is None
-                                dimension = _from_validation(d_param)
+                        if (provider_name, model.name) in FORCE_DIMENSION_MAP:
+                            optional_dimension = False
+                            dimension = FORCE_DIMENSION_MAP[(provider_name, model.name)]
+                        elif d_param.default_value is not None:
+                            optional_dimension = True
+                            assert model.vector_dimension is None
+                            dimension = _from_validation(d_param)
                         else:
                             optional_dimension = False
                             assert model.vector_dimension is None


### PR DESCRIPTION
this is becoming v1.5:

```
Deprecation of "namespace-" terminology, replaced by "keyspace-" (removal in 2.0)
    - deprecation of all *namespace* method names
    - deprecation of the `namespace=` named argument to all methods
    - deprecation of the `update_db_namespace` parameter to create_*space
Deprecation of collection bulk_write method (removal in 2.0)
APICommander logs warnings received from the Data API
Full removal of "core library" from the current API:
    - DevOps API accessed through APICommander everywhere
    - Admin objects use APICommander consistently
    - [Async]Database and [Async]Collection directly use APICommander
    - Cursor library uses APICommander directly
    - Core library imports triggers a submodule-wide deprecation warning
    - (simplification of the vector/vectorize deprecator utility)
Widened exception hierarchy with:
    - DevOpsAPIHttpException
    - DevOpsAPITimeoutException
    - DevOpsAPIFaultyResponseException
Rearrangement into separate modules for:
    - constants, strings, magic numbers and settings
    - request low-level tools
    - payload/response transformations
    - (sometimes with temporary duplication to avoid depending on 'core')
Testing:
    - testing on HCD targets Data API v 1.0.16
    - added tests for APICommander
    - improved tests for admin classes
Logging of API requests made more uniform and easier to read
Replaced collections.abc.Iterator => typing.Iterator for python3.8 compatibility
```