### PR TITLE
ci: migrate workflows to shared uv_setup composite action and uv sync

### DIFF
--- a/.github/workflows/codecov_aggregator.yml
+++ b/.github/workflows/codecov_aggregator.yml
@@ -75,18 +75,16 @@ jobs:
           # needed to retrieve the parents of the merge commit (hence the base commit on main)
           fetch-depth: 2
 
-      - name: Set up Python
+      - name: Set up Python + uv
         if: ${{ github.event.action != 'closed' }}
-        uses: actions/setup-python@v2
+        uses: "./.github/actions/uv_setup"
         with:
-          python-version: 3.11
+          python-version: "3.11"
 
       - name: Install dependencies
         if: ${{ github.event.action != 'closed' }}
-        run: |
-          python -m pip install --upgrade pip
-          pipx install uv
-          make venv
+        run: uv sync --dev
+        shell: bash
 
       - name: Download all coverage artifacts from this run
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,16 +14,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+
+    - name: Set up Python + uv
+      uses: "./.github/actions/uv_setup"
       with:
-        python-version: '3.11' # Or any version you prefer
+        python-version: "3.11"
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pipx install uv
-        make venv
+      run: uv sync --dev
+      shell: bash
 
     - name: Ruff Linting AstraPy
       run: |

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -50,16 +50,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up Python + uv
+      uses: "./.github/actions/uv_setup"
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pipx install uv
-        make venv
+      run: uv sync --dev
+      shell: bash
 
     - name: Configure AWS credentials from OIDC
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,16 +32,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up Python + uv
+      uses: "./.github/actions/uv_setup"
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pipx install uv
-        make venv
+      run: uv sync --dev
+      shell: bash
 
     - name: Run pytest
       run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -42,16 +42,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up Python + uv
+      uses: "./.github/actions/uv_setup"
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pipx install uv
-        make venv
+      run: uv sync --dev
+      shell: bash
 
     - name: Run pytest
       run: |


### PR DESCRIPTION
## Summary

Migrates the five CI workflows from the legacy Python/uv bootstrap (`actions/setup-python@v2` + `pip install --upgrade pip` + `pipx install uv` + `make venv`) to the shared `./.github/actions/uv_setup` composite action followed by `uv sync --dev`.

The composite action (`.github/actions/uv_setup/action.yml`) wraps `astral-sh/setup-uv@v6`, which installs a pinned `uv` (currently `0.8.11`) and provisions the requested Python version in one step. This removes the need for a separate `setup-python` step and the manual pip/pipx/make bootstrap, centralizing the toolchain version (uv pin + setup mechanism) in a single place so all jobs stay consistent.

This is a **mechanical, no-behavior-change migration**: the same Python versions are installed and the same dev dependency set is resolved. Only the *mechanism* of installation changes. Nothing in the package, tests, or Makefile is modified — the `make venv` target still exists for local development; CI simply no longer routes through it.

## Per-file changes

All five edits follow the same shape — replace the two setup/install steps with the composite action + `uv sync --dev`:

- **`.github/workflows/lint.yml`** — Python 3.11. `setup-python@v2` + pip/pipx/`make venv` replaced with `uv_setup` (3.11) + `uv sync --dev`.
- **`.github/workflows/local.yml`** — Python 3.12. Same migration; the subsequent AWS OIDC credentials step is unchanged.
- **`.github/workflows/main.yml`** — Python 3.12. Same migration; `pytest` step unchanged.
- **`.github/workflows/unit.yml`** — uses the matrix value `${{ matrix.python-version }}` (unchanged); only the setup/install steps are migrated.
- **`.github/workflows/codecov_aggregator.yml`** — Python 3.11. Same migration; the existing `if: ${{ github.event.action != 'closed' }}` guards on both steps are preserved, and the step is renamed "Set up Python" → "Set up Python + uv" to match the others.

Minor cosmetic alignment also applied: quoting `python-version` values consistently (e.g. `3.11` → `"3.11"`), renaming the setup step to "Set up Python + uv", and adding `shell: bash` to the `uv sync --dev` run steps.

## Scope note

This PR is the **CI-tooling half** of the split of #411. The release-robustness changes (check-pypi version-exists gate, the `success()` fix on `release.yml`, and re-enabling Sigstore attestations on the PyPI publish steps) are intentionally **excluded** and will land in a separate PR. `release.yml` and `_test_release.yml` are not touched here.

## Verification

- Confirmed all five GROUP A files on the feature branch contain **no** remaining references to `actions/setup-python`, `pipx install uv`, or `make venv`.
- Validated each migrated workflow parses as valid YAML (`yaml.safe_load`).
- Confirmed the referenced composite action exists and is well-formed: `.github/actions/uv_setup/action.yml` uses `astral-sh/setup-uv@v6` and pins `UV_VERSION: 0.8.11`, accepting a `python-version` input (MAJOR.MINOR) — matching how every call site invokes it.
- Confirmed `make venv` remains a valid Makefile target, so local developer workflows are unaffected by its removal from CI.

## Test plan

- [ ] CI green on this PR: lint, unit (across the Python matrix), and main workflows succeed using the new bootstrap.
- [ ] Spot-check a job log to confirm `uv` resolves the dev dependency group via `uv sync --dev` and the correct Python version is provisioned.
- [ ] Confirm `codecov_aggregator` still skips its setup/install steps on `closed` events (guards preserved).