### PR TITLE
feat: Support rerank override in findAndRerank

### DIFF
--- a/astrapy/data/collection.py
+++ b/astrapy/data/collection.py
@@ -56,7 +56,7 @@ from astrapy.exceptions.utils import (
     _select_singlereq_timeout_ca,
     _select_singlereq_timeout_gm,
 )
-from astrapy.info import CollectionDefinition, CollectionInfo
+from astrapy.info import CollectionDefinition, CollectionInfo, RerankServiceOptions
 from astrapy.results import (
     CollectionDeleteResult,
     CollectionInsertManyResult,
@@ -1521,6 +1521,7 @@ class Collection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> CollectionFindAndRerankCursor[DOC, RerankedResult[DOC]]: ...
@@ -1540,6 +1541,7 @@ class Collection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> CollectionFindAndRerankCursor[DOC, RerankedResult[DOC2]]: ...
@@ -1558,6 +1560,7 @@ class Collection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> CollectionFindAndRerankCursor[DOC, RerankedResult[DOC2]]:
@@ -1634,6 +1637,10 @@ class Collection(Generic[DOC]):
                 during reranking.
             rerank_query: for collections without a vectorize (server-side embeddings)
                 service, this is used to specify the query text for the reranker.
+            rerank: an optional per-call reranking service override. When supplied,
+                it is sent as the `rerank` option for the find-and-rerank operation
+                and can be expressed as either a `RerankServiceOptions` object or
+                the equivalent dictionary.
             request_timeout_ms: a timeout, in milliseconds, for each single one
                 of the underlying HTTP requests used to fetch documents as the
                 cursor is iterated over.
@@ -1859,6 +1866,7 @@ class Collection(Generic[DOC]):
             .initial_page_state(initial_page_state)
             .rerank_on(rerank_on)
             .rerank_query(rerank_query)
+            .rerank(rerank)
             .include_scores(include_scores)
             .include_sort_vector(include_sort_vector)
         )
@@ -4556,6 +4564,7 @@ class AsyncCollection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> AsyncCollectionFindAndRerankCursor[DOC, RerankedResult[DOC]]: ...
@@ -4575,6 +4584,7 @@ class AsyncCollection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> AsyncCollectionFindAndRerankCursor[DOC, RerankedResult[DOC2]]: ...
@@ -4593,6 +4603,7 @@ class AsyncCollection(Generic[DOC]):
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         request_timeout_ms: int | None = None,
         timeout_ms: int | None = None,
     ) -> AsyncCollectionFindAndRerankCursor[DOC, RerankedResult[DOC2]]:
@@ -4669,6 +4680,10 @@ class AsyncCollection(Generic[DOC]):
                 during reranking.
             rerank_query: for collections without a vectorize (server-side embeddings)
                 service, this is used to specify the query text for the reranker.
+            rerank: an optional per-call reranking service override. When supplied,
+                it is sent as the `rerank` option for the find-and-rerank operation
+                and can be expressed as either a `RerankServiceOptions` object or
+                the equivalent dictionary.
             request_timeout_ms: a timeout, in milliseconds, for each single one
                 of the underlying HTTP requests used to fetch documents as the
                 cursor is iterated over.
@@ -4729,6 +4744,7 @@ class AsyncCollection(Generic[DOC]):
             .initial_page_state(initial_page_state)
             .rerank_on(rerank_on)
             .rerank_query(rerank_query)
+            .rerank(rerank)
             .include_scores(include_scores)
             .include_sort_vector(include_sort_vector)
         )

