### PR TITLE
Minor cursor behaviour improvements (+ testing)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,9 @@ CollectionDefinition fluent interface: renamed all `set_*` methods to `with_*` (
     - This better conveys the immutable builder pattern (methods return new objects rather than mutating in place)
     - Old `set_*` methods remain as deprecated aliases (deprecated in 2.3.0, will be removed in 3.0.0)
     - Affected methods: `with_indexing`, `with_default_id`, `with_vector_dimension`, `with_vector_metric`, `with_vector_source_model`, `with_vector_service`, `with_rerank`, `with_lexical`
+Minor cursor behaviour changes:
+    - has_next called on an IDLE cursor sets it to ACTIVE;
+    - has_next may set the cursor to CLOSED if no next items are detected.
 Added support for overriding reranking options in find_and_rerank method call.
 Added support for custom CA certificates (PEM) in the APIOptions (new `ca_cert_path` parameter)
 Bugfix: faulty normalization of empty/null indexing targets for `CollectionDefinition.set_indexing`

--- a/astrapy/data/cursors/farr_cursor.py
+++ b/astrapy/data/cursors/farr_cursor.py
@@ -851,7 +851,11 @@ class CollectionFindAndRerankCursor(
         if self._state == CursorState.CLOSED:
             return False
         self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """
@@ -1640,7 +1644,11 @@ class AsyncCollectionFindAndRerankCursor(
         if self._state == CursorState.CLOSED:
             return False
         await self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     async def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """

--- a/astrapy/data/cursors/farr_cursor.py
+++ b/astrapy/data/cursors/farr_cursor.py
@@ -249,6 +249,7 @@ class CollectionFindAndRerankCursor(
                         ),
                     )
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1
@@ -1131,6 +1132,7 @@ class AsyncCollectionFindAndRerankCursor(
                         cap_timeout_label=self._request_timeout_label,
                     ),
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1

--- a/astrapy/data/cursors/farr_cursor.py
+++ b/astrapy/data/cursors/farr_cursor.py
@@ -839,8 +839,8 @@ class CollectionFindAndRerankCursor(
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item
@@ -1632,8 +1632,8 @@ class AsyncCollectionFindAndRerankCursor(
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item

--- a/astrapy/data/cursors/find_cursor.py
+++ b/astrapy/data/cursors/find_cursor.py
@@ -1866,7 +1866,7 @@ class TableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This operation is allowed only if the cursor state is still IDLE.
 
         Instead of explicitly invoking this method, the typical usage consists
-        in passing arguments to the Collection `find` method.
+        in passing arguments to the Table `find` method.
 
         Args:
             initial_page_state: a new initial_page_state setting to apply to the
@@ -2639,7 +2639,7 @@ class AsyncTableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This operation is allowed only if the cursor state is still IDLE.
 
         Instead of explicitly invoking this method, the typical usage consists
-        in passing arguments to the Collection `find` method.
+        in passing arguments to the Table `find` method.
 
         Args:
             initial_page_state: a new initial_page_state setting to apply to the

--- a/astrapy/data/cursors/find_cursor.py
+++ b/astrapy/data/cursors/find_cursor.py
@@ -720,8 +720,8 @@ class CollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item
@@ -1427,8 +1427,8 @@ class AsyncCollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item
@@ -2200,8 +2200,8 @@ class TableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item
@@ -2905,8 +2905,8 @@ class AsyncTableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         This method can trigger the fetch operation of a new page, if the current
         buffer is empty.
 
-        Calling `has_next` on an IDLE cursor triggers the first page fetch, but the
-        cursor stays in the IDLE state until actual consumption starts.
+        Calling `has_next` on an IDLE cursor triggers the first page fetch, transitioning
+        the cursor into the STARTED state.
 
         Returns:
             a boolean value of True if there is at least one further item

--- a/astrapy/data/cursors/find_cursor.py
+++ b/astrapy/data/cursors/find_cursor.py
@@ -213,6 +213,7 @@ class CollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
                         ),
                     )
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1
@@ -999,6 +1000,7 @@ class AsyncCollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
                         cap_timeout_label=self._request_timeout_label,
                     ),
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1
@@ -1685,6 +1687,7 @@ class TableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
                         ),
                     )
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1
@@ -2468,6 +2471,7 @@ class AsyncTableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
                         cap_timeout_label=self._request_timeout_label,
                     ),
                 )
