### PR TITLE
Fix compatibility with Python 3.8 and 3.9

### DIFF
--- a/astrapy/constants.py
+++ b/astrapy/constants.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, TypeVar
+from typing import Any, Dict, Iterable, Optional, Tuple, TypeVar, Union
 
 from astrapy.settings.defaults import (
     DATA_API_ENVIRONMENT_CASSANDRA,
@@ -26,12 +26,14 @@ from astrapy.settings.defaults import (
     DATA_API_ENVIRONMENT_TEST,
 )
 
-DefaultDocumentType = dict[str, Any]
-DefaultRowType = dict[str, Any]
-ProjectionType = Iterable[str] | dict[str, bool | dict[str, int | Iterable[int]]]
-SortType = dict[str, Any]
-FilterType = dict[str, Any]
-CallerType = tuple[str | None, str | None]
+DefaultDocumentType = Dict[str, Any]
+DefaultRowType = Dict[str, Any]
+ProjectionType = Union[
+    Iterable[str], Dict[str, Union[bool, Dict[str, Union[int, Iterable[int]]]]]
+]
+SortType = Dict[str, Any]
+FilterType = Dict[str, Any]
+CallerType = Tuple[Optional[str], Optional[str]]
 
 
 ROW = TypeVar("ROW")

--- a/astrapy/data/info/table_descriptor/table_altering.py
+++ b/astrapy/data/info/table_descriptor/table_altering.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Dict, cast
 
 from astrapy.data.info.table_descriptor.table_columns import (
     TableColumnTypeDescriptor,
@@ -251,7 +251,7 @@ class AlterTableAddVectorize(AlterTableOperation):
             )
         return AlterTableAddVectorize(
             columns=cast(
-                dict[str, VectorServiceOptions],
+                Dict[str, VectorServiceOptions],
                 _columns,
             )
         )

--- a/astrapy/data/utils/collection_converters.py
+++ b/astrapy/data/utils/collection_converters.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, cast
+from typing import Any, Dict, cast
 
 from astrapy.constants import DefaultDocumentType
 from astrapy.data.utils.extended_json_converters import (
@@ -125,7 +125,7 @@ def preprocess_collection_payload(
 
     if payload:
         return cast(
-            dict[str, Any],
+            Dict[str, Any],
             preprocess_collection_payload_value([], payload, options=options),
         )
     else:

--- a/astrapy/data/utils/distinct_extractors.py
+++ b/astrapy/data/utils/distinct_extractors.py
@@ -20,13 +20,15 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Optional,
+    Tuple,
 )
 
 from astrapy.data.utils.collection_converters import preprocess_collection_payload_value
 from astrapy.data_types import DataAPIMap, DataAPISet
 from astrapy.utils.api_options import FullSerdesOptions
 
-IndexPairType = tuple[str, int | None]
+IndexPairType = Tuple[str, Optional[int]]
 
 
 def _maybe_valid_list_index(key_block: str) -> int | None:

--- a/astrapy/data/utils/table_converters.py
+++ b/astrapy/data/utils/table_converters.py
@@ -21,7 +21,7 @@ import hashlib
 import ipaddress
 import json
 import math
-from typing import Any, Callable, Generic, cast
+from typing import Any, Callable, Dict, Generic, cast
 
 from astrapy.constants import ROW
 from astrapy.data.info.table_descriptor.table_columns import (
@@ -677,7 +677,7 @@ def preprocess_table_payload(
 
     if payload:
         return cast(
-            dict[str, Any],
+            Dict[str, Any],
             preprocess_table_payload_value([], payload, options=options),
         )
     else:

--- a/astrapy/data_types/data_api_map.py
+++ b/astrapy/data_types/data_api_map.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping
-from typing import Generic, Iterable, Iterator, TypeVar
+from typing import Generic, Iterable, Iterator, Mapping, TypeVar
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/astrapy/data_types/data_api_set.py
+++ b/astrapy/data_types/data_api_set.py
@@ -14,8 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Set
-from typing import Any, Generic, Iterable, Iterator, TypeVar
+from typing import AbstractSet, Any, Generic, Iterable, Iterator, TypeVar
 
 T = TypeVar("T")
 
@@ -28,7 +27,7 @@ def _accumulate(destination: list[T], source: Iterable[T]) -> list[T]:
     return _new_destination
 
 
-class DataAPISet(Generic[T], Set[T]):
+class DataAPISet(Generic[T], AbstractSet[T]):
     """
     An immutable 'set-like' class that preserves the order and can store
     non-hashable entries (entries must support __eq__). Not designed for performance.

--- a/astrapy/data_types/data_api_vector.py
+++ b/astrapy/data_types/data_api_vector.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 import struct
 from collections import UserList
 from dataclasses import dataclass
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    FloatList = UserList[float]
+else:
+    FloatList = UserList
 
 # Floats are always encoded big-endian with 4 bytes per float.
 ENDIANNESS_CHAR = ">"
@@ -61,7 +66,7 @@ def bytes_to_floats(byte_blob: bytes, n: int | None = None) -> list[float]:
 
 
 @dataclass
-class DataAPIVector(UserList[float]):
+class DataAPIVector(FloatList):
     r"""
     A class wrapping a list of float numbers to be treated as a "vector" within the
     Data API. This class has the same functionalities as the underlying `list[float]`,

--- a/astrapy/utils/api_commander.py
+++ b/astrapy/utils/api_commander.py
@@ -19,7 +19,7 @@ import logging
 import re
 from decimal import Decimal
 from types import TracebackType
-from typing import Any, Iterable, Sequence, cast
+from typing import Any, Dict, Iterable, Sequence, cast
 
 import httpx
 
@@ -291,14 +291,14 @@ class APICommander:
     @staticmethod
     def _decimal_unaware_parse_json_response(response_text: str) -> dict[str, Any]:
         return cast(
-            dict[str, Any],
+            Dict[str, Any],
             json.loads(response_text),
         )
 
     @staticmethod
     def _decimal_aware_parse_json_response(response_text: str) -> dict[str, Any]:
         return cast(
-            dict[str, Any],
+            Dict[str, Any],
             json.loads(
                 response_text,
                 parse_float=Decimal,

--- a/tests/idiomatic/conftest.py
+++ b/tests/idiomatic/conftest.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 import pytest
 
@@ -37,8 +37,8 @@ from ..conftest import (
     sync_fail_if_not_removed,
 )
 
-DefaultCollection = Collection[dict[str, Any]]
-DefaultAsyncCollection = AsyncCollection[dict[str, Any]]
+DefaultCollection = Collection[Dict[str, Any]]
+DefaultAsyncCollection = AsyncCollection[Dict[str, Any]]
 
 TEST_COLLECTION_INSTANCE_NAME = "test_coll_instance"
 TEST_COLLECTION_NAME = "id_test_collection"

--- a/tests/idiomatic/integration/test_timeout_async.py
+++ b/tests/idiomatic/integration/test_timeout_async.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -22,7 +23,10 @@ from astrapy import AsyncDatabase
 from astrapy.admin.admin import async_fetch_database_info
 from astrapy.exceptions import DataAPITimeoutException, DevOpsAPITimeoutException
 
-from ..conftest import IS_ASTRA_DB, DefaultAsyncCollection
+from ..conftest import IS_ASTRA_DB
+
+if TYPE_CHECKING:
+    from ..conftest import DefaultAsyncCollection
 
 
 class TestTimeoutAsync:

--- a/tests/tables/conftest.py
+++ b/tests/tables/conftest.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from decimal import Decimal
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 import pytest
 
@@ -44,8 +44,8 @@ from ..conftest import (
     DataAPICredentialsInfo,
 )
 
-DefaultTable = Table[dict[str, Any]]
-DefaultAsyncTable = AsyncTable[dict[str, Any]]
+DefaultTable = Table[Dict[str, Any]]
+DefaultAsyncTable = AsyncTable[Dict[str, Any]]
 
 TEST_ALL_RETURNS_TABLE_NAME = "test_table_all_returns"
 TEST_ALL_RETURNS_TABLE_DEFINITION = CreateTableDefinition(

--- a/tests/vectorize_idiomatic/conftest.py
+++ b/tests/vectorize_idiomatic/conftest.py
@@ -19,7 +19,7 @@ Fixtures specific to testing on vectorize-ready Data API.
 from __future__ import annotations
 
 import os
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 import pytest
 
@@ -34,8 +34,8 @@ from ..conftest import (
     clean_nulls_from_dict,
 )
 
-DefaultCollection = Collection[dict[str, Any]]
-DefaultAsyncCollection = AsyncCollection[dict[str, Any]]
+DefaultCollection = Collection[Dict[str, Any]]
+DefaultAsyncCollection = AsyncCollection[Dict[str, Any]]
 
 TEST_SERVICE_COLLECTION_NAME = "test_indepth_vectorize_collection"
 


### PR DESCRIPTION
I ran the tests locally on Python 3.8.
It would probably be good to have some tests run on Python 3.8 during CI.