### PR TITLE
Minor adjustments pre-v2.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
-main
-====
+v 2.3.0
+=======
 Supported Python versions are now 3.10 to 3.14:
     - removal of Python 3.9 [Breaking change w.r.t. 2.2]
 `AstraDatabaseAdmin`: support for listing PCU Groups.
@@ -29,11 +29,9 @@ maintenance: base and vectorize integration tests fail fast unless all non-syste
 
 v 2.2.1
 =======
-
 Suppress warning about unexpected 'pcu_types' field in `[async_]find_available_regions`.
 Maintenance:
     - Minor edits to `release.yaml` workflow (secrets; task names/comments).
-
 
 
 v 2.2.0

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -1256,7 +1256,7 @@ class AstraDBAdmin:
                     "PCU Group ID pre-check failed. Aborting database creation."
                 )
                 if matching_pcu_groups == []:
-                    raise ValueError(
+                    raise DevOpsAPIException(
                         f"Requested PCU Group ID '{_definition.pcu_group_id}' not found for cloud provider "
                         f"('{_definition.cloud_provider}') and region ('{_definition.region}')."
                     )
@@ -1535,7 +1535,7 @@ class AstraDBAdmin:
                     "PCU Group ID pre-check failed. Aborting database creation, async."
                 )
                 if matching_pcu_groups == []:
-                    raise ValueError(
+                    raise DevOpsAPIException(
                         f"Requested PCU Group ID '{_definition.pcu_group_id}' not found for cloud provider "
                         f"('{_definition.cloud_provider}') and region ('{_definition.region}')."
                     )

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -1264,10 +1264,13 @@ class AstraDBAdmin:
                     )
                 else:
                     # is the matching group in the right cloud provider / region?
-                    expected_cpr = (_definition.cloud_provider, _definition.region)
+                    expected_cpr = (
+                        _definition.cloud_provider.lower(),
+                        _definition.region.lower(),
+                    )
                     found_cpr = (
-                        matching_pcu_groups_overall[0].cloud_provider,
-                        matching_pcu_groups_overall[0].region,
+                        matching_pcu_groups_overall[0].cloud_provider.lower(),
+                        matching_pcu_groups_overall[0].region.lower(),
                     )
                     if expected_cpr != found_cpr:
                         # wrong region: abort 2
@@ -1563,10 +1566,13 @@ class AstraDBAdmin:
                     )
                 else:
                     # is the matching group in the right cloud provider / region?
-                    expected_cpr = (_definition.cloud_provider, _definition.region)
+                    expected_cpr = (
+                        _definition.cloud_provider.lower(),
+                        _definition.region.lower(),
+                    )
                     found_cpr = (
-                        matching_pcu_groups_overall[0].cloud_provider,
-                        matching_pcu_groups_overall[0].region,
+                        matching_pcu_groups_overall[0].cloud_provider.lower(),
+                        matching_pcu_groups_overall[0].region.lower(),
                     )
                     if expected_cpr != found_cpr:
                         # wrong region: abort 2

--- a/astrapy/admin/admin.py
+++ b/astrapy/admin/admin.py
@@ -1236,30 +1236,50 @@ class AstraDBAdmin:
         # If a PCU group ID is provided, try to validate it
         if _definition.pcu_group_id is not None:
             logger.info("PCU Group ID pre-check: starting existence check.")
-            pcu_groups: list[PCUGroupDescriptor] | None
+            pcu_groups_overall: list[PCUGroupDescriptor] | None
             try:
