### PR TITLE
DataAPIErrorDescriptor, improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 main
 ====
+Exceptions
+    - `DataAPIResponseException.error_descriptors` is a property (computed from detailed_error_descriptors)
+    - better string representation of `DataAPIDetailedErrorDescriptor`
 Spawner methods for databases/admins standardized; they don't issue DevOps API calls.
     - removed `normalize_region_for_id` utility method, not used anymore.
     - `AstraDBAdmin.get_[async]_database()`:

--- a/astrapy/exceptions/data_api_exceptions.py
+++ b/astrapy/exceptions/data_api_exceptions.py
@@ -148,9 +148,11 @@ class DataAPIDetailedErrorDescriptor:
 
     def __repr__(self) -> str:
         pieces = [
-            f"error_descriptors={self.error_descriptors.__repr__()}" if self.error_descriptors else None,
-            f"command=..." if self.command else None,
-            f"raw_response=..." if self.raw_response else None,
+            f"error_descriptors={self.error_descriptors.__repr__()}"
+            if self.error_descriptors
+            else None,
+            "command=..." if self.command else None,
+            "raw_response=..." if self.raw_response else None,
         ]
         return f"{self.__class__.__name__}({', '.join(pc for pc in pieces if pc)})"
 


### PR DESCRIPTION
- Friendlier repr
- Flattened list of errors in DataAPIResponseException is now a property (no duplication anymore)