--- a/astrapy/data/cursors/farr_cursor.py
+++ b/astrapy/data/cursors/farr_cursor.py
@@ -37,6 +37,7 @@ from astrapy.data.cursors.cursor import (
 from astrapy.data.cursors.pagination import FindAndRerankPage
 from astrapy.data.cursors.query_engine import _CollectionFindAndRerankQueryEngine
 from astrapy.data.cursors.reranked_result import RerankedResult
+from astrapy.data.info.reranking import RerankServiceOptions
 from astrapy.data_types import DataAPIVector
 from astrapy.exceptions import CursorException, MultiCallTimeoutManager
 from astrapy.utils.unset import _UNSET, UnsetType
@@ -102,6 +103,7 @@ class CollectionFindAndRerankCursor(
     _include_sort_vector: bool | None
     _rerank_on: str | None
     _rerank_query: str | None
+    _rerank: RerankServiceOptions | dict[str, Any] | None
     _mapper: Callable[[RerankedResult[TRAW]], T] | None
 
     def __init__(
@@ -122,6 +124,7 @@ class CollectionFindAndRerankCursor(
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         mapper: Callable[[RerankedResult[TRAW]], T] | None = None,
     ) -> None:
         self._filter = deepcopy(filter)
@@ -134,6 +137,7 @@ class CollectionFindAndRerankCursor(
         self._include_sort_vector = include_sort_vector
         self._rerank_on = rerank_on
         self._rerank_query = rerank_query
+        self._rerank = deepcopy(rerank)
         self._mapper = mapper
         self._request_timeout_ms = request_timeout_ms
         self._overall_timeout_ms = overall_timeout_ms
@@ -151,6 +155,7 @@ class CollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
         )
         AbstractCursor.__init__(self, initial_page_state=initial_page_state)
         self._timeout_manager = MultiCallTimeoutManager(
@@ -175,6 +180,7 @@ class CollectionFindAndRerankCursor(
         include_sort_vector: bool | None | UnsetType = _UNSET,
         rerank_on: str | None | UnsetType = _UNSET,
         rerank_query: str | None | UnsetType = _UNSET,
+        rerank: RerankServiceOptions | dict[str, Any] | None | UnsetType = _UNSET,
     ) -> CollectionFindAndRerankCursor[TRAW, T]:
         if self._query_engine.collection is None:
             raise RuntimeError("Query engine has no collection.")
@@ -217,6 +223,7 @@ class CollectionFindAndRerankCursor(
             rerank_query=self._rerank_query
             if isinstance(rerank_query, UnsetType)
             else rerank_query,
+            rerank=self._rerank if isinstance(rerank, UnsetType) else rerank,
             mapper=self._mapper,
         )
 
@@ -338,6 +345,7 @@ class CollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
             mapper=self._mapper,
         )
 
@@ -558,6 +566,29 @@ class CollectionFindAndRerankCursor(
         self._ensure_idle()
         return self._copy(rerank_query=rerank_query)
 
+    def rerank(
+        self,
+        rerank: RerankServiceOptions | dict[str, Any] | None,
+    ) -> CollectionFindAndRerankCursor[TRAW, T]:
+        """
+        Return a copy of this cursor with a new rerank service override.
+        This operation is allowed only if the cursor state is still IDLE.
+
+        Instead of explicitly invoking this method, the typical usage consists
+        in passing arguments to the Collection `find_and_rerank` method.
+
+        Args:
+            rerank: a new rerank service override to apply to the returned
+                new cursor.
+
+        Returns:
+            a new CollectionFindAndRerankCursor with the same settings as this one,
+                except for `rerank` which is the provided value.
+        """
+
+        self._ensure_idle()
+        return self._copy(rerank=rerank)
+
     def map(
         self, mapper: Callable[[T], TNEW]
     ) -> CollectionFindAndRerankCursor[TRAW, TNEW]:
@@ -639,6 +670,7 @@ class CollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
             mapper=composite_mapper,
         )
 
@@ -951,6 +983,7 @@ class AsyncCollectionFindAndRerankCursor(
     _include_sort_vector: bool | None
     _rerank_on: str | None
     _rerank_query: str | None
+    _rerank: RerankServiceOptions | dict[str, Any] | None
     _mapper: Callable[[RerankedResult[TRAW]], T] | None
 
     def __init__(
@@ -971,6 +1004,7 @@ class AsyncCollectionFindAndRerankCursor(
         include_sort_vector: bool | None = None,
         rerank_on: str | None = None,
         rerank_query: str | None = None,
+        rerank: RerankServiceOptions | dict[str, Any] | None = None,
         mapper: Callable[[RerankedResult[TRAW]], T] | None = None,
     ) -> None:
         self._filter = deepcopy(filter)
@@ -983,6 +1017,7 @@ class AsyncCollectionFindAndRerankCursor(
         self._include_sort_vector = include_sort_vector
         self._rerank_on = rerank_on
         self._rerank_query = rerank_query
+        self._rerank = deepcopy(rerank)
         self._mapper = mapper
         self._request_timeout_ms = request_timeout_ms
         self._overall_timeout_ms = overall_timeout_ms
@@ -1000,6 +1035,7 @@ class AsyncCollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
         )
         AbstractCursor.__init__(self, initial_page_state=initial_page_state)
         self._timeout_manager = MultiCallTimeoutManager(
@@ -1024,6 +1060,7 @@ class AsyncCollectionFindAndRerankCursor(
         include_sort_vector: bool | None | UnsetType = _UNSET,
         rerank_on: str | None | UnsetType = _UNSET,
         rerank_query: str | None | UnsetType = _UNSET,
+        rerank: RerankServiceOptions | dict[str, Any] | None | UnsetType = _UNSET,
     ) -> AsyncCollectionFindAndRerankCursor[TRAW, T]:
         if self._query_engine.async_collection is None:
             raise RuntimeError("Query engine has no async collection.")
@@ -1066,6 +1103,7 @@ class AsyncCollectionFindAndRerankCursor(
             rerank_query=self._rerank_query
             if isinstance(rerank_query, UnsetType)
             else rerank_query,
+            rerank=self._rerank if isinstance(rerank, UnsetType) else rerank,
             mapper=self._mapper,
         )
 
@@ -1170,6 +1208,7 @@ class AsyncCollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
             mapper=self._mapper,
         )
 
@@ -1390,6 +1429,29 @@ class AsyncCollectionFindAndRerankCursor(
         self._ensure_idle()
         return self._copy(rerank_query=rerank_query)
 
+    def rerank(
+        self,
+        rerank: RerankServiceOptions | dict[str, Any] | None,
+    ) -> AsyncCollectionFindAndRerankCursor[TRAW, T]:
+        """
+        Return a copy of this cursor with a new rerank service override.
+        This operation is allowed only if the cursor state is still IDLE.
+
+        Instead of explicitly invoking this method, the typical usage consists
+        in passing arguments to the AsyncCollection `find_and_rerank` method.
+
+        Args:
+            rerank: a new rerank service override to apply to the returned
+                new cursor.
+
+        Returns:
+            a new AsyncCollectionFindAndRerankCursor with the same settings as this one,
+                except for `rerank` which is the provided value.
+        """
+
+        self._ensure_idle()
+        return self._copy(rerank=rerank)
+
     def map(
         self, mapper: Callable[[T], TNEW]
     ) -> AsyncCollectionFindAndRerankCursor[TRAW, TNEW]:
@@ -1443,6 +1505,7 @@ class AsyncCollectionFindAndRerankCursor(
             include_sort_vector=self._include_sort_vector,
             rerank_on=self._rerank_on,
             rerank_query=self._rerank_query,
+            rerank=self._rerank,
             mapper=composite_mapper,
         )
 

--- a/astrapy/data/cursors/query_engine.py
+++ b/astrapy/data/cursors/query_engine.py
@@ -28,6 +28,7 @@ from astrapy.constants import (
 )
 from astrapy.data.cursors.cursor import TRAW, logger
 from astrapy.data.cursors.reranked_result import RerankedResult
+from astrapy.data.info.reranking import RerankServiceOptions
 from astrapy.data.utils.collection_converters import (
     postprocess_collection_response,
     preprocess_collection_payload,
@@ -381,6 +382,7 @@ class _CollectionFindAndRerankQueryEngine(
     include_sort_vector: bool | None
     rerank_on: str | None
     rerank_query: str | None
+    rerank: RerankServiceOptions | dict[str, Any] | None
     f_r_subpayload: dict[str, Any]
     f_options0: dict[str, Any]
 
@@ -398,6 +400,7 @@ class _CollectionFindAndRerankQueryEngine(
         include_sort_vector: bool | None,
         rerank_on: str | None,
         rerank_query: str | None,
+        rerank: RerankServiceOptions | dict[str, Any] | None,
     ) -> None:
         self.collection = collection
         self.async_collection = async_collection
@@ -410,6 +413,8 @@ class _CollectionFindAndRerankQueryEngine(
         self.include_sort_vector = include_sort_vector
         self.rerank_on = rerank_on
         self.rerank_query = rerank_query
+        self.rerank = rerank
+        rerank_options = RerankServiceOptions.coerce(self.rerank)
         self.f_r_subpayload = {
             k: v
             for k, v in {
@@ -428,6 +433,9 @@ class _CollectionFindAndRerankQueryEngine(
                 "includeSortVector": self.include_sort_vector,
                 "rerankOn": self.rerank_on,
                 "rerankQuery": self.rerank_query,
+                "rerank": rerank_options.as_dict()
+                if rerank_options is not None
+                else None,
             }.items()
             if v is not None
         }

--- a/tests/base/unit/test_findandrerank_options.py
+++ b/tests/base/unit/test_findandrerank_options.py
@@ -1,0 +1,185 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import werkzeug
+from pytest_httpserver import HTTPServer
+
+from astrapy import Collection, Database
+from astrapy.data.cursors.query_engine import _CollectionFindAndRerankQueryEngine
+from astrapy.info import RerankServiceOptions
+from astrapy.utils.api_options import defaultAPIOptions
+from astrapy.utils.request_tools import HttpMethod
+
+from ..conftest import DefaultAsyncCollection, DefaultCollection
+
+BASE_PATH = "v1"
+KEYSPACE = "keyspace"
+COLLECTION_NAME = "collection"
+PATH_SUFFIX = f"{KEYSPACE}/{COLLECTION_NAME}"
+
+
+@pytest.fixture
+def mock_collection(httpserver: HTTPServer) -> DefaultCollection:
+    base_endpoint = httpserver.url_for("/")
+    coll: DefaultCollection = Collection(
+        database=Database(
+            api_endpoint=base_endpoint,
+            keyspace=KEYSPACE,
+            api_options=defaultAPIOptions(environment="other"),
+        ),
+        name=COLLECTION_NAME,
+        keyspace=None,
+        api_options=defaultAPIOptions(environment="other"),
+    )
+    return coll
+
+
+@pytest.fixture
+def mock_acollection(
+    httpserver: HTTPServer, mock_collection: DefaultCollection
+) -> DefaultAsyncCollection:
+    return mock_collection.to_async()
+
+
+def _capture_find_and_rerank_payloads(
+    received_payloads: list[dict[str, Any]],
+) -> Callable[[werkzeug.Request], werkzeug.Response]:
+    def _handler(request: werkzeug.Request) -> werkzeug.Response:
+        payload = json.loads(request.get_data(as_text=True))
+        received_payloads.append(payload)
+        return werkzeug.Response(
+            json.dumps({"data": {"documents": [], "nextPageState": None}}),
+            content_type="application/json",
+        )
+
+    return _handler
+
+
+def _make_farr_query_engine(
+    rerank: RerankServiceOptions | dict[str, Any] | None,
+) -> _CollectionFindAndRerankQueryEngine[dict[str, Any]]:
+    return _CollectionFindAndRerankQueryEngine(
+        collection=None,
+        async_collection=None,
+        filter=None,
+        projection=None,
+        sort={"$hybrid": "query"},
+        limit=None,
+        hybrid_limits=None,
+        include_scores=None,
+        include_sort_vector=None,
+        rerank_on=None,
+        rerank_query=None,
+        rerank=rerank,
+    )
+
+
+class TestFindAndRerankOptions:
+    @pytest.mark.describe("test of find_and_rerank rerank option payload, sync")
+    def test_find_and_rerank_rerank_option_payload_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_collection: DefaultCollection,
+    ) -> None:
+        received_payloads: list[dict[str, Any]] = []
+        rerank = RerankServiceOptions(
+            provider="nvidia",
+            model_name="nv-rerankqa-mistral-4b-v3",
+            authentication={"providerKey": "rk"},
+            parameters={"truncate": "END"},
+        )
+
+        httpserver.expect_oneshot_request(
+            f"/{BASE_PATH}/{PATH_SUFFIX}",
+            method=HttpMethod.POST,
+        ).respond_with_handler(_capture_find_and_rerank_payloads(received_payloads))
+
+        results = mock_collection.find_and_rerank(
+            sort={"$hybrid": "query"},
+            limit=3,
+            rerank=rerank,
+        ).to_list()
+
+        assert results == []
+        assert received_payloads == [
+            {
+                "findAndRerank": {
+                    "sort": {"$hybrid": "query"},
+                    "options": {
+                        "limit": 3,
+                        "rerank": {
+                            "provider": "nvidia",
+                            "modelName": "nv-rerankqa-mistral-4b-v3",
+                            "authentication": {"providerKey": "rk"},
+                            "parameters": {"truncate": "END"},
+                        },
+                    },
+                },
+            },
+        ]
+
+    @pytest.mark.describe("test of find_and_rerank rerank option payload, async")
+    async def test_find_and_rerank_rerank_option_payload_async(
+        self,
+        httpserver: HTTPServer,
+        mock_acollection: DefaultAsyncCollection,
+    ) -> None:
+        received_payloads: list[dict[str, Any]] = []
+
+        httpserver.expect_oneshot_request(
+            f"/{BASE_PATH}/{PATH_SUFFIX}",
+            method=HttpMethod.POST,
+        ).respond_with_handler(_capture_find_and_rerank_payloads(received_payloads))
+
+        results = await mock_acollection.find_and_rerank(
+            sort={"$hybrid": {"$vectorize": "query", "$lexical": "lexical query"}},
+            include_scores=True,
+            rerank={
+                "provider": "cohere",
+                "modelName": "rerank-english-v3.0",
+            },
+        ).to_list()
+
+        assert results == []
+        assert received_payloads == [
+            {
+                "findAndRerank": {
+                    "sort": {
+                        "$hybrid": {
+                            "$vectorize": "query",
+                            "$lexical": "lexical query",
+                        },
+                    },
+                    "options": {
+                        "includeScores": True,
+                        "rerank": {
+                            "provider": "cohere",
+                            "modelName": "rerank-english-v3.0",
+                        },
+                    },
+                },
+            },
+        ]
+
+    @pytest.mark.describe("test of find_and_rerank rerank empty options")
+    def test_find_and_rerank_rerank_empty_options(self) -> None:
+        assert "rerank" not in _make_farr_query_engine(None).f_options0
+        assert _make_farr_query_engine({}).f_options0["rerank"] == {}


### PR DESCRIPTION
## Summary
- add a per-call rerank service override to sync and async find_and_rerank
- thread the override through FARR cursors into findAndRerank options.rerank
- add focused unit coverage for sync/async payloads and empty override preservation

## Testing
- uv run ruff check astrapy/data/collection.py astrapy/data/cursors/farr_cursor.py astrapy/data/cursors/query_engine.py tests/base/unit/test_findandrerank_options.py
- uv run mypy astrapy/data/collection.py astrapy/data/cursors/farr_cursor.py astrapy/data/cursors/query_engine.py
- env LOCAL_DATA_API_ENDPOINT=http://localhost:8181 LOCAL_CASSANDRA_CONTACT_POINT=127.0.0.1 LOCAL_DATA_API_USERNAME=cassandra LOCAL_DATA_API_PASSWORD=cassandra uv run pytest tests/base/unit/test_findandrerank_options.py