-                pcu_groups = self.list_pcu_groups(
-                    cloud_provider=_definition.cloud_provider,
-                    region=_definition.region,
+                pcu_groups_overall = self.list_pcu_groups(
                     database_admin_timeout_ms=database_admin_timeout_ms,
                     request_timeout_ms=request_timeout_ms,
                     timeout_ms=timeout_ms,
                 )
             except Exception as e:
-                pcu_groups = None
+                pcu_groups_overall = None
                 logger.info(f"PCU Group ID pre-check threw an exception: {str(e)}")
-            if pcu_groups is not None:
-                matching_pcu_groups = [
-                    pg for pg in pcu_groups if pg.id == _definition.pcu_group_id
+            if pcu_groups_overall is not None:
+                matching_pcu_groups_overall = [
+                    pg for pg in pcu_groups_overall if pg.id == _definition.pcu_group_id
                 ]
-                logger.info(
-                    "PCU Group ID pre-check failed. Aborting database creation."
-                )
-                if matching_pcu_groups == []:
-                    raise DevOpsAPIException(
-                        f"Requested PCU Group ID '{_definition.pcu_group_id}' not found for cloud provider "
-                        f"('{_definition.cloud_provider}') and region ('{_definition.region}')."
+                if matching_pcu_groups_overall == []:
+                    # no such pcu group id at all: abort 1
+                    logger.info(
+                        "PCU Group ID pre-check did not pass (id not found). "
+                        "Aborting database creation."
                     )
+                    raise DevOpsAPIException(
+                        f"Requested PCU Group ID '{_definition.pcu_group_id}' not "
+                        "found for cloud provider provider/region "
+                        f"('{_definition.cloud_provider}' / '{_definition.region}'). "
+                        "Aborting database creation."
+                    )
+                else:
+                    # is the matching group in the right cloud provider / region?
+                    expected_cpr = (_definition.cloud_provider, _definition.region)
+                    found_cpr = (
+                        matching_pcu_groups_overall[0].cloud_provider,
+                        matching_pcu_groups_overall[0].region,
+                    )
+                    if expected_cpr != found_cpr:
+                        # wrong region: abort 2
+                        logger.info(
+                            "PCU Group ID pre-check did not pass (wrong "
+                            "provider/region). Aborting database creation."
+                        )
+                        raise DevOpsAPIException(
+                            f"Requested PCU Group ID '{_definition.pcu_group_id}' "
+                            f"is in another cloud provider and region ('{found_cpr[0]}' "
+                            f"/ '{found_cpr[1]}'). Aborting database creation."
+                        )
                 logger.info("PCU Group ID pre-check succeeded.")
             else:
                 logger.info("PCU Group ID pre-check aborted.")
@@ -1513,32 +1533,52 @@ class AstraDBAdmin:
         # If a PCU group ID is provided, try to validate it
         if _definition.pcu_group_id is not None:
             logger.info("PCU Group ID pre-check: starting existence check, async.")
-            pcu_groups: list[PCUGroupDescriptor] | None
+            pcu_groups_overall: list[PCUGroupDescriptor] | None
             try:
-                pcu_groups = await self.async_list_pcu_groups(
-                    cloud_provider=_definition.cloud_provider,
-                    region=_definition.region,
+                pcu_groups_overall = await self.async_list_pcu_groups(
                     database_admin_timeout_ms=database_admin_timeout_ms,
                     request_timeout_ms=request_timeout_ms,
                     timeout_ms=timeout_ms,
                 )
             except Exception as e:
-                pcu_groups = None
+                pcu_groups_overall = None
                 logger.info(
-                    f"PCU Group ID pre-check threw an exception, async: {str(e)}"
+                    f"PCU Group ID pre-check threw an exception: {str(e)}, async"
                 )
-            if pcu_groups is not None:
-                matching_pcu_groups = [
-                    pg for pg in pcu_groups if pg.id == _definition.pcu_group_id
+            if pcu_groups_overall is not None:
+                matching_pcu_groups_overall = [
+                    pg for pg in pcu_groups_overall if pg.id == _definition.pcu_group_id
                 ]
-                logger.info(
-                    "PCU Group ID pre-check failed. Aborting database creation, async."
-                )
-                if matching_pcu_groups == []:
-                    raise DevOpsAPIException(
-                        f"Requested PCU Group ID '{_definition.pcu_group_id}' not found for cloud provider "
-                        f"('{_definition.cloud_provider}') and region ('{_definition.region}')."
+                if matching_pcu_groups_overall == []:
+                    # no such pcu group id at all: abort 1
+                    logger.info(
+                        "PCU Group ID pre-check did not pass (id not found). "
+                        "Aborting database creation, async."
                     )
+                    raise DevOpsAPIException(
+                        f"Requested PCU Group ID '{_definition.pcu_group_id}' "
+                        "not found for cloud provider provider/region "
+                        f"('{_definition.cloud_provider}' / '{_definition.region}'). "
+                        "Aborting database creation."
+                    )
+                else:
+                    # is the matching group in the right cloud provider / region?
+                    expected_cpr = (_definition.cloud_provider, _definition.region)
+                    found_cpr = (
+                        matching_pcu_groups_overall[0].cloud_provider,
+                        matching_pcu_groups_overall[0].region,
+                    )
+                    if expected_cpr != found_cpr:
+                        # wrong region: abort 2
+                        logger.info(
+                            "PCU Group ID pre-check did not pass (wrong "
+                            "provider/region). Aborting database creation, async."
+                        )
+                        raise DevOpsAPIException(
+                            f"Requested PCU Group ID '{_definition.pcu_group_id}' "
+                            f"is in another cloud provider and region ('{found_cpr[0]}' "
+                            f"/ '{found_cpr[1]}'). Aborting database creation."
+                        )
                 logger.info("PCU Group ID pre-check succeeded, async.")
             else:
                 logger.info("PCU Group ID pre-check aborted, async.")
@@ -1563,7 +1603,8 @@ class AstraDBAdmin:
                 )
                 raise PermissionError(CANNOT_POLL_ERROR_MESSAGE)
         logger.info(
-            f"creating database {name}/({_definition.cloud_provider}, {_definition.region}) (DevOps API), async"
+            f"creating database {name}/({_definition.cloud_provider}, "
+            f"{_definition.region}) (DevOps API), async"
         )
         cd_raw_response = await self._dev_ops_api_commander.async_raw_request(
             caller_function_name="async_create_database",

--- a/astrapy/data/info/database_info.py
+++ b/astrapy/data/info/database_info.py
@@ -545,12 +545,23 @@ class PCUGroupTypeDetailsDescriptor:
         disk_cache: the amount of disk cache for this PCU type.
     """
 
-    v_cpu: int
-    memory: str
-    disk_cache: str
+    v_cpu: int | None = None
+    memory: str | None = None
+    disk_cache: str | None = None
 
     def __repr__(self) -> str:
-        body = f"v_cpu={self.v_cpu}, memory={self.memory}, disk_cache={self.disk_cache}"
+        pieces = [
+            pc
+            for pc in (
+                f"v_cpu={self.v_cpu}" if self.v_cpu is not None else None,
+                f"memory={self.memory}" if self.memory is not None else None,
+                f"disk_cache={self.disk_cache}"
+                if self.disk_cache is not None
+                else None,
+            )
+            if pc is not None
+        ]
+        body = ", ".join(pieces)
         return f"{self.__class__.__name__}({body})"
 
     def as_dict(self) -> dict[str, Any]:
@@ -559,9 +570,13 @@ class PCUGroupTypeDetailsDescriptor:
         """
 
         return {
-            "vCPU": self.v_cpu,
-            "memory": self.memory,
-            "disk_cache": self.disk_cache,
+            k: v
+            for k, v in {
+                "vCPU": self.v_cpu,
+                "memory": self.memory,
+                "disk_cache": self.disk_cache,
+            }.items()
+            if v is not None
         }
 
     @classmethod
@@ -581,9 +596,9 @@ class PCUGroupTypeDetailsDescriptor:
             },
         )
         return PCUGroupTypeDetailsDescriptor(
-            v_cpu=raw_dict["vCPU"],
-            memory=raw_dict["memory"],
-            disk_cache=raw_dict["disk_cache"],
+            v_cpu=raw_dict.get("vCPU"),
+            memory=raw_dict.get("memory"),
+            disk_cache=raw_dict.get("disk_cache"),
         )
 
 
@@ -603,7 +618,7 @@ class PCUGroupTypeDescriptor:
     type: str
     region: str | None
     cloud_provider: str | None
-    details: PCUGroupTypeDetailsDescriptor
+    details: PCUGroupTypeDetailsDescriptor | None
 
     def __repr__(self) -> str:
         pieces = [
@@ -614,7 +629,7 @@ class PCUGroupTypeDescriptor:
                 f"cloud_provider={self.cloud_provider}"
                 if self.cloud_provider is not None
                 else None,
-                "details=...",
+                "details=..." if self.details is not None else None,
             )
             if pc is not None
         ]
@@ -632,7 +647,7 @@ class PCUGroupTypeDescriptor:
                 "type": self.type,
                 "region": self.region,
                 "provider": self.cloud_provider,
-                "details": self.details.as_dict(),
+                "details": self.details.as_dict() if self.details is not None else None,
             }.items()
             if v is not None
         }
@@ -658,7 +673,9 @@ class PCUGroupTypeDescriptor:
             type=raw_dict["type"],
             region=raw_dict.get("region"),
             cloud_provider=raw_dict["provider"] if "provider" in raw_dict else None,
-            details=PCUGroupTypeDetailsDescriptor._from_dict(raw_dict["details"]),
+            details=PCUGroupTypeDetailsDescriptor._from_dict(raw_dict["details"])
+            if "details" in raw_dict
+            else None,
         )
 
 