+                self._state = CursorState.STARTED
                 self._next_page_state = next_page_state
                 self._last_response_status = resp_status
                 self._pages_retrieved += 1

--- a/astrapy/data/cursors/find_cursor.py
+++ b/astrapy/data/cursors/find_cursor.py
@@ -732,7 +732,11 @@ class CollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         if self._state == CursorState.CLOSED:
             return False
         self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """
@@ -1435,7 +1439,11 @@ class AsyncCollectionFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         if self._state == CursorState.CLOSED:
             return False
         await self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     async def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """
@@ -2204,7 +2212,11 @@ class TableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         if self._state == CursorState.CLOSED:
             return False
         self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """
@@ -2905,7 +2917,11 @@ class AsyncTableFindCursor(Generic[TRAW, T], AbstractCursor[TRAW]):
         if self._state == CursorState.CLOSED:
             return False
         await self._try_ensure_fill_buffer()
-        return len(self._buffer) > 0
+        if self._buffer != []:
+            return True
+        else:
+            self._state = CursorState.CLOSED
+            return False
 
     async def get_sort_vector(self) -> list[float] | DataAPIVector | None:
         """

--- a/tests/base/integration/collections/test_collection_cursor_async.py
+++ b/tests/base/integration/collections/test_collection_cursor_async.py
@@ -248,7 +248,11 @@ class TestCollectionCursorSync:
     ) -> None:
         cur = async_filled_collection.find({"p_text": "ZZ"})
         assert not await cur.has_next()
