### PR TITLE
Enrich create_database method expressiveness

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 main
 ====
+`AstraDatabaseAdmin.[async_]create_database`: expose more parameters (pcu group ID, tier, db type, capacity units) with a new DatabaseDefinition method parameter and call pattern.
 CollectionDefinition fluent interface: renamed all `set_*` methods to `with_*` (e.g., `set_vector_dimension` → `with_vector_dimension`):
     - This better conveys the immutable builder pattern (methods return new objects rather than mutating in place)
     - Old `set_*` methods remain as deprecated aliases (deprecated in 2.3.0, will be removed in 3.0.0)

--- a/README.md
+++ b/README.md
@@ -918,6 +918,7 @@ from astrapy.info import (
     ColumnType,
     CreateTableDefinition,
     CreateTypeDefinition,
+    DatabaseDefinition,
     EmbeddingProvider,
     EmbeddingProviderAuthentication,
     EmbeddingProviderModel,

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -48,6 +48,7 @@ from astrapy.info import (
     AstraDBAdminDatabaseInfo,
     AstraDBAvailableRegionInfo,
     AstraDBDatabaseInfo,
+    DatabaseDefinition,
     FindEmbeddingProvidersResult,
     FindRerankingProvidersResult,
 )
@@ -1065,8 +1066,9 @@ class AstraDBAdmin:
         self,
         name: str,
         *,
-        cloud_provider: str,
-        region: str,
+        definition: DatabaseDefinition | None = None,
+        cloud_provider: str | None = None,
+        region: str | None = None,
         keyspace: str | None = None,
         wait_until_active: bool = True,
         database_admin_timeout_ms: int | None = None,
@@ -1078,12 +1080,23 @@ class AstraDBAdmin:
         """
         Create a database as requested, optionally waiting for it to be ready.
 
+        The most common database configuration are available as keyword arguments.
+        If more control is needed, a `DatabaseDefinition` object can be provided instead.
+
         Args:
             name: the desired name for the database.
-            cloud_provider: one of 'aws', 'gcp' or 'azure'.
-            region: any of the available cloud regions.
+            definition: a DatabaseDefinition object for the database.
+                If provided, `cloud_provider`, `region`, and `keyspace`
+                must not be specified.
+            cloud_provider: one of 'aws', 'gcp' or 'azure'. Required if
+                `definition` is not provided.
+                Cannot be specified if `definition` is provided.
+            region: any of the available cloud regions. Required if
+                `definition` is not provided.
+                Cannot be specified if `definition` is provided.
             keyspace: name for the one keyspace the database starts with.
                 If omitted, DevOps API will use its default.
+                Cannot be specified if `definition` is provided.
             wait_until_active: if True (default), the method returns only after
                 the newly-created database is in ACTIVE state (a few minutes,
                 usually). If False, it will return right after issuing the
@@ -1118,7 +1131,8 @@ class AstraDBAdmin:
         creation request has not reached the API server and is not going
         to be, in fact, honored.
 
-        Example:
+        Examples:
+            >>> # call pattern using the basic parameters:
             >>> my_new_db_admin = my_astra_db_admin.create_database(
             ...     "new_database",
             ...     cloud_provider="aws",
@@ -1134,7 +1148,46 @@ class AstraDBAdmin:
             ...     )
             ... )
             >>> my_coll.insert_one({"title": "The Title", "$vector": [0.1, 0.2]})
+            >>>
+            >>> # call pattern using the 'definition' parameter:
+            >>> my_custom_db_definition = DatabaseDefinition(
+            ...    cloud_provider="aws",
+            ...    region="ap-south-1",
+            ...    capacity_units=4,
+            ...    keyspace="staging_xyz",
+            ...    pcu_group_id="01234567-89ab-cdef-0123-456789abcdef",
+            ... )
+            >>> my_custom_db_admin = my_astra_db_admin.create_database(
+            ...     "new_customized_database",
+            ...     definition=my_custom_db_definition,
+            ... )
         """
+
+        # Validate parameter combinations
+        definition_fields = [cloud_provider, region, keyspace]
+        definition_fields_provided = any(f is not None for f in definition_fields)
+
+        if definition is not None and definition_fields_provided:
+            raise ValueError(
+                "Cannot specify both 'definition' and any of "
+                "'cloud_provider', 'region', 'keyspace'."
+            )
+
+        if definition is None:
+            if cloud_provider is None or region is None:
+                raise ValueError(
+                    "Either 'definition' or both 'cloud_provider' and 'region' "
+                    "must be provided."
+                )
+            # Build definition from individual parameters
+            _definition = DatabaseDefinition(
+                cloud_provider=cloud_provider,
+                region=region,
+                keyspace=keyspace,
+            ).with_defaults()
+        else:
+            # Use provided definition
+            _definition = definition.with_defaults()
 
         _database_admin_timeout_ms, _da_label = _first_valid_timeout(
             (database_admin_timeout_ms, "database_admin_timeout_ms"),
@@ -1149,19 +1202,7 @@ class AstraDBAdmin:
             (timeout_ms, "timeout_ms"),
             (self.api_options.timeout_options.request_timeout_ms, "request_timeout_ms"),
         )
-        cd_payload = {
-            k: v
-            for k, v in {
-                "name": name,
-                "cloudProvider": cloud_provider,
-                "region": region,
-                "tier": "serverless",
-                "capacityUnits": 1,
-                "dbType": "vector",
-                "keyspace": keyspace,
-            }.items()
-            if v is not None
-        }
+        cd_payload = _definition.as_dict(name=name)
         timeout_manager = MultiCallTimeoutManager(
             overall_timeout_ms=_database_admin_timeout_ms,
             dev_ops_api=True,
@@ -1179,7 +1220,7 @@ class AstraDBAdmin:
                 logger.info("polling capability check returned negative (DevOps API)")
                 raise PermissionError(CANNOT_POLL_ERROR_MESSAGE)
         logger.info(
-            f"creating database {name}/({cloud_provider}, {region}) (DevOps API)"
+            f"creating database {name}/({_definition.cloud_provider}, {_definition.region}) (DevOps API)"
         )
         cd_raw_response = self._dev_ops_api_commander.raw_request(
             caller_function_name="create_database",
@@ -1200,7 +1241,7 @@ class AstraDBAdmin:
         new_database_id = cd_raw_response.headers["Location"]
         logger.info(
             "DevOps API returned from creating database "
-            f"{name}/({cloud_provider}, {region})"
+            f"{name}/({_definition.cloud_provider}, {_definition.region})"
         )
         if wait_until_active:
             last_status_seen = DatabaseStatus.PENDING.value
@@ -1225,7 +1266,7 @@ class AstraDBAdmin:
         # return the database instance
         logger.info(
             f"finished creating database '{new_database_id}' = "
-            f"{name}/({cloud_provider}, {region}) (DevOps API)"
+            f"{name}/({_definition.cloud_provider}, {_definition.region}) (DevOps API)"
         )
         _final_api_options = self.api_options.with_override(
             spawn_api_options
@@ -1234,7 +1275,7 @@ class AstraDBAdmin:
             api_endpoint=build_api_endpoint(
                 environment=self.api_options.environment,
                 database_id=new_database_id,
-                region=region,
+                region=_definition.region,
             ),
             astra_db_admin=self,
             spawn_api_options=_final_api_options,
@@ -1244,8 +1285,9 @@ class AstraDBAdmin:
         self,
         name: str,
         *,
-        cloud_provider: str,
-        region: str,
+        definition: DatabaseDefinition | None = None,
+        cloud_provider: str | None = None,
+        region: str | None = None,
         keyspace: str | None = None,
         wait_until_active: bool = True,
         database_admin_timeout_ms: int | None = None,
@@ -1258,12 +1300,23 @@ class AstraDBAdmin:
         Create a database as requested, optionally waiting for it to be ready.
         This is an awaitable method suitable for use within an asyncio event loop.
 
+        The most common database configuration are available as keyword arguments.
+        If more control is needed, a `DatabaseDefinition` object can be provided instead.
+
         Args:
             name: the desired name for the database.
-            cloud_provider: one of 'aws', 'gcp' or 'azure'.
-            region: any of the available cloud regions.
+            definition: a DatabaseDefinition object for the database.
+                If provided, `cloud_provider`, `region`, and `keyspace`
+                must not be specified.
+            cloud_provider: one of 'aws', 'gcp' or 'azure'. Required if
+                `definition` is not provided.
+                Cannot be specified if `definition` is provided.
+            region: any of the available cloud regions. Required if
+                `definition` is not provided.
+                Cannot be specified if `definition` is provided.
             keyspace: name for the one keyspace the database starts with.
                 If omitted, DevOps API will use its default.
+                Cannot be specified if `definition` is provided.
             wait_until_active: if True (default), the method returns only after
                 the newly-created database is in ACTIVE state (a few minutes,
                 usually). If False, it will return right after issuing the
@@ -1298,16 +1351,58 @@ class AstraDBAdmin:
         creation request has not reached the API server and is not going
         to be, in fact, honored.
 
-        Example:
+        Examples:
+            >>> # call pattern using the basic parameters:
             >>> asyncio.run(
             ...     my_astra_db_admin.async_create_database(
             ...         "new_database",
             ...         cloud_provider="aws",
             ...         region="ap-south-1",
-            ....    )
+            ...     )
             ... )
             AstraDBDatabaseAdmin(id=...)
+            >>>
+            >>> # call pattern using the 'definition' parameter:
+            >>> my_custom_db_definition = DatabaseDefinition(
+            ...    cloud_provider="aws",
+            ...    region="ap-south-1",
+            ...    capacity_units=4,
+            ...    keyspace="staging_xyz",
+            ...    pcu_group_id="01234567-89ab-cdef-0123-456789abcdef",
+            ... )
+            >>> asyncio.run(
+            ...     my_astra_db_admin.create_database(
+            ...         "new_customized_database",
+            ...         definition=my_custom_db_definition,
+            ...     )
+            ... )
         """
+
+        # Validate parameter combinations
+        definition_fields = [cloud_provider, region, keyspace]
+        definition_fields_provided = any(f is not None for f in definition_fields)
+
+        if definition is not None and definition_fields_provided:
+            raise ValueError(
+                "Cannot specify both 'definition' and any of "
+                "'cloud_provider', 'region', 'keyspace'."
+            )
+
+        if definition is None:
+            if cloud_provider is None or region is None:
+                raise ValueError(
+                    "Either 'definition' or both 'cloud_provider' and 'region' "
+                    "must be provided."
+                )
+            # Build definition from individual parameters
+            _definition = DatabaseDefinition(
+                cloud_provider=cloud_provider,
+                region=region,
+                keyspace=keyspace,
+            ).with_defaults()
+        else:
+            # Use provided definition
+            _definition = definition.with_defaults()
 
         _database_admin_timeout_ms, _da_label = _first_valid_timeout(
             (database_admin_timeout_ms, "database_admin_timeout_ms"),
@@ -1322,19 +1417,7 @@ class AstraDBAdmin:
             (timeout_ms, "timeout_ms"),
             (self.api_options.timeout_options.request_timeout_ms, "request_timeout_ms"),
         )
-        cd_payload = {
-            k: v
-            for k, v in {
-                "name": name,
-                "tier": "serverless",
-                "cloudProvider": cloud_provider,
-                "region": region,
-                "capacityUnits": 1,
-                "dbType": "vector",
-                "keyspace": keyspace,
-            }.items()
-            if v is not None
-        }
+        cd_payload = _definition.as_dict(name=name)
         timeout_manager = MultiCallTimeoutManager(
             overall_timeout_ms=_database_admin_timeout_ms,
             dev_ops_api=True,
@@ -1352,7 +1435,7 @@ class AstraDBAdmin:
                 logger.info("polling capability check returned negative (DevOps API)")
                 raise PermissionError(CANNOT_POLL_ERROR_MESSAGE)
         logger.info(
-            f"creating database {name}/({cloud_provider}, {region}) (DevOps API), async"
+            f"creating database {name}/({_definition.cloud_provider}, {_definition.region}) (DevOps API), async"
         )
         cd_raw_response = await self._dev_ops_api_commander.async_raw_request(
             caller_function_name="async_create_database",
@@ -1373,7 +1456,7 @@ class AstraDBAdmin:
         new_database_id = cd_raw_response.headers["Location"]
         logger.info(
             "DevOps API returned from creating database "
-            f"{name}/({cloud_provider}, {region}), async"
+            f"{name}/({_definition.cloud_provider}, {_definition.region}), async"
         )
         if wait_until_active:
             last_status_seen = DatabaseStatus.PENDING.value
@@ -1400,7 +1483,7 @@ class AstraDBAdmin:
         # return the database instance
         logger.info(
             f"finished creating database '{new_database_id}' = "
-            f"{name}/({cloud_provider}, {region}) (DevOps API), async"
+            f"{name}/({_definition.cloud_provider}, {_definition.region}) (DevOps API), async"
         )
         _final_api_options = self.api_options.with_override(
             spawn_api_options
@@ -1409,7 +1492,7 @@ class AstraDBAdmin:
             api_endpoint=build_api_endpoint(
                 environment=self.api_options.environment,
                 database_id=new_database_id,
-                region=region,
+                region=_definition.region,
             ),
             astra_db_admin=self,
             spawn_api_options=_final_api_options,

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -19,7 +19,7 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from astrapy.admin.endpoints import (
     ParsedAPIEndpoint,
@@ -1062,6 +1062,36 @@ class AstraDBAdmin:
             environment=self.api_options.environment,
         )
 
+    @overload
+    def create_database(
+        self,
+        name: str,
+        *,
+        definition: DatabaseDefinition,
+        wait_until_active: bool = True,
+        database_admin_timeout_ms: int | None = None,
+        request_timeout_ms: int | None = None,
+        timeout_ms: int | None = None,
+        token: str | TokenProvider | UnsetType = _UNSET,
+        spawn_api_options: APIOptions | UnsetType = _UNSET,
+    ) -> AstraDBDatabaseAdmin: ...
+
+    @overload
+    def create_database(
+        self,
+        name: str,
+        *,
+        cloud_provider: str,
+        region: str,
+        keyspace: str | None = None,
+        wait_until_active: bool = True,
+        database_admin_timeout_ms: int | None = None,
+        request_timeout_ms: int | None = None,
+        timeout_ms: int | None = None,
+        token: str | TokenProvider | UnsetType = _UNSET,
+        spawn_api_options: APIOptions | UnsetType = _UNSET,
+    ) -> AstraDBDatabaseAdmin: ...
+
     def create_database(
         self,
         name: str,
@@ -1281,6 +1311,36 @@ class AstraDBAdmin:
             spawn_api_options=_final_api_options,
         )
 
+    @overload
+    async def async_create_database(
+        self,
+        name: str,
+        *,
+        definition: DatabaseDefinition,
+        wait_until_active: bool = True,
+        database_admin_timeout_ms: int | None = None,
+        request_timeout_ms: int | None = None,
+        timeout_ms: int | None = None,
+        token: str | TokenProvider | UnsetType = _UNSET,
+        spawn_api_options: APIOptions | UnsetType = _UNSET,
+    ) -> AstraDBDatabaseAdmin: ...
+
+    @overload
+    async def async_create_database(
+        self,
+        name: str,
+        *,
+        cloud_provider: str,
+        region: str,
+        keyspace: str | None = None,
+        wait_until_active: bool = True,
+        database_admin_timeout_ms: int | None = None,
+        request_timeout_ms: int | None = None,
+        timeout_ms: int | None = None,
+        token: str | TokenProvider | UnsetType = _UNSET,
+        spawn_api_options: APIOptions | UnsetType = _UNSET,
+    ) -> AstraDBDatabaseAdmin: ...
+
     async def async_create_database(
         self,
         name: str,
@@ -1371,7 +1431,7 @@ class AstraDBAdmin:
             ...    pcu_group_id="01234567-89ab-cdef-0123-456789abcdef",
             ... )
             >>> asyncio.run(
-            ...     my_astra_db_admin.create_database(
+            ...     my_astra_db_admin.async_create_database(
             ...         "new_customized_database",
             ...         definition=my_custom_db_definition,
             ...     )

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -1153,9 +1153,9 @@ class AstraDBAdmin:
             k: v
             for k, v in {
                 "name": name,
-                "tier": "serverless",
                 "cloudProvider": cloud_provider,
                 "region": region,
+                "tier": "serverless",
                 "capacityUnits": 1,
                 "dbType": "vector",
                 "keyspace": keyspace,

--- a/astrapy/data/info/database_info.py
+++ b/astrapy/data/info/database_info.py
@@ -20,6 +20,11 @@ from typing import Any
 
 from astrapy.admin.endpoints import build_api_endpoint, parse_api_endpoint
 from astrapy.data_types import DataAPITimestamp
+from astrapy.settings.defaults import (
+    DEFAULT_CREATE_DB_CAPACITY_UNITS,
+    DEFAULT_CREATE_DB_DB_TYPE,
+    DEFAULT_CREATE_DB_TIER,
+)
 from astrapy.utils.meta import deprecated_property
 from astrapy.utils.parsing import _warn_residual_keys
 
@@ -516,11 +521,13 @@ class DatabaseDefinition:
             name=self.name,
             cloud_provider=self.cloud_provider,
             region=self.region,
-            tier=self.tier if self.tier is not None else "serverless",
+            tier=self.tier if self.tier is not None else DEFAULT_CREATE_DB_TIER,
             capacity_units=self.capacity_units
             if self.capacity_units is not None
-            else 1,
-            db_type=self.db_type if self.db_type is not None else "vector",
+            else DEFAULT_CREATE_DB_CAPACITY_UNITS,
+            db_type=self.db_type
+            if self.db_type is not None
+            else DEFAULT_CREATE_DB_DB_TYPE,
             keyspace=self.keyspace,
             pcu_group_id=self.pcu_group_id,
         )

--- a/astrapy/data/info/database_info.py
+++ b/astrapy/data/info/database_info.py
@@ -417,10 +417,9 @@ class AstraDBAvailableRegionInfo:
 @dataclass
 class DatabaseDefinition:
     """
-    Represents a database definition for database creation operations.
+    Represents a database definition for database creation operations (excluding the DB name).
 
     Attributes:
-        name: the name of the database to create.
         cloud_provider: the cloud provider hosting the database (e.g. 'aws', 'gcp', 'azure').
         region: the region where the database will be created.
         tier: the database tier (e.g. 'serverless'). Optional, defaults to None.
@@ -430,7 +429,6 @@ class DatabaseDefinition:
         pcu_group_id: the PCU group ID to use for provisioning the database. Optional, defaults to None.
     """
 
-    name: str
     cloud_provider: str
     region: str
     tier: str | None = None
@@ -441,7 +439,6 @@ class DatabaseDefinition:
 
     def __repr__(self) -> str:
         pieces = [
-            f"name={self.name}",
             f"cloud_provider={self.cloud_provider}",
             f"region={self.region}",
         ]
@@ -457,15 +454,23 @@ class DatabaseDefinition:
             pieces.append(f"pcu_group_id={self.pcu_group_id}")
         return f"{self.__class__.__name__}({', '.join(pieces)})"
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self, *, name: str | None) -> dict[str, Any]:
         """
         Recast this object into a dictionary.
+
+        Args:
+            name: if provided, this is the name of the database and will
+                be used to enrich the result making it a complete payload
+                suitable for a DevOps API create-database invocation.
+
+        Returns:
+            a dictionary expressing the object (plus optionally a DB name).
         """
 
         return {
             k: v
             for k, v in {
-                "name": self.name,
+                "name": name,
                 "cloudProvider": self.cloud_provider,
                 "region": self.region,
                 "tier": self.tier,
@@ -482,6 +487,9 @@ class DatabaseDefinition:
         """
         Create an instance of DatabaseDefinition from a dictionary
         such as one from the Data API.
+
+        This operation, which should never be needed in ordinary client activity,
+        exceptionally ignores any 'name' field it would find.
         """
 
         _warn_residual_keys(
@@ -499,7 +507,6 @@ class DatabaseDefinition:
             },
         )
         return DatabaseDefinition(
-            name=raw_dict["name"],
             cloud_provider=raw_dict["cloudProvider"],
             region=raw_dict["region"],
             tier=raw_dict.get("tier"),
@@ -518,7 +525,6 @@ class DatabaseDefinition:
         This method assumes that non-optional fields are not None.
         """
         return DatabaseDefinition(
-            name=self.name,
             cloud_provider=self.cloud_provider,
             region=self.region,
             tier=self.tier if self.tier is not None else DEFAULT_CREATE_DB_TIER,

--- a/astrapy/data/info/database_info.py
+++ b/astrapy/data/info/database_info.py
@@ -407,3 +407,120 @@ class AstraDBAvailableRegionInfo:
             reserved_for_qualified_users=raw_dict["reservedForQualifiedUsers"],
             zone=raw_dict["zone"],
         )
+
+
+@dataclass
+class DatabaseDefinition:
+    """
+    Represents a database definition for database creation operations.
+
+    Attributes:
+        name: the name of the database to create.
+        cloud_provider: the cloud provider hosting the database (e.g. 'aws', 'gcp', 'azure').
+        region: the region where the database will be created.
+        tier: the database tier (e.g. 'serverless'). Optional, defaults to None.
+        capacity_units: the number of capacity units for the database. Optional, defaults to None.
+        db_type: the type of database (e.g. 'vector'). Optional, defaults to None.
+        keyspace: the default keyspace for the database. Optional, defaults to None.
+        pcu_group_id: the PCU group ID to use for provisioning the database. Optional, defaults to None.
+    """
+
+    name: str
+    cloud_provider: str
+    region: str
+    tier: str | None = None
+    capacity_units: int | None = None
+    db_type: str | None = None
+    keyspace: str | None = None
+    pcu_group_id: str | None = None
+
+    def __repr__(self) -> str:
+        pieces = [
+            f"name={self.name}",
+            f"cloud_provider={self.cloud_provider}",
+            f"region={self.region}",
+        ]
+        if self.tier is not None:
+            pieces.append(f"tier={self.tier}")
+        if self.capacity_units is not None:
+            pieces.append(f"capacity_units={self.capacity_units}")
+        if self.db_type is not None:
+            pieces.append(f"db_type={self.db_type}")
+        if self.keyspace is not None:
+            pieces.append(f"keyspace={self.keyspace}")
+        if self.pcu_group_id is not None:
+            pieces.append(f"pcu_group_id={self.pcu_group_id}")
+        return f"{self.__class__.__name__}({', '.join(pieces)})"
+
+    def as_dict(self) -> dict[str, Any]:
+        """
+        Recast this object into a dictionary.
+        """
+
+        return {
+            k: v
+            for k, v in {
+                "name": self.name,
+                "cloudProvider": self.cloud_provider,
+                "region": self.region,
+                "tier": self.tier,
+                "capacityUnits": self.capacity_units,
+                "dbType": self.db_type,
+                "keyspace": self.keyspace,
+                "pcuGroupUUID": self.pcu_group_id,
+            }.items()
+            if v is not None
+        }
+
+    @classmethod
+    def _from_dict(cls, raw_dict: dict[str, Any]) -> DatabaseDefinition:
+        """
+        Create an instance of DatabaseDefinition from a dictionary
+        such as one from the Data API.
+        """
+
+        _warn_residual_keys(
+            cls,
+            raw_dict,
+            {
+                "name",
+                "cloudProvider",
+                "region",
+                "tier",
+                "capacityUnits",
+                "dbType",
+                "keyspace",
+                "pcuGroupUUID",
+            },
+        )
+        return DatabaseDefinition(
+            name=raw_dict["name"],
+            cloud_provider=raw_dict["cloudProvider"],
+            region=raw_dict["region"],
+            tier=raw_dict.get("tier"),
+            capacity_units=raw_dict.get("capacityUnits"),
+            db_type=raw_dict.get("dbType"),
+            keyspace=raw_dict.get("keyspace"),
+            pcu_group_id=raw_dict.get("pcuGroupUUID"),
+        )
+
+    def with_defaults(self) -> DatabaseDefinition:
+        """
+        Return a new DatabaseDefinition with the default values for all
+        fields that are not set, such that the results makes for a valid
+        payload for a create-database DevOps API invocation,
+
+        This method assumes that non-optional fields are not None.
+        """
+        return DatabaseDefinition(
+            name=self.name,
+            cloud_provider=self.cloud_provider,
+            region=self.region,
+            tier=self.tier if self.tier is not None else "serverless",
+            capacity_units=self.capacity_units
+            if self.capacity_units is not None
+            else 1,
+            db_type=self.db_type if self.db_type is not None else "vector",
+            keyspace=self.keyspace,
+            pcu_group_id=self.pcu_group_id,
+        )

--- a/astrapy/info.py
+++ b/astrapy/info.py
@@ -27,6 +27,7 @@ from astrapy.data.info.database_info import (
     AstraDBAdminDatabaseInfo,
     AstraDBAvailableRegionInfo,
     AstraDBDatabaseInfo,
+    DatabaseDefinition,
 )
 from astrapy.data.info.reranking import (
     FindRerankingProvidersResult,
@@ -120,6 +121,7 @@ __all__ = [
     "ColumnType",
     "CreateTableDefinition",
     "CreateTypeDefinition",
+    "DatabaseDefinition",
     "EmbeddingAPIModelSupport",
     "EmbeddingProvider",
     "EmbeddingProviderAuthentication",

--- a/astrapy/repl.py
+++ b/astrapy/repl.py
@@ -121,6 +121,7 @@ from astrapy.info import (
     ColumnType,
     CreateTableDefinition,
     CreateTypeDefinition,
+    DatabaseDefinition,
     EmbeddingProvider,
     EmbeddingProviderAuthentication,
     EmbeddingProviderModel,

--- a/astrapy/settings/defaults.py
+++ b/astrapy/settings/defaults.py
@@ -98,6 +98,11 @@ DEV_OPS_RESPONSE_HTTP_UNAUTHORIZED = 401
 
 DEV_OPS_DEFAULT_DATABASES_PAGE_SIZE = 50
 
+# defaults for DevOps create-database DB definition
+DEFAULT_CREATE_DB_TIER = "serverless"
+DEFAULT_CREATE_DB_CAPACITY_UNITS = 1
+DEFAULT_CREATE_DB_DB_TYPE = "vector"
+
 # Settings for redacting secrets in string representations and logging
 SECRETS_REDACT_ENDING = "..."
 SECRETS_REDACT_CHAR = "*"

--- a/tests/base/unit/test_admin_create_database_async.py
+++ b/tests/base/unit/test_admin_create_database_async.py
@@ -1,0 +1,115 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from astrapy import AstraDBAdmin, DataAPIClient
+from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.settings.defaults import (
+    DEFAULT_CREATE_DB_CAPACITY_UNITS,
+    DEFAULT_CREATE_DB_DB_TYPE,
+    DEFAULT_CREATE_DB_TIER,
+    DEV_OPS_RESPONSE_HTTP_CREATED,
+)
+from astrapy.utils.request_tools import HttpMethod
+
+
+@pytest.fixture
+def mock_astra_admin(httpserver: HTTPServer) -> AstraDBAdmin:
+    base_endpoint = httpserver.url_for("/")
+    client = DataAPIClient(
+        environment="test",
+        api_options=APIOptions(
+            dev_ops_api_url_options=DevOpsAPIURLOptions(
+                dev_ops_url=base_endpoint,
+                dev_ops_api_version="vx",
+            )
+        ),
+    )
+
+    return client.get_admin()
+
+
+class TestAdminCreateDatabaseAsync:
+    @pytest.mark.describe("test of admin create database simple, async")
+    async def test_admin_create_database_simple_async(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        base_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "tier": DEFAULT_CREATE_DB_TIER,
+            "capacityUnits": DEFAULT_CREATE_DB_CAPACITY_UNITS,
+            "dbType": DEFAULT_CREATE_DB_DB_TYPE,
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=base_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            await mock_astra_admin.async_create_database(
+                "the_db_name",
+                cloud_provider="cp",
+                region="r",
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database rich, async")
+    async def test_admin_create_database_rich_async(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        # TODO add all of the optional params here
+        rich_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": DEFAULT_CREATE_DB_TIER,
+            "capacityUnits": DEFAULT_CREATE_DB_CAPACITY_UNITS,
+            "dbType": DEFAULT_CREATE_DB_DB_TYPE,
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=rich_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            await mock_astra_admin.async_create_database(
+                "the_db_name",
+                cloud_provider="cp",
+                region="r",
+                keyspace="ks",
+                wait_until_active=False,
+            )

--- a/tests/base/unit/test_admin_create_database_async.py
+++ b/tests/base/unit/test_admin_create_database_async.py
@@ -19,6 +19,7 @@ from pytest_httpserver import HTTPServer
 
 from astrapy import AstraDBAdmin, DataAPIClient
 from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.info import DatabaseDefinition
 from astrapy.settings.defaults import (
     DEFAULT_CREATE_DB_CAPACITY_UNITS,
     DEFAULT_CREATE_DB_DB_TYPE,
@@ -84,7 +85,6 @@ class TestAdminCreateDatabaseAsync:
         httpserver: HTTPServer,
         mock_astra_admin: AstraDBAdmin,
     ) -> None:
-        # TODO add all of the optional params here
         rich_payload = {
             "name": "the_db_name",
             "cloudProvider": "cp",
@@ -110,6 +110,69 @@ class TestAdminCreateDatabaseAsync:
                 "the_db_name",
                 cloud_provider="cp",
                 region="r",
+                keyspace="ks",
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database definition, async")
+    async def test_admin_create_database_definition_async(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        full_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": "tr",
+            "capacityUnits": 5,
+            "dbType": "ty",
+            "pcuGroupUUID": "d",
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=full_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        db_definition = DatabaseDefinition(
+            cloud_provider="cp",
+            region="r",
+            keyspace="ks",
+            tier="tr",
+            capacity_units=5,
+            db_type="ty",
+            pcu_group_id="d",
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            await mock_astra_admin.async_create_database(
+                "the_db_name",
+                definition=db_definition,
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database bad patterns, async")
+    async def test_admin_create_database_badpatterns_async(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        with pytest.raises(ValueError, match="must be provided"):
+            await mock_astra_admin.async_create_database(
+                "the_db_name", wait_until_active=False
+            )
+
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            await mock_astra_admin.async_create_database(
+                "the_db_name",
+                definition=DatabaseDefinition(cloud_provider="cp", region="r"),
                 keyspace="ks",
                 wait_until_active=False,
             )

--- a/tests/base/unit/test_admin_create_database_async.py
+++ b/tests/base/unit/test_admin_create_database_async.py
@@ -165,12 +165,12 @@ class TestAdminCreateDatabaseAsync:
         mock_astra_admin: AstraDBAdmin,
     ) -> None:
         with pytest.raises(ValueError, match="must be provided"):
-            await mock_astra_admin.async_create_database(
+            await mock_astra_admin.async_create_database(  # type: ignore[call-overload]
                 "the_db_name", wait_until_active=False
             )
 
         with pytest.raises(ValueError, match="Cannot specify both"):
-            await mock_astra_admin.async_create_database(
+            await mock_astra_admin.async_create_database(  # type: ignore[call-overload]
                 "the_db_name",
                 definition=DatabaseDefinition(cloud_provider="cp", region="r"),
                 keyspace="ks",

--- a/tests/base/unit/test_admin_create_database_sync.py
+++ b/tests/base/unit/test_admin_create_database_sync.py
@@ -1,0 +1,115 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from astrapy import AstraDBAdmin, DataAPIClient
+from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.settings.defaults import (
+    DEFAULT_CREATE_DB_CAPACITY_UNITS,
+    DEFAULT_CREATE_DB_DB_TYPE,
+    DEFAULT_CREATE_DB_TIER,
+    DEV_OPS_RESPONSE_HTTP_CREATED,
+)
+from astrapy.utils.request_tools import HttpMethod
+
+
+@pytest.fixture
+def mock_astra_admin(httpserver: HTTPServer) -> AstraDBAdmin:
+    base_endpoint = httpserver.url_for("/")
+    client = DataAPIClient(
+        environment="test",
+        api_options=APIOptions(
+            dev_ops_api_url_options=DevOpsAPIURLOptions(
+                dev_ops_url=base_endpoint,
+                dev_ops_api_version="vx",
+            )
+        ),
+    )
+
+    return client.get_admin()
+
+
+class TestAdminCreateDatabaseSync:
+    @pytest.mark.describe("test of admin create database simple, sync")
+    def test_admin_create_database_simple_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        base_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "tier": DEFAULT_CREATE_DB_TIER,
+            "capacityUnits": DEFAULT_CREATE_DB_CAPACITY_UNITS,
+            "dbType": DEFAULT_CREATE_DB_DB_TYPE,
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=base_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            mock_astra_admin.create_database(
+                "the_db_name",
+                cloud_provider="cp",
+                region="r",
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database rich, sync")
+    def test_admin_create_database_rich_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        # TODO add all of the optional params here
+        rich_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": DEFAULT_CREATE_DB_TIER,
+            "capacityUnits": DEFAULT_CREATE_DB_CAPACITY_UNITS,
+            "dbType": DEFAULT_CREATE_DB_DB_TYPE,
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=rich_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            mock_astra_admin.create_database(
+                "the_db_name",
+                cloud_provider="cp",
+                region="r",
+                keyspace="ks",
+                wait_until_active=False,
+            )

--- a/tests/base/unit/test_admin_create_database_sync.py
+++ b/tests/base/unit/test_admin_create_database_sync.py
@@ -165,10 +165,10 @@ class TestAdminCreateDatabaseSync:
         mock_astra_admin: AstraDBAdmin,
     ) -> None:
         with pytest.raises(ValueError, match="must be provided"):
-            mock_astra_admin.create_database("the_db_name", wait_until_active=False)
+            mock_astra_admin.create_database("the_db_name", wait_until_active=False)  # type: ignore[call-overload]
 
         with pytest.raises(ValueError, match="Cannot specify both"):
-            mock_astra_admin.create_database(
+            mock_astra_admin.create_database(  # type: ignore[call-overload]
                 "the_db_name",
                 definition=DatabaseDefinition(cloud_provider="cp", region="r"),
                 keyspace="ks",

--- a/tests/base/unit/test_admin_create_database_sync.py
+++ b/tests/base/unit/test_admin_create_database_sync.py
@@ -19,6 +19,7 @@ from pytest_httpserver import HTTPServer
 
 from astrapy import AstraDBAdmin, DataAPIClient
 from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.info import DatabaseDefinition
 from astrapy.settings.defaults import (
     DEFAULT_CREATE_DB_CAPACITY_UNITS,
     DEFAULT_CREATE_DB_DB_TYPE,
@@ -84,7 +85,6 @@ class TestAdminCreateDatabaseSync:
         httpserver: HTTPServer,
         mock_astra_admin: AstraDBAdmin,
     ) -> None:
-        # TODO add all of the optional params here
         rich_payload = {
             "name": "the_db_name",
             "cloudProvider": "cp",
@@ -110,6 +110,67 @@ class TestAdminCreateDatabaseSync:
                 "the_db_name",
                 cloud_provider="cp",
                 region="r",
+                keyspace="ks",
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database definition, sync")
+    def test_admin_create_database_definition_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        full_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": "tr",
+            "capacityUnits": 5,
+            "dbType": "ty",
+            "pcuGroupUUID": "d",
+        }
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=full_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        db_definition = DatabaseDefinition(
+            cloud_provider="cp",
+            region="r",
+            keyspace="ks",
+            tier="tr",
+            capacity_units=5,
+            db_type="ty",
+            pcu_group_id="d",
+        )
+
+        # We prepare for failure here, but it's a good failure: we want to ensure the httpserver
+        # gets the right payload and the error is when the client instantiates the db admin all right.
+        with pytest.raises(ValueError, match="Cannot parse the supplied API endpoint"):
+            mock_astra_admin.create_database(
+                "the_db_name",
+                definition=db_definition,
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe("test of admin create database bad patterns, sync")
+    def test_admin_create_database_badpatterns_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        with pytest.raises(ValueError, match="must be provided"):
+            mock_astra_admin.create_database("the_db_name", wait_until_active=False)
+
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            mock_astra_admin.create_database(
+                "the_db_name",
+                definition=DatabaseDefinition(cloud_provider="cp", region="r"),
                 keyspace="ks",
                 wait_until_active=False,
             )

--- a/tests/base/unit/test_collection_timeouts.py
+++ b/tests/base/unit/test_collection_timeouts.py
@@ -1,3 +1,17 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import time

--- a/tests/base/unit/test_imports.py
+++ b/tests/base/unit/test_imports.py
@@ -179,6 +179,7 @@ def test_imports() -> None:
         ColumnType,
         CreateTableDefinition,
         CreateTypeDefinition,
+        DatabaseDefinition,
         EmbeddingProvider,
         EmbeddingProviderAuthentication,
         EmbeddingProviderModel,

--- a/tests/base/unit/test_info.py
+++ b/tests/base/unit/test_info.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import pytest
 
 from astrapy.admin import ParsedAPIEndpoint, parse_api_endpoint
-from astrapy.info import AstraDBAvailableRegionInfo
+from astrapy.info import AstraDBAvailableRegionInfo, DatabaseDefinition
 
 
 @pytest.mark.describe("test of parsing API endpoints")
@@ -82,3 +82,67 @@ def test_parse_availableregioninfo() -> None:
         "zone": "na",
     }
     assert AstraDBAvailableRegionInfo._from_dict(region_dict).as_dict() == region_dict
+
+
+@pytest.mark.describe("test of marshaling and unmarshaling of database definition")
+def test_parse_databasedefinition() -> None:
+    def_payload0 = {
+        "name": "the_name0",
+        "cloudProvider": "the_cloudProvider0",
+        "region": "the_region0",
+    }
+    def_payload1 = {
+        "name": "the_name1",
+        "cloudProvider": "the_cloudProvider1",
+        "region": "the_region1",
+        "tier": "the_tier1",
+        "capacityUnits": 9999,
+        "dbType": "the_dbType1",
+        "keyspace": "the_keyspace1",
+        "pcuGroupUUID": "the_pcuGroupUUID1",
+    }
+
+    # _from_dict + default, dict match test
+
+    db_def0 = DatabaseDefinition._from_dict(def_payload0)
+    db_def1 = DatabaseDefinition._from_dict(def_payload1)
+    expected_pload0 = {
+        "name": "the_name0",
+        "cloudProvider": "the_cloudProvider0",
+        "region": "the_region0",
+        "tier": "serverless",
+        "capacityUnits": 1,
+        "dbType": "vector",
+    }
+    expected_pload1 = {
+        "name": "the_name1",
+        "cloudProvider": "the_cloudProvider1",
+        "region": "the_region1",
+        "tier": "the_tier1",
+        "capacityUnits": 9999,
+        "dbType": "the_dbType1",
+        "keyspace": "the_keyspace1",
+        "pcuGroupUUID": "the_pcuGroupUUID1",
+    }
+    assert db_def0.with_defaults().as_dict() == expected_pload0
+    assert db_def1.with_defaults().as_dict() == expected_pload1
+
+    # instance match test
+
+    built_def0 = DatabaseDefinition(
+        name="the_name0",
+        cloud_provider="the_cloudProvider0",
+        region="the_region0",
+    )
+    built_def1 = DatabaseDefinition(
+        name="the_name1",
+        cloud_provider="the_cloudProvider1",
+        region="the_region1",
+        tier="the_tier1",
+        capacity_units=9999,
+        db_type="the_dbType1",
+        keyspace="the_keyspace1",
+        pcu_group_id="the_pcuGroupUUID1",
+    )
+    assert built_def0 == db_def0
+    assert built_def1 == db_def1

--- a/tests/base/unit/test_info.py
+++ b/tests/base/unit/test_info.py
@@ -22,6 +22,11 @@ import pytest
 
 from astrapy.admin import ParsedAPIEndpoint, parse_api_endpoint
 from astrapy.info import AstraDBAvailableRegionInfo, DatabaseDefinition
+from astrapy.settings.defaults import (
+    DEFAULT_CREATE_DB_CAPACITY_UNITS,
+    DEFAULT_CREATE_DB_DB_TYPE,
+    DEFAULT_CREATE_DB_TIER,
+)
 
 
 @pytest.mark.describe("test of parsing API endpoints")
@@ -110,9 +115,9 @@ def test_parse_databasedefinition() -> None:
         "name": "the_name0",
         "cloudProvider": "the_cloudProvider0",
         "region": "the_region0",
-        "tier": "serverless",
-        "capacityUnits": 1,
-        "dbType": "vector",
+        "tier": DEFAULT_CREATE_DB_TIER,
+        "capacityUnits": DEFAULT_CREATE_DB_CAPACITY_UNITS,
+        "dbType": DEFAULT_CREATE_DB_DB_TYPE,
     }
     expected_pload1 = {
         "name": "the_name1",

--- a/tests/base/unit/test_info.py
+++ b/tests/base/unit/test_info.py
@@ -129,18 +129,16 @@ def test_parse_databasedefinition() -> None:
         "keyspace": "the_keyspace1",
         "pcuGroupUUID": "the_pcuGroupUUID1",
     }
-    assert db_def0.with_defaults().as_dict() == expected_pload0
-    assert db_def1.with_defaults().as_dict() == expected_pload1
+    assert db_def0.with_defaults().as_dict(name="the_name0") == expected_pload0
+    assert db_def1.with_defaults().as_dict(name="the_name1") == expected_pload1
 
     # instance match test
 
     built_def0 = DatabaseDefinition(
-        name="the_name0",
         cloud_provider="the_cloudProvider0",
         region="the_region0",
     )
     built_def1 = DatabaseDefinition(
-        name="the_name1",
         cloud_provider="the_cloudProvider1",
         region="the_region1",
         tier="the_tier1",


### PR DESCRIPTION
This PR expands the capabilities of the AstraDBAdmin's `create_database` (+ `async_`) by exposing the payload settings so far hardcoded in the clients (db type + capacity units + tier), and the newly-introduced "pcu group uuid".

This is done not with additional keyword arguments, one per setting, rather with the introduction of a `DatabaseDefinition` object with all properties (minus `name`, kept separate as customary in client createXYZ method signatures) and a new `definition` parameter to `create_database`, mutually exclusive with the (pre-existing) corresponding keyword arguments.

Tests and examples in the docstring will explain the rest.

Fixes #408 .