@@ -689,26 +706,36 @@ class PCUGroupDescriptor:
     """
 
     id: str
-    org_id: str
-    title: str
+    org_id: str | None
+    title: str | None
     cloud_provider: str
     region: str
-    instance_type: str
-    pcu_type: PCUGroupTypeDescriptor
-    provision_type: str
-    min: int
-    max: int
-    description: str
+    instance_type: str | None
+    pcu_type: PCUGroupTypeDescriptor | None
+    provision_type: str | None
+    min: int | None
+    max: int | None
+    description: str | None
     created_at: datetime.datetime | None
     updated_at: datetime.datetime | None
-    created_by: str
-    updated_by: str
-    status: str
+    created_by: str | None
+    updated_by: str | None
+    status: str | None
     reserved: int | None = None
 
     def __repr__(self) -> str:
-        body = f"id={self.id}, org_id={self.org_id}, title={self.title}, status={self.status}, ..."
-        return f"{self.__class__.__name__}({body})"
+        pieces = [
+            pc
+            for pc in (
+                f"id={self.id}" if self.id is not None else None,
+                f"org_id={self.org_id}" if self.org_id is not None else None,
+                f"title={self.title}" if self.title is not None else None,
+                f"status={self.status}" if self.status is not None else None,
+            )
+            if pc is not None
+        ]
+        body = ", ".join(pieces)
+        return f"{self.__class__.__name__}({body}, ...)"
 
     def as_dict(self) -> dict[str, Any]:
         """
