### PR TITLE
Finalize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,13 +120,12 @@ jobs:
           ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
         run: make test
 
-      # TODO restore integration tests for final
-      # - name: Run integration tests
-      #   env:
-      #     ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-      #     ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
-      #     HEADER_EMBEDDING_API_KEY_OPENAI: ${{ secrets.HEADER_EMBEDDING_API_KEY_OPENAI }}
-      #   run: make test-integration
+      - name: Run integration tests
+        env:
+          ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
+          ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
+          HEADER_EMBEDDING_API_KEY_OPENAI: ${{ secrets.HEADER_EMBEDDING_API_KEY_OPENAI }}
+        run: make test-integration
 
   pre-release-unit-lowest-python:
     needs:
@@ -190,16 +189,12 @@ jobs:
           name: dist
           path: dist/
 
-      # TODO: retarget prod PyPI (remove 'repository-url' and skip-existing)
       - name: Publish package distributions to PyPI - TEST FOR NOW
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
           verbose: true
           print-hash: true
-          repository-url: https://test.pypi.org/legacy/
-          # This setting ONLY IN CI AND ON TEST PYPI! See https://github.com/pypa/gh-action-pypi-publish#tolerating-release-package-file-duplicates
-          skip-existing: true
           # TODO determine whether to enable attestations later on, and how
           attestations: false
 
@@ -229,18 +224,12 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Create release (TMP draft, prerelease)
+      - name: Create release on Github
         uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: restore to false
-          draft: true
           generateReleaseNotes: true
-          # TODO: restore `v${{ needs.build.outputs.version }}`
-          tag: test-v${{ needs.build.outputs.version }}
-          # TODO: restore (no 'test-'')
-          name: "test-Release v${{ needs.build.outputs.version }}"
+          tag: v${{ needs.build.outputs.version }}
+          name: "Release v${{ needs.build.outputs.version }}"
           commit: ${{ github.sha }}
-          # TODO: restore false
-          prerelease: true


### PR DESCRIPTION
This is a follow-up of #379 .

The workflow has been tested successfully as per #379 (non-finalized), see image.

<img width="1920" height="316" alt="success" src="https://github.com/user-attachments/assets/3fcfaab5-f019-4729-8e33-3160150b1101" />

It is now time for this PR, which:

- restores integration tests in release.yml
- targets PROD pypi in release, lifting the "skip-existing" flag (suitable for testing only)
- finalizes 'create release' step by removing the "draft" and "prerelease" flags and restoring the right title and tag for the release being created on GH.

The second point in particular implies that the flow would fail if a package of the current version is already found on PyPI (this is intentional). Meaning that the final test will be with the next revision increase.