-        assert [doc async for doc in cur] == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            [doc async for doc in cur]
+        with pytest.raises(CursorException):
+            await cur.to_list()
 
     @pytest.mark.describe("test of prematurely closing collection cursors, async")
     async def test_collection_cursors_early_closing_async(

--- a/tests/base/integration/collections/test_collection_cursor_async.py
+++ b/tests/base/integration/collections/test_collection_cursor_async.py
@@ -98,23 +98,23 @@ class TestCollectionCursorSync:
         with pytest.raises(CursorException):
             await toclose.to_list()
 
-        cur.rewind()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
-        assert cur.buffered_count == 0
+        toclose.rewind()
+        assert toclose.state == CursorState.IDLE  # type: ignore[comparison-overlap]
+        assert toclose.consumed == 0
+        assert toclose.buffered_count == 0
 
-        cur.filter({"c": True})
-        cur.project({"c": True})
-        cur.sort({"c": SortMode.ASCENDING})
-        cur.limit(1)
-        cur.include_similarity(False)
-        cur.include_sort_vector(False)
-        cur.skip(1)
-        cur.map(lambda rw: None)
+        toclose.filter({"c": True})
+        toclose.project({"c": True})
+        toclose.sort({"c": SortMode.ASCENDING})
+        toclose.limit(1)
+        toclose.include_similarity(False)
+        toclose.include_sort_vector(False)
+        toclose.skip(1)
+        toclose.map(lambda rw: None)
 
-        cur.project({}).map(lambda rw: None)
+        toclose.project({}).map(lambda rw: None)
         with pytest.raises(CursorException):
-            cur.map(lambda rw: None).project({})
+            toclose.map(lambda rw: None).project({})
 
     @pytest.mark.describe("test of a CLOSED collection cursors properties, async")
     async def test_collection_cursors_closed_properties_async(
@@ -154,6 +154,8 @@ class TestCollectionCursorSync:
             cur1.skip(1)
         with pytest.raises(CursorException):
             cur1.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur1.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of a STARTED collection cursors properties, async")
     async def test_collection_cursors_started_properties_async(
@@ -192,6 +194,8 @@ class TestCollectionCursorSync:
             cur.skip(1)
         with pytest.raises(CursorException):
             cur.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of collection cursors has_next, async")
     async def test_collection_cursors_has_next_async(
@@ -204,9 +208,11 @@ class TestCollectionCursorSync:
         assert cur.has_next()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
+        await cur.__anext__()
+        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
         [doc async for doc in cur]
         assert cur.consumed == NUM_DOCS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = async_filled_collection.find()
         await curmf.__anext__()

--- a/tests/base/integration/collections/test_collection_cursor_async.py
+++ b/tests/base/integration/collections/test_collection_cursor_async.py
@@ -202,14 +202,20 @@ class TestCollectionCursorSync:
         self,
         async_filled_collection: DefaultAsyncCollection,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = async_filled_collection.find()
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert await cur_hn.has_next()
+        assert cur_hn.consumed == 0
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = async_filled_collection.find()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert await cur.has_next()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
         await cur.__anext__()
-        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.STARTED
         [doc async for doc in cur]
         assert cur.consumed == NUM_DOCS
         assert cur.state == CursorState.CLOSED

--- a/tests/base/integration/collections/test_collection_cursor_async.py
+++ b/tests/base/integration/collections/test_collection_cursor_async.py
@@ -205,7 +205,7 @@ class TestCollectionCursorSync:
         cur = async_filled_collection.find()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert cur.has_next()
+        assert await cur.has_next()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
         await cur.__anext__()
@@ -219,7 +219,7 @@ class TestCollectionCursorSync:
         await curmf.__anext__()
         assert curmf.consumed == 2
         assert curmf.state == CursorState.STARTED
-        assert curmf.has_next()
+        assert await curmf.has_next()
         assert curmf.consumed == 2
         assert curmf.state == CursorState.STARTED
         for _ in range(FIND_PAGE_SIZE - 2):

--- a/tests/base/integration/collections/test_collection_cursor_sync.py
+++ b/tests/base/integration/collections/test_collection_cursor_sync.py
@@ -246,7 +246,11 @@ class TestCollectionCursorSync:
     ) -> None:
         cur = filled_collection.find({"p_text": "ZZ"})
         assert not cur.has_next()
-        assert list(cur) == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            list(cur)
+        with pytest.raises(CursorException):
+            cur.to_list()
 
     @pytest.mark.describe("test of prematurely closing collection cursors, sync")
     def test_collection_cursors_early_closing_sync(

--- a/tests/base/integration/collections/test_collection_cursor_sync.py
+++ b/tests/base/integration/collections/test_collection_cursor_sync.py
@@ -96,23 +96,23 @@ class TestCollectionCursorSync:
         with pytest.raises(CursorException):
             toclose.to_list()
 
-        cur.rewind()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
-        assert cur.buffered_count == 0
+        toclose.rewind()
+        assert toclose.state == CursorState.IDLE  # type: ignore[comparison-overlap]
+        assert toclose.consumed == 0
+        assert toclose.buffered_count == 0
 
-        cur.filter({"c": True})
-        cur.project({"c": True})
-        cur.sort({"c": SortMode.ASCENDING})
-        cur.limit(1)
-        cur.include_similarity(False)
-        cur.include_sort_vector(False)
-        cur.skip(1)
-        cur.map(lambda rw: None)
+        toclose.filter({"c": True})
+        toclose.project({"c": True})
+        toclose.sort({"c": SortMode.ASCENDING})
+        toclose.limit(1)
+        toclose.include_similarity(False)
+        toclose.include_sort_vector(False)
+        toclose.skip(1)
+        toclose.map(lambda rw: None)
 
-        cur.project({}).map(lambda rw: None)
+        toclose.project({}).map(lambda rw: None)
         with pytest.raises(CursorException):
-            cur.map(lambda rw: None).project({})
+            toclose.map(lambda rw: None).project({})
 
     @pytest.mark.describe("test of a CLOSED collection cursors properties, sync")
     def test_collection_cursors_closed_properties_sync(
@@ -152,6 +152,8 @@ class TestCollectionCursorSync:
             cur1.skip(1)
         with pytest.raises(CursorException):
             cur1.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur1.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of a STARTED collection cursors properties, sync")
     def test_collection_cursors_started_properties_sync(
@@ -190,6 +192,8 @@ class TestCollectionCursorSync:
             cur.skip(1)
         with pytest.raises(CursorException):
             cur.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of collection cursors has_next, sync")
     def test_collection_cursors_has_next_sync(
@@ -202,9 +206,11 @@ class TestCollectionCursorSync:
         assert cur.has_next()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
+        cur.__next__()
+        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
         list(cur)
         assert cur.consumed == NUM_DOCS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = filled_collection.find()
         next(curmf)

--- a/tests/base/integration/collections/test_collection_cursor_sync.py
+++ b/tests/base/integration/collections/test_collection_cursor_sync.py
@@ -200,14 +200,20 @@ class TestCollectionCursorSync:
         self,
         filled_collection: DefaultCollection,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = filled_collection.find()
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert cur_hn.has_next()
+        assert cur_hn.consumed == 0
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = filled_collection.find()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert cur.has_next()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
         cur.__next__()
-        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.STARTED
         list(cur)
         assert cur.consumed == NUM_DOCS
         assert cur.state == CursorState.CLOSED

--- a/tests/base/integration/collections/test_collection_farrcursor_async.py
+++ b/tests/base/integration/collections/test_collection_farrcursor_async.py
@@ -198,18 +198,33 @@ class TestCollectionCursorSync:
         self,
         afilled_vectorize_collection: DefaultAsyncCollection,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = afilled_vectorize_collection.find_and_rerank(
+            sort={"$hybrid": "a sentence."},
+            limit=NUM_DOCS,
+        )
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert await cur_hn.has_next()
+        assert cur_hn.consumed == 0
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = afilled_vectorize_collection.find_and_rerank(
             sort={"$hybrid": "a sentence."},
             limit=NUM_DOCS,
         )
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert await cur.has_next()
+        cur = afilled_vectorize_collection.find_and_rerank(
+            sort={"$hybrid": "a sentence."},
+            limit=NUM_DOCS,
+        )
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
         [r_res async for r_res in cur]
         assert cur.consumed == NUM_DOCS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = afilled_vectorize_collection.find_and_rerank(
             sort={"$hybrid": "a sentence."},

--- a/tests/base/integration/collections/test_collection_farrcursor_async.py
+++ b/tests/base/integration/collections/test_collection_farrcursor_async.py
@@ -263,7 +263,11 @@ class TestCollectionCursorSync:
             limit=NUM_DOCS,
         )
         assert not await cur.has_next()
-        assert [r_res async for r_res in cur] == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            [r_res async for r_res in cur]
+        with pytest.raises(CursorException):
+            await cur.to_list()
 
         cur_no_sv = afilled_vectorize_collection.find_and_rerank(
             {"parity": -1},

--- a/tests/base/integration/collections/test_collection_farrcursor_sync.py
+++ b/tests/base/integration/collections/test_collection_farrcursor_sync.py
@@ -198,18 +198,27 @@ class TestCollectionCursorSync:
         self,
         filled_vectorize_collection: DefaultCollection,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = filled_vectorize_collection.find_and_rerank(
+            sort={"$hybrid": "a sentence."},
+            limit=NUM_DOCS,
+        )
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert cur_hn.has_next()
+        assert cur_hn.consumed == 0
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = filled_vectorize_collection.find_and_rerank(
             sort={"$hybrid": "a sentence."},
             limit=NUM_DOCS,
         )
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert cur.has_next()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
         list(cur)
         assert cur.consumed == NUM_DOCS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = filled_vectorize_collection.find_and_rerank(
             sort={"$hybrid": "a sentence."},

--- a/tests/base/integration/collections/test_collection_farrcursor_sync.py
+++ b/tests/base/integration/collections/test_collection_farrcursor_sync.py
@@ -257,7 +257,11 @@ class TestCollectionCursorSync:
             limit=NUM_DOCS,
         )
         assert not cur.has_next()
-        assert list(cur) == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            assert list(cur) == []
+        with pytest.raises(CursorException):
+            cur.to_list()
 
         cur_no_sv = filled_vectorize_collection.find_and_rerank(
             {"parity": -1},

--- a/tests/base/integration/tables/test_table_cursor_async.py
+++ b/tests/base/integration/tables/test_table_cursor_async.py
@@ -202,14 +202,20 @@ class TestTableCursorSync:
         self,
         filled_composite_atable: DefaultAsyncTable,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = filled_composite_atable.find()
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert await cur_hn.has_next()
+        assert cur_hn.consumed == 0
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = filled_composite_atable.find()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert await cur.has_next()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
         await cur.__anext__()
-        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.STARTED
         [None async for _ in cur]
         assert cur.consumed == NUM_ROWS
         assert cur.state == CursorState.CLOSED

--- a/tests/base/integration/tables/test_table_cursor_async.py
+++ b/tests/base/integration/tables/test_table_cursor_async.py
@@ -248,7 +248,11 @@ class TestTableCursorSync:
     ) -> None:
         cur = filled_composite_atable.find({"p_text": "ZZ"})
         assert not await cur.has_next()
-        assert [row async for row in cur] == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            [doc async for doc in cur]
+        with pytest.raises(CursorException):
+            await cur.to_list()
 
     @pytest.mark.describe("test of prematurely closing table cursors, async")
     async def test_table_cursors_early_closing_async(

--- a/tests/base/integration/tables/test_table_cursor_async.py
+++ b/tests/base/integration/tables/test_table_cursor_async.py
@@ -98,23 +98,23 @@ class TestTableCursorSync:
         with pytest.raises(CursorException):
             await toclose.to_list()
 
-        cur.rewind()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
-        assert cur.buffered_count == 0
+        toclose.rewind()
+        assert toclose.state == CursorState.IDLE  # type: ignore[comparison-overlap]
+        assert toclose.consumed == 0
+        assert toclose.buffered_count == 0
 
-        cur.filter({"c": True})
-        cur.project({"c": True})
-        cur.sort({"c": SortMode.ASCENDING})
-        cur.limit(1)
-        cur.include_similarity(False)
-        cur.include_sort_vector(False)
-        cur.skip(1)
-        cur.map(lambda rw: None)
+        toclose.filter({"c": True})
+        toclose.project({"c": True})
+        toclose.sort({"c": SortMode.ASCENDING})
+        toclose.limit(1)
+        toclose.include_similarity(False)
+        toclose.include_sort_vector(False)
+        toclose.skip(1)
+        toclose.map(lambda rw: None)
 
-        cur.project({}).map(lambda rw: None)
+        toclose.project({}).map(lambda rw: None)
         with pytest.raises(CursorException):
-            cur.map(lambda rw: None).project({})
+            toclose.map(lambda rw: None).project({})
 
     @pytest.mark.describe("test of a CLOSED table cursors properties, async")
     async def test_table_cursors_closed_properties_async(
@@ -154,6 +154,8 @@ class TestTableCursorSync:
             cur1.skip(1)
         with pytest.raises(CursorException):
             cur1.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur1.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of a STARTED table cursors properties, async")
     async def test_table_cursors_started_properties_async(
@@ -192,6 +194,8 @@ class TestTableCursorSync:
             cur.skip(1)
         with pytest.raises(CursorException):
             cur.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of table cursors has_next, async")
     async def test_table_cursors_has_next_async(
@@ -204,9 +208,11 @@ class TestTableCursorSync:
         assert await cur.has_next()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
+        await cur.__anext__()
+        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
         [None async for _ in cur]
         assert cur.consumed == NUM_ROWS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = filled_composite_atable.find()
         await curmf.__anext__()

--- a/tests/base/integration/tables/test_table_cursor_sync.py
+++ b/tests/base/integration/tables/test_table_cursor_sync.py
@@ -96,23 +96,23 @@ class TestTableCursorSync:
         with pytest.raises(CursorException):
             toclose.to_list()
 
-        cur.rewind()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
-        assert cur.buffered_count == 0
+        toclose.rewind()
+        assert toclose.state == CursorState.IDLE  # type: ignore[comparison-overlap]
+        assert toclose.consumed == 0
+        assert toclose.buffered_count == 0
 
-        cur.filter({"c": True})
-        cur.project({"c": True})
-        cur.sort({"c": SortMode.ASCENDING})
-        cur.limit(1)
-        cur.include_similarity(False)
-        cur.include_sort_vector(False)
-        cur.skip(1)
-        cur.map(lambda rw: None)
+        toclose.filter({"c": True})
+        toclose.project({"c": True})
+        toclose.sort({"c": SortMode.ASCENDING})
+        toclose.limit(1)
+        toclose.include_similarity(False)
+        toclose.include_sort_vector(False)
+        toclose.skip(1)
+        toclose.map(lambda rw: None)
 
-        cur.project({}).map(lambda rw: None)
+        toclose.project({}).map(lambda rw: None)
         with pytest.raises(CursorException):
-            cur.map(lambda rw: None).project({})
+            toclose.map(lambda rw: None).project({})
 
     @pytest.mark.describe("test of a CLOSED table cursors properties, sync")
     def test_table_cursors_closed_properties_sync(
@@ -152,6 +152,8 @@ class TestTableCursorSync:
             cur1.skip(1)
         with pytest.raises(CursorException):
             cur1.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur1.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of a STARTED table cursors properties, sync")
     def test_table_cursors_started_properties_sync(
@@ -190,6 +192,8 @@ class TestTableCursorSync:
             cur.skip(1)
         with pytest.raises(CursorException):
             cur.map(lambda rw: None)
+        with pytest.raises(CursorException):
+            cur.initial_page_state("Blaaa")
 
     @pytest.mark.describe("test of table cursors has_next, sync")
     def test_table_cursors_has_next_sync(
@@ -202,9 +206,11 @@ class TestTableCursorSync:
         assert cur.has_next()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
+        cur.__next__()
+        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
         list(cur)
         assert cur.consumed == NUM_ROWS
-        assert cur.state == CursorState.CLOSED  # type: ignore[comparison-overlap]
+        assert cur.state == CursorState.CLOSED
 
         curmf = filled_composite_table.find()
         next(curmf)

--- a/tests/base/integration/tables/test_table_cursor_sync.py
+++ b/tests/base/integration/tables/test_table_cursor_sync.py
@@ -246,7 +246,11 @@ class TestTableCursorSync:
     ) -> None:
         cur = filled_composite_table.find({"p_text": "ZZ"})
         assert not cur.has_next()
-        assert list(cur) == []
+        assert cur.state == CursorState.CLOSED
+        with pytest.raises(CursorException):
+            list(cur)
+        with pytest.raises(CursorException):
+            cur.to_list()
 
     @pytest.mark.describe("test of prematurely closing table cursors, sync")
     def test_table_cursors_early_closing_sync(

--- a/tests/base/integration/tables/test_table_cursor_sync.py
+++ b/tests/base/integration/tables/test_table_cursor_sync.py
@@ -200,14 +200,20 @@ class TestTableCursorSync:
         self,
         filled_composite_table: DefaultTable,
     ) -> None:
+        # has_next sets to STARTED
+        cur_hn = filled_composite_table.find()
+        assert cur_hn.state == CursorState.IDLE
+        assert cur_hn.consumed == 0
+        assert cur_hn.has_next()
+        assert cur_hn.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+
+        # next sets to STARTED (and subsequent testing)
         cur = filled_composite_table.find()
         assert cur.state == CursorState.IDLE
         assert cur.consumed == 0
-        assert cur.has_next()
-        assert cur.state == CursorState.IDLE
-        assert cur.consumed == 0
         cur.__next__()
-        assert cur.state == CursorState.STARTED  # type: ignore[comparison-overlap]
+        assert cur_hn.consumed == 0
+        assert cur.state == CursorState.STARTED
         list(cur)
         assert cur.consumed == NUM_ROWS
         assert cur.state == CursorState.CLOSED

--- a/tests/vectorize/vectorize_models.py
+++ b/tests/vectorize/vectorize_models.py
@@ -129,8 +129,11 @@ EXCLUDED_MODEL_QUADRUPLES = {
     ("openai", "text-embedding-3-small", "HEADER", "f"),
     ("openai", "text-embedding-ada-002", "HEADER", "0"),
     ("openai", "text-embedding-ada-002", "HEADER", "f"),
+    # This appears on some DEV environments (probably will go away soon):
+    ("vertexai", "textembedding-gecko@003", "HEADER", "0"),
+    ("vertexai", "textembedding-gecko@003", "NONE", "0"),
+    ("vertexai", "textembedding-gecko@003", "SHARED_SECRET", "0"),
 }
-
 
 # this is a way to suppress/limit certain combinations of
 # "full param" testing from the start. If even one of the optional params
@@ -204,6 +207,9 @@ if TEST_EXTENDED_VECTORIZE:
         ("bedrock", "amazon.titan-embed-text-v2:0", "region"): os.environ[
             "BEDROCK_REGION"
         ],
+        # moot
+        ("vertexai", "textembedding-gecko@003", "projectId"): PARAM_SKIP_MARKER,
+        ("vertexai", "textembedding-gecko@003", "autoTruncate"): PARAM_SKIP_MARKER,
     }
 
     # this is ad-hoc for HF dedicated. Models here, though "optional" dimension,


### PR DESCRIPTION
This PR fixes/enhances a couple of details in the cursor testing and introduces two slight changes in the cursor behaviour, related to reflecting more faithfully the cursor state (IDLE -> STARTED -> CLOSED) under certain operations.

_(it also denylists some unreleased vectorize models to be able to run vectorize tests on certain dev deployments, but this is irrelevant)_

The cursor behaviour changes, dictated by a better alignment with the Typescript client cursor behaviour, are so tiny that I do not think they should be treated as "breaking changes", rather as essentially bug fixes. "started" means we started issuing request, and "closed" means there is nothing more to fetch, so...

