### PR TITLE
chore: skip integration tests when no target DB is configured

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Bugfix: faulty normalization of empty/null indexing targets for `CollectionDefin
 maintenance: integration testing gets an embedding provider switcher logic
 maintenance: integration tests use the latest HCD (2.0.6) and a recent Data API build (1.0.46)
 maintenance: integration tests have configurable page size for find pagination
+maintenance: integration tests are skipped (instead of aborting collection) when no target DB is configured, so the unit-test suite can run without credentials
 
 v 2.2.1
 =======

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -65,7 +65,9 @@ Tests can be run on three types of Data API _targets_ (with slight differences i
 
 Depending on the target chosen, different environment variables are needed: refer to
 the `tests/env_templates/*.base.template` examples.
-Note that the variables defined in the desired "base" template **must** be set to run test, even for unit tests.
+Note that the variables defined in the desired "base" template **must** be set to run the integration tests.
+If no target DB is configured at all, the integration tests are automatically skipped, so the pure unit tests
+(those that need no database) can still be run with no environment setup.
 
 Additionally, you will need to define the environment variables in `tests/env_templates/env.vectorize-minimal.template`,
 which are needed by the minimal set of "vectorize" testing belonging to the "base" test group.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ from .preprocess_env import (
     LOCAL_DATA_API_USERNAME,
     RUN_SHARED_SECRET_VECTORIZE_TESTS,
     SECONDARY_KEYSPACE,
+    TARGET_DB_EMPTY,
     USE_RERANKER_API_KEY_HEADER,
 )
 
@@ -198,6 +199,50 @@ def clean_nulls_from_dict(in_dict: dict[str, Any]) -> dict[str, Any]:
             return _in
 
     return _cleand(in_dict)  # type: ignore[no-any-return]
+
+
+# Fixtures (directly or transitively, via the fixture closure) that require a
+# reachable target database. Every integration test ends up depending on
+# `data_api_credentials_kwargs`, which performs network calls during setup.
+_DB_REQUIRING_FIXTURES = frozenset(
+    {
+        "data_api_credentials_kwargs",
+        "data_api_credentials_info",
+        "client",
+        "sync_database",
+        "async_database",
+        "cql_session",
+    }
+)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """
+    Skip integration tests when no target Data API/DB is configured.
+
+    With no credentials set, `tests/preprocess_env` leaves `TARGET_DB_EMPTY`
+    True. In that case every test located under an `integration` directory, as
+    well as every test whose fixture closure needs a live database, is marked
+    as skipped. This lets `pytest tests/base/unit` (and the whole suite) run
+    without any database credentials instead of aborting collection.
+
+    When a target DB *is* configured (always the case in CI), `TARGET_DB_EMPTY`
+    is False and this hook is a no-op: the full suite runs exactly as before.
+    """
+    if not TARGET_DB_EMPTY:
+        return
+    skip_no_target_db = pytest.mark.skip(
+        reason=(
+            "No target Data API/DB configured: set ASTRA_DB_API_ENDPOINT "
+            "(plus token) or LOCAL_DATA_API_ENDPOINT to run integration tests."
+        )
+    )
+    for item in items:
+        needs_db = "integration" in item.path.parts or bool(
+            _DB_REQUIRING_FIXTURES & set(getattr(item, "fixturenames", ()))
+        )
+        if needs_db:
+            item.add_marker(skip_no_target_db)
 
 
 @pytest.fixture(scope="session")
@@ -373,6 +418,7 @@ __all__ = [
     "LOCAL_DATA_API_ENDPOINT",
     "LOCAL_DATA_API_KEYSPACE",
     "SECONDARY_KEYSPACE",
+    "TARGET_DB_EMPTY",
     "ADMIN_ENV_LIST",
     "ADMIN_ENV_VARIABLE_MAP",
     "ASTRA_DB_TOKEN_PROVIDER",

--- a/tests/preprocess_env.py
+++ b/tests/preprocess_env.py
@@ -42,6 +42,10 @@ docker_compose_filepath = os.path.join(base_dir, "hcd_compose")
 IS_ASTRA_DB: bool
 DOCKER_COMPOSE_LOCAL_DATA_API: bool
 SECONDARY_KEYSPACE: str
+# True when no target Data API/DB is configured at all. In that case the
+# integration tests are skipped (see pytest_collection_modifyitems in
+# tests/conftest.py) so that the unit-test suite can run without credentials.
+TARGET_DB_EMPTY: bool = False
 ASTRA_DB_API_ENDPOINT: str | None = None
 ASTRA_DB_APPLICATION_TOKEN: str | None = None
 ASTRA_DB_KEYSPACE: str | None = None
@@ -125,7 +129,14 @@ elif "ASTRA_DB_API_ENDPOINT" in os.environ and os.environ["ASTRA_DB_API_ENDPOINT
     ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
     ASTRA_DB_KEYSPACE = os.environ.get("ASTRA_DB_KEYSPACE", DEFAULT_ASTRA_DB_KEYSPACE)
 else:
-    raise ValueError("No credentials.")
+    # No target Data API/DB configured: rather than aborting collection of the
+    # whole test suite, flag this so that the integration tests get skipped
+    # (the unit tests, which need no database, still run). Safe defaults are set
+    # for the names imported elsewhere (e.g. by skipif markers using IS_ASTRA_DB).
+    IS_ASTRA_DB = False
+    DOCKER_COMPOSE_LOCAL_DATA_API = False
+    SECONDARY_KEYSPACE = DEFAULT_SECONDARY_KEYSPACE
+    TARGET_DB_EMPTY = True
 
 RUN_SHARED_SECRET_VECTORIZE_TESTS = extended_booleanize_env(
     "RUN_SHARED_SECRET_VECTORIZE_TESTS", default=True
@@ -134,18 +145,19 @@ RUN_SHARED_SECRET_VECTORIZE_TESTS = extended_booleanize_env(
 if os.environ.get("HEADER_RERANKING_API_KEY_NVIDIA") is not None:
     USE_RERANKER_API_KEY_HEADER = True
 
-# token provider setup
-if IS_ASTRA_DB:
-    ASTRA_DB_TOKEN_PROVIDER = StaticTokenProvider(ASTRA_DB_APPLICATION_TOKEN)
-else:
-    # there must be a user/pwd pair
-    if LOCAL_DATA_API_USERNAME and LOCAL_DATA_API_PASSWORD:
-        LOCAL_DATA_API_TOKEN_PROVIDER = UsernamePasswordTokenProvider(
-            username=LOCAL_DATA_API_USERNAME,
-            password=LOCAL_DATA_API_PASSWORD,
-        )
+# token provider setup (skipped entirely when no target DB is configured)
+if not TARGET_DB_EMPTY:
+    if IS_ASTRA_DB:
+        ASTRA_DB_TOKEN_PROVIDER = StaticTokenProvider(ASTRA_DB_APPLICATION_TOKEN)
     else:
-        raise ValueError("No full authentication data for local Data API")
+        # there must be a user/pwd pair
+        if LOCAL_DATA_API_USERNAME and LOCAL_DATA_API_PASSWORD:
+            LOCAL_DATA_API_TOKEN_PROVIDER = UsernamePasswordTokenProvider(
+                username=LOCAL_DATA_API_USERNAME,
+                password=LOCAL_DATA_API_PASSWORD,
+            )
+        else:
+            raise ValueError("No full authentication data for local Data API")
 
 
 # Ensure docker compose, if needed, is started and ready before anything else


### PR DESCRIPTION
## Summary

Running **any** test in this repo currently requires a target Data API/DB to be configured. With no credentials set, `tests/conftest.py` imports `tests/preprocess_env`, which raises `ValueError("No credentials.")` at module-load time — aborting **collection of the entire suite, including the unit tests**:

```
ImportError while loading conftest 'tests/conftest.py'.
tests/preprocess_env.py:128: in <module>
    raise ValueError("No credentials.")
E   ValueError: No credentials.
```

This PR makes the **integration tests skip** (instead of crashing the run) when no target DB is configured, so contributors can run the unit suite with zero environment setup.

## What changed

- **`tests/preprocess_env.py`** — when none of `ASTRA_DB_API_ENDPOINT` / `LOCAL_DATA_API_ENDPOINT` / `DOCKER_COMPOSE_LOCAL_DATA_API` is set, record this via a new `TARGET_DB_EMPTY` flag (with safe defaults for `IS_ASTRA_DB`, `DOCKER_COMPOSE_LOCAL_DATA_API`, `SECONDARY_KEYSPACE`) instead of raising. The token-provider setup is guarded accordingly.
- **`tests/conftest.py`** — add a `pytest_collection_modifyitems` hook that, when `TARGET_DB_EMPTY`, skips every test located under an `integration/` directory **or** whose fixture closure needs a live database (`data_api_credentials_kwargs` & friends — `data_api_credentials_kwargs` is the only fixture that performs network calls during setup, and all integration tests depend on it transitively).
- **`CHANGES`**, **`DEVELOPING.md`** — documentation.

## Safety: no CI behavior change

When a target DB **is** configured (always the case in CI), `TARGET_DB_EMPTY` is `False` and the hook returns immediately — a complete no-op. `unit.yml` is intentionally left untouched (it still passes credentials), so the DB-dependent unit tests keep running there with full coverage.

## Test plan

Verified locally with **no** DB env configured:

- `pytest tests/base --collect-only` → **730 collected, no crash** (previously: hard `ValueError`).
- `pytest tests/base/unit` → **257 passed, 36 skipped, 0 DB errors**. *(One unrelated failure, `test_dataapitimestamp_lifecycle`, reproduces on `main` too — it's a local-timezone artifact and passes in UTC CI.)*
- `pytest tests/base/integration` → **436 skipped, 0 errors**.
- `pytest tests/admin tests/vectorize` → **19 skipped, 0 errors**.
- `TARGET_DB_EMPTY` is `True` with no creds, `False` with Astra creds (hook no-ops in CI).
- `ruff check tests`, `ruff format --check tests`, `mypy tests` → all clean.