### PR TITLE
chore: bump idna and pygments in uv.lock to clear Dependabot alerts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Bugfix: faulty normalization of empty/null indexing targets for `CollectionDefin
 maintenance: integration testing gets an embedding provider switcher logic
 maintenance: integration tests use the latest HCD (2.0.6) and a recent Data API build (1.0.46)
 maintenance: integration tests have configurable page size for find pagination
+maintenance: bump idna (3.10->3.18) and pygments (2.19.2->2.20.0) in uv.lock to clear Dependabot alerts (remaining alerts require dropping Python 3.9)
 
 v 2.2.1
 =======

--- a/uv.lock
+++ b/uv.lock
@@ -582,11 +582,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1058,11 +1058,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the Dependabot security alerts that can be cleared **without dropping Python 3.9 support** — a lock-file-only change (transitive dependencies, no `pyproject.toml` constraints touched):

| Alert | Package | Bump | Advisory | Patched in | py3.9? |
|------|---------|------|----------|-----------|--------|
| #32 (medium) | `idna` | 3.10 → 3.18 | `idna.encode()` can bypass the CVE-2024-3651 fix | 3.15 | ✅ requires `>=3.8` |
| #27 (low) | `pygments` | 2.19.2 → 2.20.0 | ReDoS in GUID-matching regex | 2.20.0 | ✅ requires `>=3.9` |

Both patched versions still support Python 3.9, so uv resolves each to a single (non-forked) version and the alerts clear.

## Why the other 7 alerts are not included

The remaining open alerts — `urllib3` (#30, #31), `requests` (#26), `python-dotenv` (#29), `pytest` (#28), `filelock` (#20, #23) — **cannot be cleared while the project supports Python 3.9**. Every one of their first-patched versions requires `python >=3.10`:

- `urllib3 2.7.0`, `requests 2.33.0`, `python-dotenv 1.2.2`, `pytest 9.0.3`, `filelock 3.20.3` → all `requires-python >=3.10`.

With `requires-python = ">=3.9"`, uv forks the resolution: it installs the patched version for py3.10+ but **keeps the vulnerable version pinned for the py3.9 branch** of `uv.lock`. Dependabot scans the whole lock, so the alert stays open. (`filelock` already demonstrates this today — it's at the safe 3.24.3 for py3.10+ but stuck at 3.18.0 for py3.9.) These are the same exceptions documented in #398 ("address dependabot vulns except incompatible with supporting py 3.9").

Clearing those 7 requires a separate decision to drop Python 3.9 (already EOL as of Oct 2025), which is out of scope for a routine version-bump PR.

## Test plan

- [x] `ruff check astrapy tests` — passes
- [x] `ruff format --check astrapy tests` — passes
- [x] `mypy astrapy tests` — passes (215 files, no issues)
- [x] `pytest tests/base/unit` — no new failures vs. baseline (idna/pygments are transitive deps unused at the astrapy layer)
- [ ] CI green