@@ -724,7 +751,9 @@ class PCUGroupDescriptor:
                 "cloudProvider": self.cloud_provider,
                 "region": self.region,
                 "instanceType": self.instance_type,
-                "pcuType": self.pcu_type.as_dict(),
+                "pcuType": self.pcu_type.as_dict()
+                if self.pcu_type is not None
+                else None,
                 "provisionType": self.provision_type,
                 "min": self.min,
                 "max": self.max,
@@ -775,20 +804,22 @@ class PCUGroupDescriptor:
         )
         return PCUGroupDescriptor(
             id=raw_dict["uuid"],
-            org_id=raw_dict["orgId"],
-            title=raw_dict["title"],
+            org_id=raw_dict.get("orgId"),
+            title=raw_dict.get("title"),
             cloud_provider=raw_dict["cloudProvider"],
             region=raw_dict["region"],
-            instance_type=raw_dict["instanceType"],
-            pcu_type=PCUGroupTypeDescriptor._from_dict(raw_dict["pcuType"]),
-            provision_type=raw_dict["provisionType"],
-            min=raw_dict["min"],
-            max=raw_dict["max"],
+            instance_type=raw_dict.get("instanceType"),
+            pcu_type=PCUGroupTypeDescriptor._from_dict(raw_dict["pcuType"])
+            if "pcuType" in raw_dict
+            else None,
+            provision_type=raw_dict.get("provisionType"),
+            min=raw_dict.get("min"),
+            max=raw_dict.get("max"),
             reserved=raw_dict.get("reserved"),
-            description=raw_dict["description"],
+            description=raw_dict.get("description"),
             created_at=_failsafe_parse_date(raw_dict.get("createdAt")),
             updated_at=_failsafe_parse_date(raw_dict.get("updatedAt")),
-            created_by=raw_dict["createdBy"],
-            updated_by=raw_dict["updatedBy"],
-            status=raw_dict["status"],
+            created_by=raw_dict.get("createdBy"),
+            updated_by=raw_dict.get("updatedBy"),
+            status=raw_dict.get("status"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.10,<4.0"
 name = "astrapy"
-version = "2.2.1"
+version = "2.3.0"
 description = "A Python client for the Data API on DataStax Astra DB"
 authors = [
     {"name" = "Stefano Lottini", "email" = "stefano.lottini@ibm.com"},

--- a/tests/base/admin_assets.py
+++ b/tests/base/admin_assets.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import datetime
+from typing import Any
 
 from astrapy.info import (
     PCUGroupTypeDescriptor,
@@ -130,3 +131,15 @@ SOME_PCU_GROUP_DESCRIPTOR_KWARGS_NORESERVED = {
     "updated_by": "umWGYUwuxFvQKBKPAHwHjKef",
     "status": "CREATED",
 }
+
+MINIMAL_PCU_GROUP_DESCRIPTOR = {
+    "uuid": "minimal_pgd_id",
+    "cloudProvider": "AWS",
+    "region": "us-west-2",
+}
+
+MINIMAL_PCU_GROUP_TYPE_DESCRIPTOR = {
+    "type": "small",
+}
+
+MINIMAL_PCU_GROUP_TYPE_DETAILS_DESCRIPTOR: dict[str, Any] = {}

--- a/tests/base/unit/test_admin_create_database_async.py
+++ b/tests/base/unit/test_admin_create_database_async.py
@@ -280,12 +280,78 @@ class TestAdminCreateDatabaseAsync:
             tier="tr",
             capacity_units=5,
             db_type="ty",
-            pcu_group_id="d",
+            pcu_group_id="requested_pcu_g_id",
         )
 
         # Expected: PCU not found in the listing, creation aborted.
         with pytest.raises(
-            DevOpsAPIException, match="Requested PCU Group ID 'd' not found"
+            DevOpsAPIException,
+            match="Requested PCU Group ID 'requested_pcu_g_id' not found",
+        ):
+            await mock_astra_admin.async_create_database(
+                "the_db_name",
+                definition=db_definition,
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe(
+        "test of admin create database definition wrongregionpcucheck, async"
+    )
+    async def test_admin_create_database_definition_wrongregionpcucheck_async(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        full_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": "tr",
+            "capacityUnits": 5,
+            "dbType": "ty",
+            "pcuGroupUUID": "requested_pcu_g_id",
+        }
+        # We pass a pcu ID which the listing endpoint does return but in another region, and expect db creation to fail
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=full_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        httpserver.expect_oneshot_request(
+            "/vx/pcus/actions/get",
+            method=HttpMethod.POST,
+        ).respond_with_json(
+            response_json=[
+                {
+                    "uuid": "requested_pcu_g_id",
+                    **SOME_PCU_GROUP_DESC_JSON,
+                    **{
+                        "cloudProvider": "another_cp",
+                        "region": "another_r",
+                    },
+                },
+            ],
+        )
+
+        db_definition = DatabaseDefinition(
+            cloud_provider="cp",
+            region="r",
+            keyspace="ks",
+            tier="tr",
+            capacity_units=5,
+            db_type="ty",
+            pcu_group_id="requested_pcu_g_id",
+        )
+
+        # Expected: PCU not found in the listing, creation aborted.
+        with pytest.raises(
+            DevOpsAPIException,
+            match="Requested PCU Group ID 'requested_pcu_g_id' is in another",
         ):
             await mock_astra_admin.async_create_database(
                 "the_db_name",

--- a/tests/base/unit/test_admin_create_database_async.py
+++ b/tests/base/unit/test_admin_create_database_async.py
@@ -19,6 +19,7 @@ from pytest_httpserver import HTTPServer
 
 from astrapy import AstraDBAdmin, DataAPIClient
 from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.exceptions import DevOpsAPIException
 from astrapy.info import DatabaseDefinition
 from astrapy.settings.defaults import (
     DEFAULT_CREATE_DB_CAPACITY_UNITS,
@@ -283,7 +284,9 @@ class TestAdminCreateDatabaseAsync:
         )
 
         # Expected: PCU not found in the listing, creation aborted.
-        with pytest.raises(ValueError, match="Requested PCU Group ID 'd' not found"):
+        with pytest.raises(
+            DevOpsAPIException, match="Requested PCU Group ID 'd' not found"
+        ):
             await mock_astra_admin.async_create_database(
                 "the_db_name",
                 definition=db_definition,

--- a/tests/base/unit/test_admin_create_database_sync.py
+++ b/tests/base/unit/test_admin_create_database_sync.py
@@ -19,6 +19,7 @@ from pytest_httpserver import HTTPServer
 
 from astrapy import AstraDBAdmin, DataAPIClient
 from astrapy.api_options import APIOptions, DevOpsAPIURLOptions
+from astrapy.exceptions import DevOpsAPIException
 from astrapy.info import DatabaseDefinition
 from astrapy.settings.defaults import (
     DEFAULT_CREATE_DB_CAPACITY_UNITS,
@@ -279,7 +280,9 @@ class TestAdminCreateDatabaseSync:
         )
 
         # Expected: PCU not found in the listing, creation aborted.
-        with pytest.raises(ValueError, match="Requested PCU Group ID 'd' not found"):
+        with pytest.raises(
+            DevOpsAPIException, match="Requested PCU Group ID 'd' not found"
+        ):
             mock_astra_admin.create_database(
                 "the_db_name",
                 definition=db_definition,

--- a/tests/base/unit/test_admin_create_database_sync.py
+++ b/tests/base/unit/test_admin_create_database_sync.py
@@ -276,12 +276,78 @@ class TestAdminCreateDatabaseSync:
             tier="tr",
             capacity_units=5,
             db_type="ty",
-            pcu_group_id="d",
+            pcu_group_id="requested_pcu_g_id",
         )
 
         # Expected: PCU not found in the listing, creation aborted.
         with pytest.raises(
-            DevOpsAPIException, match="Requested PCU Group ID 'd' not found"
+            DevOpsAPIException,
+            match="Requested PCU Group ID 'requested_pcu_g_id' not found",
+        ):
+            mock_astra_admin.create_database(
+                "the_db_name",
+                definition=db_definition,
+                wait_until_active=False,
+            )
+
+    @pytest.mark.describe(
+        "test of admin create database definition wrongregionpcucheck, sync"
+    )
+    def test_admin_create_database_definition_wrongregionpcucheck_sync(
+        self,
+        httpserver: HTTPServer,
+        mock_astra_admin: AstraDBAdmin,
+    ) -> None:
+        full_payload = {
+            "name": "the_db_name",
+            "cloudProvider": "cp",
+            "region": "r",
+            "keyspace": "ks",
+            "tier": "tr",
+            "capacityUnits": 5,
+            "dbType": "ty",
+            "pcuGroupUUID": "requested_pcu_g_id",
+        }
+        # We pass a pcu ID which the listing endpoint does return but in another region, and expect db creation to fail
+
+        httpserver.expect_oneshot_request(
+            "/vx/databases",
+            method=HttpMethod.POST,
+            json=full_payload,
+        ).respond_with_data(
+            "", headers={"Location": "xyz"}, status=DEV_OPS_RESPONSE_HTTP_CREATED
+        )
+
+        httpserver.expect_oneshot_request(
+            "/vx/pcus/actions/get",
+            method=HttpMethod.POST,
+        ).respond_with_json(
+            response_json=[
+                {
+                    "uuid": "requested_pcu_g_id",
+                    **SOME_PCU_GROUP_DESC_JSON,
+                    **{
+                        "cloudProvider": "another_cp",
+                        "region": "another_r",
+                    },
+                },
+            ],
+        )
+
+        db_definition = DatabaseDefinition(
+            cloud_provider="cp",
+            region="r",
+            keyspace="ks",
+            tier="tr",
+            capacity_units=5,
+            db_type="ty",
+            pcu_group_id="requested_pcu_g_id",
+        )
+
+        # Expected: PCU not found in the listing, creation aborted.
+        with pytest.raises(
+            DevOpsAPIException,
+            match="Requested PCU Group ID 'requested_pcu_g_id' is in another",
         ):
             mock_astra_admin.create_database(
                 "the_db_name",

--- a/tests/base/unit/test_info.py
+++ b/tests/base/unit/test_info.py
@@ -25,6 +25,8 @@ from astrapy.info import (
     AstraDBAvailableRegionInfo,
     DatabaseDefinition,
     PCUGroupDescriptor,
+    PCUGroupTypeDescriptor,
+    PCUGroupTypeDetailsDescriptor,
 )
 from astrapy.settings.defaults import (
     DEFAULT_CREATE_DB_CAPACITY_UNITS,
@@ -33,6 +35,9 @@ from astrapy.settings.defaults import (
 )
 
 from ..admin_assets import (
+    MINIMAL_PCU_GROUP_DESCRIPTOR,
+    MINIMAL_PCU_GROUP_TYPE_DESCRIPTOR,
+    MINIMAL_PCU_GROUP_TYPE_DETAILS_DESCRIPTOR,
     SOME_PCU_GROUP_DESC_JSON,
     SOME_PCU_GROUP_DESC_JSON_NORESERVED,
     SOME_PCU_GROUP_DESCRIPTOR_KWARGS,
@@ -221,3 +226,23 @@ def test_parse_noreserved_pcugroupdescriptor() -> None:
 
     assert gtype_desc.as_dict() == pcugt_json
     assert PCUGroupDescriptor._from_dict(pcugt_json) == gtype_desc
+
+
+@pytest.mark.describe(
+    "test of marshaling and unmarshaling of minimal PCU Group descriptor objects"
+)
+def test_parse_minimal_pcugroupobjects() -> None:
+    assert (
+        PCUGroupDescriptor._from_dict(MINIMAL_PCU_GROUP_DESCRIPTOR).as_dict()
+        == MINIMAL_PCU_GROUP_DESCRIPTOR
+    )
+    assert (
+        PCUGroupTypeDescriptor._from_dict(MINIMAL_PCU_GROUP_TYPE_DESCRIPTOR).as_dict()
+        == MINIMAL_PCU_GROUP_TYPE_DESCRIPTOR
+    )
+    assert (
+        PCUGroupTypeDetailsDescriptor._from_dict(
+            MINIMAL_PCU_GROUP_TYPE_DETAILS_DESCRIPTOR
+        ).as_dict()
+        == MINIMAL_PCU_GROUP_TYPE_DETAILS_DESCRIPTOR
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ wheels = [
 
 [[package]]
 name = "astrapy"
-version = "2.2.1"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "deprecation" },


### PR DESCRIPTION
- (following Cédrick) Different errors if the PCU Group ID is outright nonexistent or belongs to a different cloud provider/region (+ specific tests)
- the error raised is not ValueError anymore, rather DevOpsAPIException
- more robust unmarshaling of pcu-related devops api responses (= everything that is not critical is made optional, no errors if fields missing from responses)